### PR TITLE
Integrate /energy into Portfolio Hub

### DIFF
--- a/ui/partner-hub/app/(routes)/tools/energy/page.tsx
+++ b/ui/partner-hub/app/(routes)/tools/energy/page.tsx
@@ -1,6 +1,6 @@
 import { Embed } from "@/components/embed";
 
-export default function EnergyAppPage() {
+export default function EnergyToolPage() {
   return (
     <main className="flex h-full flex-col gap-6">
       <div className="space-y-2">
@@ -9,7 +9,7 @@ export default function EnergyAppPage() {
           Model data center energy consumption and efficiency scenarios alongside the portfolio.
         </p>
       </div>
-      <Embed src="/energy" title="Energy Tool" />
+      <Embed src="/energy/" title="Energy Tool" bypassBasePath openInNewTab />
     </main>
   );
 }

--- a/ui/partner-hub/app/page.tsx
+++ b/ui/partner-hub/app/page.tsx
@@ -16,7 +16,8 @@ const featureCards = [
   {
     title: "Energy Tool",
     description: "Model power and cooling impact for data center refreshes.",
-    href: "/energy",
+    href: "/energy/",
+    external: true,
   },
 ];
 
@@ -71,12 +72,21 @@ export default function HomePage() {
               </CardHeader>
               <CardContent className="space-y-4 text-sm text-foreground/70">
                 <p>{card.description}</p>
-                <Link
-                  href={card.href}
-                  className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary transition hover:bg-primary/10"
-                >
-                  Open app
-                </Link>
+                {card.external ? (
+                  <a
+                    href={card.href}
+                    className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary transition hover:bg-primary/10"
+                  >
+                    Open app
+                  </a>
+                ) : (
+                  <Link
+                    href={card.href}
+                    className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary transition hover:bg-primary/10"
+                  >
+                    Open app
+                  </Link>
+                )}
               </CardContent>
             </Card>
           ))}

--- a/ui/partner-hub/components/embed.tsx
+++ b/ui/partner-hub/components/embed.tsx
@@ -9,11 +9,16 @@ export type EmbedProps = {
   src: string;
   title: string;
   restricted?: boolean;
+  bypassBasePath?: boolean;
+  openInNewTab?: boolean;
 };
 
