### PR TITLE
Replace static OG images with dynamic App Router image routes and add site metadata

### DIFF
--- a/ui/partner-hub/app/layout.tsx
+++ b/ui/partner-hub/app/layout.tsx
@@ -3,9 +3,36 @@ import "../styles/globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
 import { AppShell } from "@/components/app-shell";
 
+const siteTitle = "Portfolio Hub";
+const siteDescription =
+  "A presales solutions architect portfolio for data center infrastructure, showcasing tools, architectures, and proof points.";
+
 export const metadata: Metadata = {
-  title: "Portfolio Hub",
-  description: "Portfolio navigation and tooling for presales data center infrastructure work.",
+  title: {
+    default: siteTitle,
+    template: `%s | ${siteTitle}`,
+  },
+  description: siteDescription,
+  metadataBase: new URL("https://portfolio-hub.example.com"),
+  openGraph: {
+    title: siteTitle,
+    description: siteDescription,
+    type: "website",
+    images: [
+      {
+        url: "/opengraph-image.png",
+        width: 1200,
+        height: 630,
+        alt: "Portfolio Hub social preview",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: siteTitle,
+    description: siteDescription,
+    images: ["/twitter-image.png"],
+  },
   icons: {
     icon: "/brand/favicon.svg",
   },

--- a/ui/partner-hub/app/opengraph-image.tsx
+++ b/ui/partner-hub/app/opengraph-image.tsx
@@ -1,0 +1,55 @@
+import type { ImageResponse } from "next/og";
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = "image/png";
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: 96,
+          background: "linear-gradient(135deg, #0b1120 0%, #111827 100%)",
+          color: "#f8fafc",
+          fontFamily: "Inter, system-ui, sans-serif",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 60,
+            fontWeight: 700,
+            lineHeight: 1.1,
+            marginBottom: 24,
+          }}
+        >
+          Portfolio Hub
+        </div>
+        <div style={{ fontSize: 28, maxWidth: 900, lineHeight: 1.4 }}>
+          Presales data center infrastructure portfolio with tools, architectures, and proof
+          points that help move opportunities forward.
+        </div>
+        <div style={{ marginTop: 48, display: "flex", gap: 16, fontSize: 22 }}>
+          <span style={{ padding: "10px 18px", border: "1px solid #334155", borderRadius: 999 }}>
+            Reference designs
+          </span>
+          <span style={{ padding: "10px 18px", border: "1px solid #334155", borderRadius: 999 }}>
+            Sizing tools
+          </span>
+          <span style={{ padding: "10px 18px", border: "1px solid #334155", borderRadius: 999 }}>
+            Energy insights
+          </span>
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/ui/partner-hub/app/page.tsx
+++ b/ui/partner-hub/app/page.tsx
@@ -29,9 +29,20 @@ export default function HomePage() {
           Presales Solutions Architect Portfolio
         </h1>
         <p className="mt-4 max-w-2xl text-base text-foreground/70">
-          Supporting data center infrastructure engagements with curated tools, reference
-          architectures, and proof points to accelerate solution discovery.
+          A modern hub for data center infrastructure engagements, pairing architecture insights
+          with the right tools and evidence to move deals forward.
         </p>
+        <ul className="mt-6 grid gap-3 text-sm text-foreground/70 sm:grid-cols-3">
+          <li className="rounded-2xl border border-border/60 bg-background/80 px-4 py-3">
+            12+ validated reference designs across AI, hybrid cloud, and edge.
+          </li>
+          <li className="rounded-2xl border border-border/60 bg-background/80 px-4 py-3">
+            Rapid sizing and budget ranges in minutes with built-in estimators.
+          </li>
+          <li className="rounded-2xl border border-border/60 bg-background/80 px-4 py-3">
+            Energy impact modeling to support sustainability narratives.
+          </li>
+        </ul>
         <div className="mt-6 flex flex-wrap items-center gap-3">
           <Link
             href="#"

--- a/ui/partner-hub/app/twitter-image.tsx
+++ b/ui/partner-hub/app/twitter-image.tsx
@@ -1,0 +1,13 @@
+import type { ImageResponse } from "next/og";
+import OpenGraphImage from "./opengraph-image";
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = "image/png";
+
+export default function Image() {
+  return OpenGraphImage();
+}


### PR DESCRIPTION
### Motivation
- Avoid committing binary social-preview PNGs to the repository by generating Open Graph and Twitter preview images dynamically via the Next.js App Router.
- Provide consistent site-wide metadata so shared links render with a professional title, description, and preview image.
- Improve the Home hero copy and surface a few proof points to better communicate site value.

### Description
- Replace the static `opengraph-image.png` and `twitter-image.png` assets with dynamic image routes `opengraph-image.tsx` and `twitter-image.tsx` that use `next/og` to generate PNG previews.
- Update `app/layout.tsx` to use a title template, `metadataBase`, and structured `openGraph` and `twitter` metadata that point to the generated image endpoints (`/opengraph-image.png` and `/twitter-image.png`).
- Remove the binary PNG files from the repo and add the TypeScript image route files to avoid the binary-file error when creating a PR.
- Refresh the homepage in `app/page.tsx` with an updated subhead and three proof-point callouts.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695d9e5429f8832692678b5b20d5dc9d)