### PR TITLE
Add Architecture Explorer tool (React Flow)

### DIFF
--- a/ui/partner-hub/app/page.tsx
+++ b/ui/partner-hub/app/page.tsx
@@ -6,7 +6,7 @@ const featureCards = [
   {
     title: "Architecture Explorer",
     description: "Navigate reference architectures and validated design patterns.",
-    href: "/architecture-explorer",
+    href: "/tools/architecture-explorer",
   },
   {
     title: "Estimator",

--- a/ui/partner-hub/app/tools/architecture-explorer/ArchitectureExplorer.tsx
+++ b/ui/partner-hub/app/tools/architecture-explorer/ArchitectureExplorer.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import ReactFlow, {
+  Background,
+  Controls,
+  type ReactFlowInstance,
+  useEdgesState,
+  useNodesState,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { diagramScenarios, type ArchitectureNodeData } from "./diagramScenarios";
+
+export default function ArchitectureExplorer() {
+  const [scenarioId, setScenarioId] = useState(diagramScenarios[0]?.id ?? "");
+  const scenario = useMemo(
+    () => diagramScenarios.find((item) => item.id === scenarioId) ?? diagramScenarios[0],
+    [scenarioId],
+  );
+  const [nodes, setNodes, onNodesChange] = useNodesState<ArchitectureNodeData>(
+    scenario?.nodes ?? [],
+  );
+  const [edges, setEdges, onEdgesChange] = useEdgesState(scenario?.edges ?? []);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(
+    scenario?.nodes[0]?.id ?? null,
+  );
+  const [flowInstance, setFlowInstance] = useState<ReactFlowInstance | null>(null);
+
+  useEffect(() => {
+    if (!scenario) {
+      return;
+    }
+
+    setNodes(scenario.nodes);
+    setEdges(scenario.edges);
+    setSelectedNodeId(scenario.nodes[0]?.id ?? null);
+
+    if (flowInstance) {
+      requestAnimationFrame(() => {
+        flowInstance.fitView({ padding: 0.2, duration: 400 });
+      });
+    }
+  }, [scenario, setNodes, setEdges, flowInstance]);
+
+  const selectedNode = nodes.find((node) => node.id === selectedNodeId);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <span className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+            Scenario
+          </span>
+          <select
+            value={scenarioId}
+            onChange={(event) => setScenarioId(event.target.value)}
+            className="w-56 rounded-lg border border-border bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+          >
+            {diagramScenarios.map((item) => (
+              <option key={item.id} value={item.id}>
+                {item.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <Button
+          variant="outline"
+          onClick={() => flowInstance?.fitView({ padding: 0.2, duration: 400 })}
+        >
+          Reset View
+        </Button>
+      </div>
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <Card className="min-h-[420px]">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Architecture Map</CardTitle>
+          </CardHeader>
+          <CardContent className="h-[420px]">
+            <div className="h-full rounded-lg border border-dashed border-border/70">
+              <ReactFlow
+                nodes={nodes}
+                edges={edges}
+                onNodesChange={onNodesChange}
+                onEdgesChange={onEdgesChange}
+                onInit={setFlowInstance}
+                onNodeClick={(_, node) => setSelectedNodeId(node.id)}
+                fitView
+              >
+                <Background gap={16} color="hsl(var(--border))" />
+                <Controls />
+              </ReactFlow>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Node Details</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm text-foreground/70">
+            {selectedNode ? (
+              <>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+                    {selectedNode.data.label}
+                  </p>
+                  <h3 className="text-lg font-semibold text-foreground">
+                    {selectedNode.data.title}
+                  </h3>
+                </div>
+                <ul className="list-disc space-y-2 pl-5">
+                  {selectedNode.data.bullets.map((bullet) => (
+                    <li key={bullet}>{bullet}</li>
+                  ))}
+                </ul>
+              </>
+            ) : (
+              <p>Select a node to review architecture details.</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/ui/partner-hub/app/tools/architecture-explorer/diagramScenarios.ts
+++ b/ui/partner-hub/app/tools/architecture-explorer/diagramScenarios.ts
@@ -1,0 +1,209 @@
+import type { Edge, Node } from "@xyflow/react";
+
+export type ArchitectureNodeData = {
+  label: string;
+  title: string;
+  bullets: string[];
+};
+
+export type ArchitectureScenario = {
+  id: string;
+  label: string;
+  nodes: Node<ArchitectureNodeData>[];
+  edges: Edge[];
+};
+
+export const diagramScenarios: ArchitectureScenario[] = [
+  {
+    id: "data-center-refresh",
+    label: "Data Center Refresh",
+    nodes: [
+      {
+        id: "intake",
+        position: { x: 40, y: 40 },
+        data: {
+          label: "Discovery",
+          title: "Discovery & Assessment",
+          bullets: [
+            "Capture workload inventory and growth projections.",
+            "Audit resiliency gaps and modernization constraints.",
+            "Align stakeholders on refresh timelines and risk posture.",
+          ],
+        },
+      },
+      {
+        id: "core",
+        position: { x: 300, y: 20 },
+        data: {
+          label: "Core Platform",
+          title: "Core Storage Platform",
+          bullets: [
+            "Standardize on a consolidated block + file tier.",
+            "Introduce automation for provisioning and policy.",
+            "Prepare for scale-out growth over the next 3 years.",
+          ],
+        },
+      },
+      {
+        id: "backup",
+        position: { x: 300, y: 190 },
+        data: {
+          label: "Protection",
+          title: "Data Protection Layer",
+          bullets: [
+            "Replace legacy backup tooling with immutable snapshots.",
+            "Define retention tiers and recovery objectives.",
+            "Coordinate DR runbooks with application teams.",
+          ],
+        },
+      },
+      {
+        id: "operations",
+        position: { x: 560, y: 105 },
+        data: {
+          label: "Operations",
+          title: "Operational Excellence",
+          bullets: [
+            "Centralize monitoring and ticket automation.",
+            "Train ops teams on new workflows.",
+            "Measure success with refresh KPIs and service health.",
+          ],
+        },
+      },
+    ],
+    edges: [
+      { id: "e-intake-core", source: "intake", target: "core" },
+      { id: "e-intake-backup", source: "intake", target: "backup" },
+      { id: "e-core-ops", source: "core", target: "operations" },
+      { id: "e-backup-ops", source: "backup", target: "operations" },
+    ],
+  },
+  {
+    id: "hybrid-cloud",
+    label: "Hybrid Cloud",
+    nodes: [
+      {
+        id: "edge",
+        position: { x: 30, y: 120 },
+        data: {
+          label: "Edge DC",
+          title: "Edge Data Center",
+          bullets: [
+            "Collect latency-sensitive workloads close to users.",
+            "Cache data for AI/ML inferencing at the edge.",
+            "Stream telemetry back to core cloud services.",
+          ],
+        },
+      },
+      {
+        id: "core-hub",
+        position: { x: 280, y: 30 },
+        data: {
+          label: "Core Hub",
+          title: "Private Cloud Hub",
+          bullets: [
+            "Host regulated workloads and shared services.",
+            "Apply policy-based data tiering for governance.",
+            "Provide API integration for dev teams.",
+          ],
+        },
+      },
+      {
+        id: "public-cloud",
+        position: { x: 280, y: 210 },
+        data: {
+          label: "Public Cloud",
+          title: "Public Cloud Extension",
+          bullets: [
+            "Burst analytics and test environments on demand.",
+            "Maintain secure connectivity via VPN / Direct Connect.",
+            "Enforce tagging for cost management.",
+          ],
+        },
+      },
+      {
+        id: "control-plane",
+        position: { x: 560, y: 120 },
+        data: {
+          label: "Control Plane",
+          title: "Unified Control Plane",
+          bullets: [
+            "Surface one view of inventory and compliance.",
+            "Automate data mobility workflows.",
+            "Enable consistent identity and access control.",
+          ],
+        },
+      },
+    ],
+    edges: [
+      { id: "e-edge-core", source: "edge", target: "core-hub" },
+      { id: "e-edge-public", source: "edge", target: "public-cloud" },
+      { id: "e-core-control", source: "core-hub", target: "control-plane" },
+      { id: "e-public-control", source: "public-cloud", target: "control-plane" },
+    ],
+  },
+  {
+    id: "dr-bc",
+    label: "DR / BC",
+    nodes: [
+      {
+        id: "primary",
+        position: { x: 40, y: 40 },
+        data: {
+          label: "Primary",
+          title: "Primary Data Center",
+          bullets: [
+            "Host Tier-1 workloads and critical data services.",
+            "Provide synchronous replication for key systems.",
+            "Maintain local backup and snapshot schedules.",
+          ],
+        },
+      },
+      {
+        id: "replication",
+        position: { x: 300, y: 30 },
+        data: {
+          label: "Replication",
+          title: "Replication Fabric",
+          bullets: [
+            "Stream deltas to secondary sites in real time.",
+            "Monitor lag and alert on RPO deviations.",
+            "Test failover without impacting production.",
+          ],
+        },
+      },
+      {
+        id: "secondary",
+        position: { x: 300, y: 200 },
+        data: {
+          label: "Secondary",
+          title: "Secondary Data Center",
+          bullets: [
+            "Standby infrastructure for automated failover.",
+            "Run quarterly DR exercises and audits.",
+            "Provide recovery workflows for critical apps.",
+          ],
+        },
+      },
+      {
+        id: "command",
+        position: { x: 560, y: 110 },
+        data: {
+          label: "Command",
+          title: "BC Command Center",
+          bullets: [
+            "Coordinate communications during an incident.",
+            "Track recovery status and business impact.",
+            "Review post-incident improvements.",
+          ],
+        },
+      },
+    ],
+    edges: [
+      { id: "e-primary-rep", source: "primary", target: "replication" },
+      { id: "e-primary-secondary", source: "primary", target: "secondary" },
+      { id: "e-rep-command", source: "replication", target: "command" },
+      { id: "e-secondary-command", source: "secondary", target: "command" },
+    ],
+  },
+];

--- a/ui/partner-hub/app/tools/architecture-explorer/page.tsx
+++ b/ui/partner-hub/app/tools/architecture-explorer/page.tsx
@@ -1,0 +1,42 @@
+import dynamic from "next/dynamic";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+const ArchitectureExplorer = dynamic(() => import("./ArchitectureExplorer"), {
+  ssr: false,
+  loading: () => (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+      <Card className="min-h-[420px]">
+        <CardHeader className="pb-2">Architecture Map</CardHeader>
+        <CardContent>
+          <div className="h-[380px] animate-pulse rounded-lg border border-dashed border-border/70 bg-muted" />
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="pb-2">Node Details</CardHeader>
+        <CardContent className="space-y-3">
+          <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+          <div className="h-5 w-48 animate-pulse rounded bg-muted" />
+          <div className="space-y-2">
+            <div className="h-3 w-full animate-pulse rounded bg-muted" />
+            <div className="h-3 w-5/6 animate-pulse rounded bg-muted" />
+            <div className="h-3 w-2/3 animate-pulse rounded bg-muted" />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  ),
+});
+
+export default function ArchitectureExplorerPage() {
+  return (
+    <section className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Architecture Explorer</h1>
+        <p className="text-sm text-foreground/70">
+          Compare reference architectures and capture impacts for presales discovery.
+        </p>
+      </header>
+      <ArchitectureExplorer />
+    </section>
+  );
+}

--- a/ui/partner-hub/components/left-nav.tsx
+++ b/ui/partner-hub/components/left-nav.tsx
@@ -9,7 +9,7 @@ import { clsx } from "clsx";
 const links = [
   { name: "Home", href: "/" },
   { name: "Case Studies", href: "/case-studies" },
-  { name: "Architecture Explorer", href: "/architecture-explorer" },
+  { name: "Architecture Explorer", href: "/tools/architecture-explorer" },
   { name: "Estimator", href: "/estimator" },
   { name: "Energy Tool", href: "/energy/", external: true },
   { name: "About / Contact", href: "/about" },

--- a/ui/partner-hub/data/links.json
+++ b/ui/partner-hub/data/links.json
@@ -7,7 +7,7 @@
     },
     {
       "label": "Architecture Explorer",
-      "href": "/architecture-explorer",
+      "href": "/tools/architecture-explorer",
       "type": "internal"
     }
   ],

--- a/ui/partner-hub/package-lock.json
+++ b/ui/partner-hub/package-lock.json
@@ -8,6 +8,7 @@
             "name": "partner-hub",
             "version": "0.0.1",
             "dependencies": {
+                "@xyflow/react": "^12.3.0",
                 "clsx": "^2.1.0",
                 "lucide-react": "^0.365.0",
                 "next": "^14.0.0",
@@ -25,6 +26,27 @@
                 "postcss": "^8.4.31",
                 "tailwindcss": "^3.4.0",
                 "typescript": "^5.3.0"
+            }
+        },
+        "node_modules/@xyflow/react": {
+            "version": "12.3.0",
+            "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.3.0.tgz",
+            "integrity": "sha512-PLACEHOLDER",
+            "dependencies": {
+                "@xyflow/system": "^12.3.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8",
+                "react-dom": ">=16.8"
+            }
+        },
+        "node_modules/@xyflow/system": {
+            "version": "12.3.0",
+            "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-12.3.0.tgz",
+            "integrity": "sha512-PLACEHOLDER",
+            "peerDependencies": {
+                "react": ">=16.8",
+                "react-dom": ">=16.8"
             }
         },
         "node_modules/@alloc/quick-lru": {

--- a/ui/partner-hub/package.json
+++ b/ui/partner-hub/package.json
@@ -13,6 +13,7 @@
                          "next":  "^14.0.0",
                          "react":  "^18.0.0",
                          "react-dom":  "^18.0.0",
+                         "@xyflow/react":  "^12.3.0",
                          "next-themes":  "^0.2.1",
                          "lucide-react":  "^0.365.0",
                          "clsx":  "^2.1.0"


### PR DESCRIPTION
### Motivation
- Provide an interactive Architecture Explorer for exploring reference architectures and deployment patterns using a diagram canvas.  
- Keep the feature client-only to avoid SSR/static export issues when rendering React Flow.  
- Surface scenario-driven diagrams with node-level details to aid presales discovery.  
- Integrate the tool into the existing navigation and discovery UX under the app basePath (`/partner-hub`).

### Description
- Add a client-only page at `app/tools/architecture-explorer/page.tsx` that dynamically loads the diagram component with `ssr: false` and a loading skeleton.  
- Implement `ArchitectureExplorer.tsx` (a `"use client"` component) using React Flow for pan/zoom, `fitView`, a scenario dropdown, `Reset View` button, and a right-side node details panel.  
- Add static scenario data in `diagramScenarios.ts` (nodes/edges and node bullets) and wire node click selection to the details panel.  
- Update navigation and discovery links to point to `/tools/architecture-explorer` and add `@xyflow/react` to `package.json` with corresponding lockfile entries (lockfile entries were added as placeholders).

### Testing
- Ran `npm run dev` and the Next dev server started successfully (local server ready).  
- Attempted to load `http://localhost:3000/partner-hub/tools/architecture-explorer` but the build failed with `Module not found: Can't resolve '@xyflow/react'` because the dependency could not be installed.  
- Dependency installation was blocked by registry access (403), and the lockfile contains placeholder entries for `@xyflow/react`/`@xyflow/system`.  
- A Playwright screenshot was captured showing the module-not-found build error (page did not render the diagram).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695da2013df48326940e1f4251819cb3)