-export function Embed({ src, title, restricted }: EmbedProps) {
-  const type = src.startsWith("http") ? "external" : "internal";
+export function Embed({ src, title, restricted, bypassBasePath, openInNewTab }: EmbedProps) {
+  const isExternal = src.startsWith("http");
+  const type = isExternal ? "external" : "internal";
   const link = { label: title, href: src, type, restricted } as const;
+  const usePlainAnchor = bypassBasePath || isExternal;
+  const shouldOpenNewTab = openInNewTab || isExternal;
 
   return (
     <div className="flex h-full flex-col gap-4">
@@ -35,14 +40,25 @@ export function Embed({ src, title, restricted }: EmbedProps) {
       <div className="text-sm text-foreground/70">
         Having trouble with the embedded view?{" "}
         <RestrictedLink link={link}>
-          <Link
-            href={src}
-            target={type === "external" ? "_blank" : undefined}
-            rel={type === "external" ? "noreferrer" : undefined}
-            className="font-semibold text-primary underline"
-          >
-            Open in new tab
-          </Link>
+          {usePlainAnchor ? (
+            <a
+              href={src}
+              target={shouldOpenNewTab ? "_blank" : undefined}
+              rel={shouldOpenNewTab ? "noreferrer" : undefined}
+              className="font-semibold text-primary underline"
+            >
+              Open in new tab
+            </a>
+          ) : (
+            <Link
+              href={src}
+              target={shouldOpenNewTab ? "_blank" : undefined}
+              rel={shouldOpenNewTab ? "noreferrer" : undefined}
+              className="font-semibold text-primary underline"
+            >
+              Open in new tab
+            </Link>
+          )}
         </RestrictedLink>
         .
       </div>

--- a/ui/partner-hub/components/left-nav.tsx
+++ b/ui/partner-hub/components/left-nav.tsx
@@ -11,7 +11,7 @@ const links = [
   { name: "Case Studies", href: "/case-studies" },
   { name: "Architecture Explorer", href: "/architecture-explorer" },
   { name: "Estimator", href: "/estimator" },
-  { name: "Energy Tool", href: "/energy" },
+  { name: "Energy Tool", href: "/energy/", external: true },
   { name: "About / Contact", href: "/about" },
 ];
 
@@ -37,16 +37,22 @@ export function LeftNav() {
       <nav className="flex flex-1 flex-col gap-1 px-2 pb-6">
         {links.map((link) => {
           const active = link.href === "/" ? pathname === "/" : pathname.startsWith(link.href);
+          const baseClasses = clsx(
+            "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition hover:bg-muted",
+            active ? "bg-primary/10 text-primary" : "text-foreground/70",
+            collapsed && "justify-center px-0",
+          );
+
+          if (link.external) {
+            return (
+              <a key={link.name} href={link.href} className={baseClasses}>
+                <span className={clsx(collapsed && "sr-only")}>{link.name}</span>
+              </a>
+            );
+          }
+
           return (
-            <Link
-              key={link.name}
-              href={link.href}
-              className={clsx(
-                "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition hover:bg-muted",
-                active ? "bg-primary/10 text-primary" : "text-foreground/70",
-                collapsed && "justify-center px-0",
-              )}
-            >
+            <Link key={link.name} href={link.href} className={baseClasses}>
               <span className={clsx(collapsed && "sr-only")}>{link.name}</span>
             </Link>
           );

--- a/ui/partner-hub/data/links.json
+++ b/ui/partner-hub/data/links.json
@@ -19,8 +19,8 @@
     },
     {
       "label": "Energy Tool",
-      "href": "/energy",
-      "type": "internal"
+      "href": "/energy/",
+      "type": "external"
     }
   ],
   "About": [


### PR DESCRIPTION
### Motivation
- Make the standalone Flask `/energy` tool feel integrated in the Portfolio Hub while keeping the app hosted at the root `/energy` path.  
- Provide a prominent entry point from the left navigation and the Home featured apps so users can reach `/energy/` easily.  
- Add an optional in-portfolio embedding page at `/tools/energy` that iframes the tool and offers a safe fallback to open the tool in a new tab.  
- Ensure links continue to work with `basePath: "/partner-hub"` by bypassing the Next `basePath` when targeting the root `/energy/` path.

### Description
- Added an `Energy Tool` nav item to `ui/partner-hub/components/left-nav.tsx` that uses an external anchor (`href: "/energy/"`, `external: true`) so it bypasses Next `basePath`.  
- Marked the Home featured card for Energy as external and updated `ui/partner-hub/app/page.tsx` to render a plain `<a>` when `external: true`.  
- Moved the embedded view into `ui/partner-hub/app/(routes)/tools/energy/page.tsx` and used the `Embed` component with `bypassBasePath` and `openInNewTab` targeting `"/energy/"`.  
- Extended `ui/partner-hub/components/embed.tsx` to support `bypassBasePath` and `openInNewTab` and to choose between Next `Link` and a plain `<a>` for the fallback link, and updated `ui/partner-hub/data/links.json` to mark the Energy Tool as external.

### Testing
- Ran the dev server with `npm run dev` in `ui/partner-hub`, and Next compiled and served the site successfully.  
- Executed a Playwright script that loaded `http://127.0.0.1:3000/partner-hub/` and captured a screenshot, which completed successfully and produced an artifact.  
- No automated failures were observed during the dev compile and the Playwright run.  
- Static export (`next export`) was not executed as part of these automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695da0a9f63c8326b257a6d2ac68333f)