### PR TITLE
Polish Architecture Explorer scenarios + export/share

### DIFF
--- a/ui/partner-hub/app/tools/architecture-explorer/ArchitectureExplorer.tsx
+++ b/ui/partner-hub/app/tools/architecture-explorer/ArchitectureExplorer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import ReactFlow, {
   Background,
   Controls,
+  type Node,
   type ReactFlowInstance,
   useEdgesState,
   useNodesState,
@@ -11,7 +12,104 @@ import ReactFlow, {
 import "@xyflow/react/dist/style.css";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { diagramScenarios, type ArchitectureNodeData } from "./diagramScenarios";
+import {
+  diagramScenarios,
+  type ArchitectureNodeCategory,
+  type ArchitectureNodeData,
+} from "./diagramScenarios";
+
+type CategoryStyle = {
+  label: ArchitectureNodeCategory;
+  backgroundColor: string;
+  borderColor: string;
+  textColor: string;
+};
+
+const CATEGORY_STYLES: Record<ArchitectureNodeCategory, CategoryStyle> = {
+  Compute: {
+    label: "Compute",
+    backgroundColor: "#DBEAFE",
+    borderColor: "#60A5FA",
+    textColor: "#1E3A8A",
+  },
+  Storage: {
+    label: "Storage",
+    backgroundColor: "#DCFCE7",
+    borderColor: "#4ADE80",
+    textColor: "#166534",
+  },
+  Network: {
+    label: "Network",
+    backgroundColor: "#FEF3C7",
+    borderColor: "#FBBF24",
+    textColor: "#92400E",
+  },
+  Security: {
+    label: "Security",
+    backgroundColor: "#FCE7F3",
+    borderColor: "#F472B6",
+    textColor: "#9D174D",
+  },
+  Operations: {
+    label: "Operations",
+    backgroundColor: "#EDE9FE",
+    borderColor: "#A78BFA",
+    textColor: "#5B21B6",
+  },
+};
+
+const buildShareUrl = (scenarioId: string) => {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  const url = new URL(window.location.href);
+  url.searchParams.set("scenario", scenarioId);
+  return url.toString();
+};
+
+const decorateNodes = (nodes: Node<ArchitectureNodeData>[]) =>
+  nodes.map((node) => {
+    const categoryStyle = CATEGORY_STYLES[node.data.category];
+    return {
+      ...node,
+      style: {
+        backgroundColor: categoryStyle.backgroundColor,
+        borderColor: categoryStyle.borderColor,
+        color: categoryStyle.textColor,
+        borderRadius: 12,
+        borderWidth: 2,
+        borderStyle: "solid",
+        padding: 12,
+        width: 180,
+        fontWeight: 600,
+      },
+    };
+  });
+
+const Legend = () => (
+  <Card className="h-fit">
+    <CardHeader className="pb-2">
+      <CardTitle className="text-base">Legend</CardTitle>
+    </CardHeader>
+    <CardContent className="space-y-3 text-sm">
+      {Object.values(CATEGORY_STYLES).map((category) => (
+        <div key={category.label} className="flex items-center gap-3">
+          <span
+            className="h-3 w-3 rounded-sm border"
+            style={{
+              backgroundColor: category.backgroundColor,
+              borderColor: category.borderColor,
+            }}
+          />
+          <span className="font-medium" style={{ color: category.textColor }}>
+            {category.label}
+          </span>
+        </div>
+      ))}
+    </CardContent>
+  </Card>
+);
 
 export default function ArchitectureExplorer() {
   const [scenarioId, setScenarioId] = useState(diagramScenarios[0]?.id ?? "");
@@ -20,20 +118,33 @@ export default function ArchitectureExplorer() {
     [scenarioId],
   );
   const [nodes, setNodes, onNodesChange] = useNodesState<ArchitectureNodeData>(
-    scenario?.nodes ?? [],
+    decorateNodes(scenario?.nodes ?? []),
   );
   const [edges, setEdges, onEdgesChange] = useEdgesState(scenario?.edges ?? []);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(
     scenario?.nodes[0]?.id ?? null,
   );
   const [flowInstance, setFlowInstance] = useState<ReactFlowInstance | null>(null);
+  const [copyState, setCopyState] = useState("Copy share link");
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    const scenarioParam = params.get("scenario");
+    if (scenarioParam && diagramScenarios.some((item) => item.id === scenarioParam)) {
+      setScenarioId(scenarioParam);
+    }
+  }, []);
 
   useEffect(() => {
     if (!scenario) {
       return;
     }
 
-    setNodes(scenario.nodes);
+    setNodes(decorateNodes(scenario.nodes));
     setEdges(scenario.edges);
     setSelectedNodeId(scenario.nodes[0]?.id ?? null);
 
@@ -44,7 +155,60 @@ export default function ArchitectureExplorer() {
     }
   }, [scenario, setNodes, setEdges, flowInstance]);
 
+  useEffect(() => {
+    if (typeof window === "undefined" || !scenarioId) {
+      return;
+    }
+
+    const url = new URL(window.location.href);
+    url.searchParams.set("scenario", scenarioId);
+    window.history.replaceState({}, "", url.toString());
+  }, [scenarioId]);
+
   const selectedNode = nodes.find((node) => node.id === selectedNodeId);
+
+  const handleCopyShare = async () => {
+    const shareUrl = buildShareUrl(scenarioId);
+    if (!shareUrl) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopyState("Copied!");
+      window.setTimeout(() => setCopyState("Copy share link"), 2000);
+    } catch (error) {
+      console.error("Failed to copy share link", error);
+      setCopyState("Copy failed");
+      window.setTimeout(() => setCopyState("Copy share link"), 2000);
+    }
+  };
+
+  const handleExportScenario = () => {
+    if (!scenario) {
+      return;
+    }
+
+    const payload = {
+      id: scenario.id,
+      label: scenario.label,
+      nodes: scenario.nodes,
+      edges: scenario.edges,
+      exportedAt: new Date().toISOString(),
+    };
+
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${scenario.id}-architecture.json`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  };
 
   return (
     <div className="flex flex-col gap-6">
@@ -65,12 +229,20 @@ export default function ArchitectureExplorer() {
             ))}
           </select>
         </div>
-        <Button
-          variant="outline"
-          onClick={() => flowInstance?.fitView({ padding: 0.2, duration: 400 })}
-        >
-          Reset View
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" onClick={handleCopyShare}>
+            {copyState}
+          </Button>
+          <Button variant="outline" onClick={handleExportScenario}>
+            Export scenario JSON
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => flowInstance?.fitView({ padding: 0.2, duration: 400 })}
+          >
+            Reset View
+          </Button>
+        </div>
       </div>
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
         <Card className="min-h-[420px]">
@@ -94,32 +266,64 @@ export default function ArchitectureExplorer() {
             </div>
           </CardContent>
         </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-base">Node Details</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4 text-sm text-foreground/70">
-            {selectedNode ? (
-              <>
-                <div>
-                  <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
-                    {selectedNode.data.label}
-                  </p>
-                  <h3 className="text-lg font-semibold text-foreground">
-                    {selectedNode.data.title}
-                  </h3>
-                </div>
-                <ul className="list-disc space-y-2 pl-5">
-                  {selectedNode.data.bullets.map((bullet) => (
-                    <li key={bullet}>{bullet}</li>
-                  ))}
-                </ul>
-              </>
-            ) : (
-              <p>Select a node to review architecture details.</p>
-            )}
-          </CardContent>
-        </Card>
+        <div className="space-y-6">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base">Node Details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4 text-sm text-foreground/70">
+              {selectedNode ? (
+                <>
+                  <div className="space-y-1">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+                      {selectedNode.data.category}
+                    </span>
+                    <h3 className="text-lg font-semibold text-foreground">
+                      {selectedNode.data.label}
+                    </h3>
+                  </div>
+                  <div className="space-y-3">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+                        What it does
+                      </p>
+                      <p className="text-foreground/80">{selectedNode.data.notes.what}</p>
+                    </div>
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+                        Why this design
+                      </p>
+                      <p className="text-foreground/80">{selectedNode.data.notes.why}</p>
+                    </div>
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+                        Common alternatives
+                      </p>
+                      <ul className="list-disc space-y-1 pl-5">
+                        {selectedNode.data.notes.alternatives.map((bullet) => (
+                          <li key={bullet}>{bullet}</li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+                        Tradeoffs
+                      </p>
+                      <ul className="list-disc space-y-1 pl-5">
+                        {selectedNode.data.notes.tradeoffs.map((bullet) => (
+                          <li key={bullet}>{bullet}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <p>Select a node to review architecture details.</p>
+              )}
+            </CardContent>
+          </Card>
+          <Legend />
+        </div>
       </div>
     </div>
   );

--- a/ui/partner-hub/app/tools/architecture-explorer/diagramScenarios.ts
+++ b/ui/partner-hub/app/tools/architecture-explorer/diagramScenarios.ts
@@ -1,9 +1,18 @@
 import type { Edge, Node } from "@xyflow/react";
 
+export type ArchitectureNodeCategory = "Compute" | "Storage" | "Network" | "Security" | "Operations";
+
+export type ArchitectureNodeNotes = {
+  what: string;
+  why: string;
+  alternatives: string[];
+  tradeoffs: string[];
+};
+
 export type ArchitectureNodeData = {
   label: string;
-  title: string;
-  bullets: string[];
+  category: ArchitectureNodeCategory;
+  notes: ArchitectureNodeNotes;
 };
 
 export type ArchitectureScenario = {
@@ -19,127 +28,255 @@ export const diagramScenarios: ArchitectureScenario[] = [
     label: "Data Center Refresh",
     nodes: [
       {
-        id: "intake",
-        position: { x: 40, y: 40 },
+        id: "core-switching",
+        position: { x: 60, y: 40 },
         data: {
-          label: "Discovery",
-          title: "Discovery & Assessment",
-          bullets: [
-            "Capture workload inventory and growth projections.",
-            "Audit resiliency gaps and modernization constraints.",
-            "Align stakeholders on refresh timelines and risk posture.",
-          ],
+          label: "Core Switching",
+          category: "Network",
+          notes: {
+            what: "Redundant core switching that anchors east-west traffic and inter-VLAN routing.",
+            why: "Keeps the refresh anchored on a resilient, high-throughput fabric before modernizing workloads.",
+            alternatives: [
+              "Collapsed core with spine/leaf fabrics",
+              "MPLS core if WAN routing is the primary requirement",
+            ],
+            tradeoffs: [
+              "Higher capex up front to avoid mid-cycle forklift swaps",
+              "Requires coordinated cutovers with network/security teams",
+            ],
+          },
         },
       },
       {
-        id: "core",
-        position: { x: 300, y: 20 },
+        id: "tor-switching",
+        position: { x: 300, y: 40 },
         data: {
-          label: "Core Platform",
-          title: "Core Storage Platform",
-          bullets: [
-            "Standardize on a consolidated block + file tier.",
-            "Introduce automation for provisioning and policy.",
-            "Prepare for scale-out growth over the next 3 years.",
-          ],
+          label: "ToR Switching",
+          category: "Network",
+          notes: {
+            what: "Top-of-rack switching for compute and storage racks with consistent VLAN segmentation.",
+            why: "Enables predictable latency and simplifies cabling during the hardware refresh phase.",
+            alternatives: ["End-of-row switching", "Fully converged fabric with DCB"],
+            tradeoffs: [
+              "More switches to manage, but shorter cable runs",
+              "Needs consistent automation to avoid config drift",
+            ],
+          },
+        },
+      },
+      {
+        id: "compute-cluster",
+        position: { x: 560, y: 30 },
+        data: {
+          label: "Compute Cluster",
+          category: "Compute",
+          notes: {
+            what: "Virtualization or container cluster hosting tier-1 and tier-2 workloads.",
+            why: "Consolidates legacy hosts while enabling automation and capacity headroom.",
+            alternatives: ["Dedicated bare metal for latency-sensitive apps", "Public cloud burst only"],
+            tradeoffs: [
+              "Requires careful sizing to avoid over-commit",
+              "Cluster upgrades need coordinated maintenance windows",
+            ],
+          },
+        },
+      },
+      {
+        id: "storage-platform",
+        position: { x: 560, y: 200 },
+        data: {
+          label: "SAN / HCI Storage",
+          category: "Storage",
+          notes: {
+            what: "Primary storage platform with block/file services and QoS policies.",
+            why: "Balances performance and cost while supporting mixed workload profiles.",
+            alternatives: ["Scale-out NAS", "All-flash SAN with tiering"],
+            tradeoffs: [
+              "SAN requires specialized skills; HCI trades raw performance for simplicity",
+              "Growth planning must align with application refresh cycles",
+            ],
+          },
         },
       },
       {
         id: "backup",
-        position: { x: 300, y: 190 },
+        position: { x: 820, y: 200 },
         data: {
-          label: "Protection",
-          title: "Data Protection Layer",
-          bullets: [
-            "Replace legacy backup tooling with immutable snapshots.",
-            "Define retention tiers and recovery objectives.",
-            "Coordinate DR runbooks with application teams.",
-          ],
+          label: "Backup & Recovery",
+          category: "Storage",
+          notes: {
+            what: "Immutable backups and recovery vault for ransomware resilience.",
+            why: "Protects the refreshed environment with modern retention and air-gap policies.",
+            alternatives: ["Tape vaulting", "Cloud-only backup repositories"],
+            tradeoffs: [
+              "Immutable storage adds capacity overhead",
+              "Requires periodic recovery testing to validate SLAs",
+            ],
+          },
         },
       },
       {
-        id: "operations",
-        position: { x: 560, y: 105 },
+        id: "management",
+        position: { x: 560, y: 330 },
         data: {
-          label: "Operations",
-          title: "Operational Excellence",
-          bullets: [
-            "Centralize monitoring and ticket automation.",
-            "Train ops teams on new workflows.",
-            "Measure success with refresh KPIs and service health.",
-          ],
+          label: "Management & Monitoring",
+          category: "Operations",
+          notes: {
+            what: "Unified monitoring, ticketing, and automation for the refreshed stack.",
+            why: "Gives operations a single pane of glass for the new platform and legacy coexistence.",
+            alternatives: ["Tool-by-tool monitoring", "Outsourced NOC"],
+            tradeoffs: [
+              "Requires integration effort across vendors",
+              "Automation needs governance to avoid unintended changes",
+            ],
+          },
+        },
+      },
+      {
+        id: "security-boundary",
+        position: { x: 300, y: 200 },
+        data: {
+          label: "Security Boundary",
+          category: "Security",
+          notes: {
+            what: "Firewalls, segmentation, and zero-trust controls between user, server, and storage zones.",
+            why: "Ensures the refresh does not expand the attack surface while introducing new platforms.",
+            alternatives: ["Flat network with IDS only", "Service mesh segmentation"],
+            tradeoffs: [
+              "Tighter segmentation can add latency for east-west flows",
+              "Policy design needs app owner input to prevent outages",
+            ],
+          },
         },
       },
     ],
     edges: [
-      { id: "e-intake-core", source: "intake", target: "core" },
-      { id: "e-intake-backup", source: "intake", target: "backup" },
-      { id: "e-core-ops", source: "core", target: "operations" },
-      { id: "e-backup-ops", source: "backup", target: "operations" },
+      { id: "e-core-tor", source: "core-switching", target: "tor-switching" },
+      { id: "e-tor-compute", source: "tor-switching", target: "compute-cluster" },
+      { id: "e-tor-storage", source: "tor-switching", target: "storage-platform" },
+      { id: "e-storage-backup", source: "storage-platform", target: "backup" },
+      { id: "e-management-compute", source: "management", target: "compute-cluster" },
+      { id: "e-management-storage", source: "management", target: "storage-platform" },
+      { id: "e-security-core", source: "security-boundary", target: "core-switching" },
+      { id: "e-security-storage", source: "security-boundary", target: "storage-platform" },
     ],
   },
   {
     id: "hybrid-cloud",
-    label: "Hybrid Cloud",
+    label: "Hybrid Cloud Landing Zone",
     nodes: [
       {
-        id: "edge",
-        position: { x: 30, y: 120 },
+        id: "on-prem",
+        position: { x: 40, y: 90 },
         data: {
-          label: "Edge DC",
-          title: "Edge Data Center",
-          bullets: [
-            "Collect latency-sensitive workloads close to users.",
-            "Cache data for AI/ML inferencing at the edge.",
-            "Stream telemetry back to core cloud services.",
-          ],
+          label: "On-Prem Cluster",
+          category: "Compute",
+          notes: {
+            what: "Modernized on-prem cluster hosting regulated and latency-sensitive workloads.",
+            why: "Keeps data residency and performance requirements anchored on-site.",
+            alternatives: ["Colocation private cloud", "Dedicated cloud region only"],
+            tradeoffs: [
+              "Requires ongoing hardware lifecycle management",
+              "Capacity growth planning must align with budget cycles",
+            ],
+          },
         },
       },
       {
-        id: "core-hub",
-        position: { x: 280, y: 30 },
+        id: "connectivity",
+        position: { x: 300, y: 40 },
         data: {
-          label: "Core Hub",
-          title: "Private Cloud Hub",
-          bullets: [
-            "Host regulated workloads and shared services.",
-            "Apply policy-based data tiering for governance.",
-            "Provide API integration for dev teams.",
-          ],
+          label: "Private Connectivity",
+          category: "Network",
+          notes: {
+            what: "Redundant VPN/Direct Connect/ExpressRoute links with QoS.",
+            why: "Provides predictable latency and secure transport between on-prem and cloud.",
+            alternatives: ["Public internet only", "SD-WAN overlay"],
+            tradeoffs: [
+              "Carrier lead times can delay go-live",
+              "Dual circuits add recurring cost but reduce outage risk",
+            ],
+          },
         },
       },
       {
-        id: "public-cloud",
-        position: { x: 280, y: 210 },
+        id: "landing-zone",
+        position: { x: 560, y: 40 },
         data: {
-          label: "Public Cloud",
-          title: "Public Cloud Extension",
-          bullets: [
-            "Burst analytics and test environments on demand.",
-            "Maintain secure connectivity via VPN / Direct Connect.",
-            "Enforce tagging for cost management.",
-          ],
+          label: "Cloud Landing Zone",
+          category: "Compute",
+          notes: {
+            what: "Hardened cloud subscription/account with guardrails, networks, and shared services.",
+            why: "Accelerates app migrations while enforcing security and cost controls.",
+            alternatives: ["Single shared VPC/VNet", "Manual per-app accounts"],
+            tradeoffs: [
+              "Requires upfront design effort for guardrails",
+              "Too many accounts can slow governance workflows",
+            ],
+          },
         },
       },
       {
-        id: "control-plane",
-        position: { x: 560, y: 120 },
+        id: "identity",
+        position: { x: 560, y: 200 },
         data: {
-          label: "Control Plane",
-          title: "Unified Control Plane",
-          bullets: [
-            "Surface one view of inventory and compliance.",
-            "Automate data mobility workflows.",
-            "Enable consistent identity and access control.",
-          ],
+          label: "Identity & Access",
+          category: "Security",
+          notes: {
+            what: "Federated identity, MFA, and role-based access for hybrid workloads.",
+            why: "Keeps user experience consistent while enforcing least privilege.",
+            alternatives: ["Cloud-native identities only", "Separate identities per environment"],
+            tradeoffs: [
+              "Federation adds dependency on core IdP uptime",
+              "Role mapping requires continuous review",
+            ],
+          },
+        },
+      },
+      {
+        id: "monitoring",
+        position: { x: 300, y: 220 },
+        data: {
+          label: "Monitoring & Ops",
+          category: "Operations",
+          notes: {
+            what: "Centralized observability, incident routing, and runbooks across clouds.",
+            why: "Ensures hybrid visibility and faster mean time to recovery.",
+            alternatives: ["Separate monitoring per environment", "MSSP-only monitoring"],
+            tradeoffs: [
+              "Integration effort is significant",
+              "Tool sprawl can occur without clear ownership",
+            ],
+          },
+        },
+      },
+      {
+        id: "backup-dr",
+        position: { x: 820, y: 150 },
+        data: {
+          label: "Backup & DR Replication",
+          category: "Storage",
+          notes: {
+            what: "Cross-site backup copy and replication to cloud vaults.",
+            why: "Meets RPO/RTO targets while enabling cloud-based recovery options.",
+            alternatives: ["On-prem only backup", "Active-active multi-cloud"],
+            tradeoffs: [
+              "Replication bandwidth needs to be sized for growth",
+              "Cloud vault storage adds recurring cost",
+            ],
+          },
         },
       },
     ],
     edges: [
-      { id: "e-edge-core", source: "edge", target: "core-hub" },
-      { id: "e-edge-public", source: "edge", target: "public-cloud" },
-      { id: "e-core-control", source: "core-hub", target: "control-plane" },
-      { id: "e-public-control", source: "public-cloud", target: "control-plane" },
+      { id: "e-onprem-connect", source: "on-prem", target: "connectivity" },
+      { id: "e-connect-landing", source: "connectivity", target: "landing-zone" },
+      { id: "e-identity-onprem", source: "identity", target: "on-prem" },
+      { id: "e-identity-landing", source: "identity", target: "landing-zone" },
+      { id: "e-monitoring-onprem", source: "monitoring", target: "on-prem" },
+      { id: "e-monitoring-landing", source: "monitoring", target: "landing-zone" },
+      { id: "e-backup-onprem", source: "backup-dr", target: "on-prem" },
+      { id: "e-backup-landing", source: "backup-dr", target: "landing-zone" },
     ],
   },
   {
@@ -147,63 +284,116 @@ export const diagramScenarios: ArchitectureScenario[] = [
     label: "DR / BC",
     nodes: [
       {
-        id: "primary",
-        position: { x: 40, y: 40 },
+        id: "primary-site",
+        position: { x: 40, y: 60 },
         data: {
-          label: "Primary",
-          title: "Primary Data Center",
-          bullets: [
-            "Host Tier-1 workloads and critical data services.",
-            "Provide synchronous replication for key systems.",
-            "Maintain local backup and snapshot schedules.",
-          ],
+          label: "Primary Site",
+          category: "Compute",
+          notes: {
+            what: "Production site hosting critical applications and databases.",
+            why: "Maintains performance and proximity for core business services.",
+            alternatives: ["Active-active dual sites", "Cloud-first production"],
+            tradeoffs: [
+              "Primary site remains a single point of failure without DR",
+              "Higher uptime tiers increase facility costs",
+            ],
+          },
         },
       },
       {
-        id: "replication",
-        position: { x: 300, y: 30 },
+        id: "replication-fabric",
+        position: { x: 300, y: 40 },
         data: {
-          label: "Replication",
-          title: "Replication Fabric",
-          bullets: [
-            "Stream deltas to secondary sites in real time.",
-            "Monitor lag and alert on RPO deviations.",
-            "Test failover without impacting production.",
-          ],
+          label: "Replication Fabric",
+          category: "Storage",
+          notes: {
+            what: "Synchronous/async replication streams with RPO tracking.",
+            why: "Aligns data protection with application RPO/RTO targets.",
+            alternatives: ["Batch replication windows", "Application-level replication"],
+            tradeoffs: [
+              "Lower RPOs require more bandwidth and tighter latency",
+              "Replication tooling adds licensing overhead",
+            ],
+          },
         },
       },
       {
-        id: "secondary",
-        position: { x: 300, y: 200 },
+        id: "dr-site",
+        position: { x: 560, y: 60 },
         data: {
-          label: "Secondary",
-          title: "Secondary Data Center",
-          bullets: [
-            "Standby infrastructure for automated failover.",
-            "Run quarterly DR exercises and audits.",
-            "Provide recovery workflows for critical apps.",
-          ],
+          label: "DR Site",
+          category: "Compute",
+          notes: {
+            what: "Warm standby infrastructure ready for controlled failover.",
+            why: "Provides predictable recovery while limiting idle spend.",
+            alternatives: ["Cold site with delayed recovery", "Active-active mirroring"],
+            tradeoffs: [
+              "Warm standby needs periodic patching and testing",
+              "Capacity must match peak recovery needs",
+            ],
+          },
         },
       },
       {
-        id: "command",
-        position: { x: 560, y: 110 },
+        id: "dns-failover",
+        position: { x: 560, y: 220 },
         data: {
-          label: "Command",
-          title: "BC Command Center",
-          bullets: [
-            "Coordinate communications during an incident.",
-            "Track recovery status and business impact.",
-            "Review post-incident improvements.",
-          ],
+          label: "DNS + Failover",
+          category: "Network",
+          notes: {
+            what: "Global DNS and traffic management steering users during failover.",
+            why: "Ensures client traffic shifts to the DR site within SLA windows.",
+            alternatives: ["Manual DNS updates", "GSLB appliance"],
+            tradeoffs: [
+              "TTL tuning can impact cache behavior",
+              "Automated failover requires rigorous testing",
+            ],
+          },
+        },
+      },
+      {
+        id: "backup-vault",
+        position: { x: 300, y: 240 },
+        data: {
+          label: "Backup Vault",
+          category: "Storage",
+          notes: {
+            what: "Immutable backup vault isolated from production credentials.",
+            why: "Guards against ransomware and supports point-in-time restores.",
+            alternatives: ["Tape vaults", "Cloud snapshot only"],
+            tradeoffs: [
+              "Vault capacity grows quickly without tiering",
+              "Vault access controls require strict governance",
+            ],
+          },
+        },
+      },
+      {
+        id: "rpo-rto",
+        position: { x: 820, y: 140 },
+        data: {
+          label: "RPO/RTO Targets",
+          category: "Operations",
+          notes: {
+            what: "Business-approved recovery targets tied to runbooks and testing cadence.",
+            why: "Aligns technology spend with stakeholder expectations during outages.",
+            alternatives: ["Best-effort recovery", "Uniform targets for all apps"],
+            tradeoffs: [
+              "Aggressive targets increase infrastructure cost",
+              "Requires frequent validation exercises",
+            ],
+          },
         },
       },
     ],
     edges: [
-      { id: "e-primary-rep", source: "primary", target: "replication" },
-      { id: "e-primary-secondary", source: "primary", target: "secondary" },
-      { id: "e-rep-command", source: "replication", target: "command" },
-      { id: "e-secondary-command", source: "secondary", target: "command" },
+      { id: "e-primary-rep", source: "primary-site", target: "replication-fabric" },
+      { id: "e-rep-dr", source: "replication-fabric", target: "dr-site" },
+      { id: "e-primary-backup", source: "primary-site", target: "backup-vault" },
+      { id: "e-dr-dns", source: "dr-site", target: "dns-failover" },
+      { id: "e-primary-dns", source: "primary-site", target: "dns-failover" },
+      { id: "e-rpo-rep", source: "rpo-rto", target: "replication-fabric" },
+      { id: "e-rpo-backup", source: "rpo-rto", target: "backup-vault" },
     ],
   },
 ];


### PR DESCRIPTION
### Motivation
- Replace generic placeholders with presales-ready reference architectures so scenarios can be used in real discovery conversations.
- Surface richer node-level guidance (what/why/alternatives/tradeoffs) to help presales explain design choices and tradeoffs.
- Add share/export flows so users can copy a scenario link or export scenario JSON for handoff.
- Keep the feature static-export friendly and client-only (no server/API calls) to remain compatible with static Next.js deploys.

### Description
- Replaced scenario data in `diagramScenarios.ts` with three detailed scenarios (Data Center Refresh, Hybrid Cloud Landing Zone, DR / BC) where each node includes `label`, `category`, and `notes` (what/why/alternatives/tradeoffs).
- Expanded `ArchitectureExplorer.tsx` with `decorateNodes` styling, a `Legend` component, and an enriched Node Details panel that shows `What it does`, `Why this design`, `Common alternatives`, and `Tradeoffs` when a node is selected.
- Added client-side share/export features: `handleCopyShare` + `buildShareUrl` to copy a `?scenario=...` link and client-only parsing of `window.location.search`, and `handleExportScenario` to download scenario JSON, using only browser APIs.
- Kept all logic client-side (URL param parsing and history updates via `window.history.replaceState`) with no server/API calls to preserve static-export compatibility.

### Testing
- Started the dev server with `npm run dev` and the Next.js app reported ready (local dev server started successfully).
- Automated Playwright screenshot attempt failed due to a Chromium crash in the environment (browser `TargetClosedError`), so no screenshot was produced.
- No unit tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695da4cce30c832697dc03bb47181ba4)