### PR TITLE
Make NetApp candidate keys unique and improve candidate row accessibility

### DIFF
--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -68,7 +68,18 @@ export function EnergyTool() {
   const [selected, setSelected] = useState<NetAppCandidate | null>(null);
   const [computeError, setComputeError] = useState<string | null>(null);
 
-  const candidateKey = (candidate: NetAppCandidate) => `${candidate.controllerModel}-${candidate.expansionQty}`;
+  const candidateKey = (candidate: NetAppCandidate) => {
+    const effTb = Math.round(candidate.effectiveTb);
+    const annualCostCents = Math.round(candidate.annualEnergyCost * 100);
+    return [
+      candidate.controllerModel,
+      candidate.expansionModel,
+      candidate.controllerQty,
+      candidate.expansionQty,
+      effTb,
+      annualCostCents,
+    ].join("-");
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -347,8 +358,10 @@ export function EnergyTool() {
                               key={candidateKey(c)}
                               className={
                                 "cursor-pointer border-b border-border/60 transition focus-visible:outline-none focus-visible:ring-2 " +
-                                "focus-visible:ring-primary/60 focus-visible:ring-inset hover:bg-muted/40 " +
-                                (isSelected ? "bg-muted/60 font-semibold ring-1 ring-primary/30" : "")
+                                "focus-visible:ring-primary/60 focus-visible:ring-inset " +
+                                (isSelected
+                                  ? "bg-muted/60 font-semibold ring-1 ring-primary/30"
+                                  : "hover:bg-muted/40")
                               }
                               onClick={() => setSelected(c)}
                               onKeyDown={(event) => {
@@ -357,11 +370,20 @@ export function EnergyTool() {
                                   setSelected(c);
                                 }
                               }}
-                              role="row"
+                              role="button"
                               aria-selected={isSelected}
                               tabIndex={0}
                             >
-                              <td className="py-2 pr-3 font-medium">{c.controllerModel}</td>
+                              <td className="py-2 pr-3 font-medium">
+                                <div className="flex items-center gap-2">
+                                  <span>{c.controllerModel}</span>
+                                  {isSelected ? (
+                                    <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                                      Selected
+                                    </span>
+                                  ) : null}
+                                </div>
+                              </td>
                               <td className="py-2 pr-3">{c.expansionQty}</td>
                               <td className="py-2 pr-3">{fmt0.format(c.effectiveTb)}</td>
                               <td className="py-2 pr-3">{fmt2.format(c.pctDiffFromTarget)}%</td>


### PR DESCRIPTION
### Motivation

- Make the clickable NetApp candidates table semantically and accessibly correct while keeping behavior identical.  
- Ensure selection persists and cannot collide when the candidate set changes or expands.  
- Provide a small visual polish so the selected row is unambiguous without adding clutter.  

### Description

- Replace the simple key generation with a collision-resistant `candidateKey` that includes `controllerModel`, `expansionModel`, `controllerQty`, `expansionQty`, rounded `effectiveTb`, and `annualEnergyCost` in cents.  
- Change the interactive row semantics from `role="row"` to `role="button"` while keeping `onClick`/`onKeyDown` handlers and focus classes to preserve existing keyboard behavior.  
- Add hover-only styling for non-selected rows and a small `Selected` pill in the controller cell for the selected row, keeping selection styling via state.  
- No calculation logic was modified.  

### Testing

- `npm run build` at the repository root failed due to a missing `package.json` (expected environment issue).  
- `npm run build` executed from `ui/partner-hub` completed successfully and produced a static export.  
- Next's linting and type checks ran as part of the build and passed.  
- A headless Playwright smoke script launched the dev server and captured a screenshot of the energy tool page (script completed and artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695ec29973088326857e496627727349)