### PR TITLE
Sync canonical energy CSVs at build and add Assumptions & Sources panel to Energy Tool

### DIFF
--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -22,6 +22,13 @@ const fmt0 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
 const fmt1 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
 const fmt2 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 });
 
+type EnergyMeta = {
+  lastSyncedISO?: string;
+  sourceFiles?: string[];
+  copiedFiles?: string[];
+  sha256?: Record<string, string>;
+};
+
 type Inputs = {
   dfmTb: number;
   capacityPb: number;
@@ -65,6 +72,9 @@ export function EnergyTool() {
   const [netappRows, setNetappRows] = useState<NetAppRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [energyMeta, setEnergyMeta] = useState<EnergyMeta | null>(null);
+  const [metaError, setMetaError] = useState<string | null>(null);
+  const [assumptionsOpen, setAssumptionsOpen] = useState(false);
 
   const [inputs, setInputs] = useState<Inputs>(() => ({
     dfmTb: 48,
@@ -124,6 +134,31 @@ export function EnergyTool() {
         setLoadError(err instanceof Error ? err.message : "Failed to load energy datasets");
       } finally {
         setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [basePath]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        setMetaError(null);
+        const res = await fetch(`${basePath}/data/energy/energy_data_meta.json`);
+        if (!res.ok) {
+          throw new Error(`Failed to load energy metadata (${res.status})`);
+        }
+        const data = (await res.json()) as EnergyMeta;
+        if (!cancelled) {
+          setEnergyMeta(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setMetaError(err instanceof Error ? err.message : "Failed to load energy metadata");
+        }
       }
     })();
 
@@ -241,6 +276,69 @@ export function EnergyTool() {
   }, [fb, inputs.tolPct]);
 
   const selectedCandidate = mode === "manual" ? manualCandidate : selected;
+  const sourceEntries = useMemo(() => {
+    const entries: Array<{ model: string; url?: string }> = [];
+    if (pureRows.length > 0) {
+      const dfm = inputs.dfmTb;
+      const lookup = (needle: string) =>
+        pureRows.find(
+          (row) => row.DFM_Size_TB === dfm && String(row.Model ?? "").toLowerCase().includes(needle),
+        );
+      const ecRow = lookup("ec chassis");
+      const exRow = lookup("ex chassis");
+      const xfmRow = lookup("xfm");
+      [ecRow, exRow, xfmRow].forEach((row) => {
+        if (!row) return;
+        entries.push({
+          model: String(row.Model ?? "Unknown model"),
+          url: row.Source_URL ? String(row.Source_URL) : undefined,
+        });
+      });
+    }
+
+    if (selectedCandidate) {
+      const controllerRow = netappRows.find(
+        (row) =>
+          row.Component_Type === "Controller_Shelf" &&
+          String(row.Model ?? "") === selectedCandidate.controllerModel,
+      );
+      if (controllerRow) {
+        entries.push({
+          model: String(controllerRow.Model ?? selectedCandidate.controllerModel),
+          url: controllerRow.Source_URL ? String(controllerRow.Source_URL) : undefined,
+        });
+      }
+      const expansionRow = netappRows.find(
+        (row) =>
+          row.Component_Type === "Expansion_Shelf" &&
+          String(row.Model ?? "") === selectedCandidate.expansionModel,
+      );
+      if (expansionRow) {
+        entries.push({
+          model: String(expansionRow.Model ?? selectedCandidate.expansionModel),
+          url: expansionRow.Source_URL ? String(expansionRow.Source_URL) : undefined,
+        });
+      }
+    }
+
+    return entries;
+  }, [inputs.dfmTb, netappRows, pureRows, selectedCandidate]);
+
+  const sourceList = useMemo(() => {
+    const seen = new Set<string>();
+    const items: Array<{ type: "link" | "missing"; label: string; url?: string }> = [];
+    for (const entry of sourceEntries) {
+      if (entry.url) {
+        if (seen.has(entry.url)) continue;
+        seen.add(entry.url);
+        items.push({ type: "link", label: entry.url, url: entry.url });
+      } else {
+        items.push({ type: "missing", label: `Source missing for ${entry.model}` });
+      }
+    }
+    return items;
+  }, [sourceEntries]);
+
   const savings = useMemo(() => {
     if (!fb || !selectedCandidate) return null;
     const deltaW = fb.weightedW - selectedCandidate.weightedW;
@@ -253,6 +351,49 @@ export function EnergyTool() {
       pctCost: fb.annualCost > 0 ? (deltaCost / fb.annualCost) * 100 : null,
     };
   }, [fb, selectedCandidate]);
+
+  const handleDownloadAssumptions = () => {
+    const payload = {
+      lastSyncedISO: energyMeta?.lastSyncedISO ?? null,
+      mode,
+      assumptions: {
+        flashblade: {
+          utilizationPct: inputs.pureUtilPct,
+          pue: inputs.purePue,
+          pricePerKwh: inputs.purePrice,
+          drr: inputs.pureDrr,
+          dfmSizeTb: inputs.dfmTb,
+          capacityPb: inputs.capacityPb,
+        },
+        netapp: {
+          utilizationPct: inputs.naUtilPct,
+          pue: inputs.naPue,
+          pricePerKwh: inputs.naPrice,
+          overheadRawToUsable: inputs.naOverhead,
+          drr: inputs.naDrr,
+          driveSizeTb: inputs.naDriveSizeTb,
+          driveSizeSelection: "User-selected drive size input",
+        },
+      },
+      selectedNetApp: selectedCandidate
+        ? {
+            controllerModel: selectedCandidate.controllerModel,
+            expansionModel: selectedCandidate.expansionModel,
+            expansionShelves: selectedCandidate.expansionQty,
+            driveSizeTb: inputs.naDriveSizeTb,
+          }
+        : null,
+      sources: sourceList.map((item) => (item.type === "link" ? item.url : item.label)),
+    };
+
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "assumptions.json";
+    link.click();
+    URL.revokeObjectURL(url);
+  };
 
   return (
     <div className="space-y-6">
@@ -432,6 +573,13 @@ export function EnergyTool() {
                   Apply manual config
                 </button>
               )}
+              <button
+                type="button"
+                className="inline-flex h-10 items-center justify-center rounded-md border border-border bg-background px-4 text-sm font-semibold text-foreground transition hover:bg-muted/50"
+                onClick={() => setAssumptionsOpen((prev) => !prev)}
+              >
+                Assumptions &amp; Sources
+              </button>
               {loading ? <span className="text-xs text-foreground/60">Loading datasets…</span> : null}
               {computeError ? <span className="text-xs font-semibold text-red-600">{computeError}</span> : null}
             </div>
@@ -599,6 +747,96 @@ export function EnergyTool() {
             </CardContent>
           </Card>
         </div>
+      ) : null}
+
+      {assumptionsOpen ? (
+        <Card>
+          <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <CardTitle className="text-base">Assumptions &amp; Sources</CardTitle>
+              <p className="text-xs text-foreground/60">
+                Last synced: {energyMeta?.lastSyncedISO ?? (metaError ? "Unavailable" : "Loading…")}
+              </p>
+            </div>
+            <button
+              type="button"
+              className="inline-flex h-9 items-center justify-center rounded-md border border-border bg-background px-3 text-xs font-semibold text-foreground transition hover:bg-muted/50"
+              onClick={handleDownloadAssumptions}
+              disabled={sourceEntries.length === 0 && !energyMeta}
+            >
+              Download assumptions.json
+            </button>
+          </CardHeader>
+          <CardContent className="space-y-6 text-sm">
+            <section className="space-y-3">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-foreground/60">A) Assumptions</h3>
+              <div className="grid gap-4 lg:grid-cols-2">
+                <div className="rounded-md border border-border p-3">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-foreground/60">FlashBlade//E</div>
+                  <ul className="mt-2 space-y-1">
+                    <li>Utilization: {fmt1.format(inputs.pureUtilPct)}%</li>
+                    <li>PUE: {fmt2.format(inputs.purePue)}</li>
+                    <li>$ / kWh: ${fmt2.format(inputs.purePrice)}</li>
+                    <li>DRR: {fmt2.format(inputs.pureDrr)}</li>
+                    <li>DFM size: {fmt0.format(inputs.dfmTb)} TB</li>
+                    <li>Capacity target: {fmt2.format(inputs.capacityPb)} PB</li>
+                  </ul>
+                </div>
+                <div className="rounded-md border border-border p-3">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-foreground/60">NetApp baseline</div>
+                  <ul className="mt-2 space-y-1">
+                    <li>Utilization: {fmt1.format(inputs.naUtilPct)}%</li>
+                    <li>PUE: {fmt2.format(inputs.naPue)}</li>
+                    <li>$ / kWh: ${fmt2.format(inputs.naPrice)}</li>
+                    <li>Overhead (raw→usable): {fmt2.format(inputs.naOverhead)}</li>
+                    <li>DRR: {fmt2.format(inputs.naDrr)}</li>
+                    <li>Drive size selection: {fmt0.format(inputs.naDriveSizeTb)} TB (user input)</li>
+                    <li>
+                      Selected config:{" "}
+                      {selectedCandidate
+                        ? `${selectedCandidate.controllerModel} + ${selectedCandidate.expansionQty} ${selectedCandidate.expansionQty === 1 ? "shelf" : "shelves"} (${selectedCandidate.expansionModel})`
+                        : "No NetApp candidate selected"}
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </section>
+
+            <section className="space-y-3">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-foreground/60">B) Formulas</h3>
+              <ul className="list-disc space-y-1 pl-5 text-foreground/80">
+                <li>Weighted power (W) = Idle + Utilization × (Typical − Idle)</li>
+                <li>kWh / year (with PUE) = (Weighted power × 8760 / 1000) × PUE</li>
+                <li>Annual energy cost = kWh / year × $ / kWh</li>
+                <li>Effective TB = Usable TB × DRR</li>
+                <li>BTU / hour = Weighted power (W) × 3.412</li>
+              </ul>
+            </section>
+
+            <section className="space-y-3">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-foreground/60">C) Sources</h3>
+              {sourceList.length > 0 ? (
+                <ul className="space-y-1">
+                  {sourceList.map((item) =>
+                    item.type === "link" ? (
+                      <li key={item.label}>
+                        <a className="text-primary underline-offset-2 hover:underline" href={item.url} target="_blank" rel="noreferrer">
+                          {item.label}
+                        </a>
+                      </li>
+                    ) : (
+                      <li key={item.label} className="text-foreground/70">
+                        {item.label}
+                      </li>
+                    ),
+                  )}
+                </ul>
+              ) : (
+                <p className="text-foreground/60">No source links available for the current selection.</p>
+              )}
+            </section>
+          </CardContent>
+        </Card>
       ) : null}
     </div>
   );

--- a/ui/partner-hub/package-lock.json
+++ b/ui/partner-hub/package-lock.json
@@ -614,7 +614,6 @@
             "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -675,7 +674,6 @@
             "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.52.0",
                 "@typescript-eslint/types": "8.52.0",
@@ -1214,7 +1212,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1644,7 +1641,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -1965,7 +1961,6 @@
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -2406,7 +2401,6 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -2576,7 +2570,6 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -3943,7 +3936,6 @@
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -4712,7 +4704,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -4914,7 +4905,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -4927,7 +4917,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -5815,7 +5804,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -5985,7 +5973,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/ui/partner-hub/package.json
+++ b/ui/partner-hub/package.json
@@ -4,10 +4,10 @@
     "version":  "0.0.1",
     "scripts":  {
                     "dev":  "next dev",
-                    "build":  "next build && node scripts/post-export.mjs",
+                    "build":  "node scripts/sync-energy-data.mjs && next build && node scripts/post-export.mjs",
                     "start":  "next start",
                     "lint":  "next lint",
-                    "build:export":  "next build && node scripts/post-export.mjs"
+                    "build:export":  "node scripts/sync-energy-data.mjs && next build && node scripts/post-export.mjs"
                 },
     "dependencies":  {
                          "next":  "^14.0.0",

--- a/ui/partner-hub/scripts/sync-energy-data.mjs
+++ b/ui/partner-hub/scripts/sync-energy-data.mjs
@@ -1,0 +1,47 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+
+const cwd = process.cwd();
+const repoRoot = path.resolve(cwd, "..", "..");
+const sourceFiles = [
+  "energy/data/netapp_e_series.csv",
+  "energy/data/pure_flashblade_e.csv",
+];
+
+const destDir = path.join(cwd, "public", "data", "energy");
+
+const readFileSha256 = async (filePath) => {
+  const buf = await fs.readFile(filePath);
+  return crypto.createHash("sha256").update(buf).digest("hex");
+};
+
+const main = async () => {
+  await fs.mkdir(destDir, { recursive: true });
+
+  const copiedFiles = [];
+  const sha256 = {};
+
+  for (const rel of sourceFiles) {
+    const sourcePath = path.join(repoRoot, rel);
+    const destPath = path.join(destDir, path.basename(rel));
+    await fs.copyFile(sourcePath, destPath);
+    copiedFiles.push(path.join("ui", "partner-hub", "public", "data", "energy", path.basename(rel)));
+    sha256[path.basename(rel)] = await readFileSha256(destPath);
+  }
+
+  const meta = {
+    lastSyncedISO: new Date().toISOString(),
+    sourceFiles,
+    copiedFiles,
+    sha256,
+  };
+
+  const metaPath = path.join(destDir, "energy_data_meta.json");
+  await fs.writeFile(metaPath, `${JSON.stringify(meta, null, 2)}\n`);
+};
+
+main().catch((err) => {
+  console.error("Failed to sync energy data:", err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
### Motivation
- Ensure the exported static UI always reflects the canonical CSVs under `energy/data/` by adding a deterministic sync step run as part of the build. 
- Surface a professional “Assumptions & Sources” panel so users can see the values, formulas, source links (links only) and when the CSVs were last synced. 
- Avoid any runtime scraping or fetching of external sources by only showing links already present in the CSV rows. 
- Preserve existing static export/relocation behavior while making the UI deterministic and auditable.

### Description
- Add a build-time sync script `ui/partner-hub/scripts/sync-energy-data.mjs` that copies `energy/data/netapp_e_series.csv` and `energy/data/pure_flashblade_e.csv` into `ui/partner-hub/public/data/energy/` and writes `energy_data_meta.json` with `lastSyncedISO`, `sourceFiles`, `copiedFiles`, and per-file `sha256`.
- Update `ui/partner-hub/package.json` `build` and `build:export` scripts to run `node scripts/sync-energy-data.mjs` before `next build` and `node scripts/post-export.mjs` so exports always include the latest CSVs.
- Add an Assumptions & Sources panel in `ui/partner-hub/components/energy/energy-tool.tsx` with a button next to `Recalculate` that opens a panel showing (A) current assumptions and selected NetApp identifiers, (B) static formulas, and (C) deduplicated source links extracted from the dataset rows used for the current run (showing `Source missing for <Model>` when a row lacks `Source_URL`), plus a `Last synced` read from `/data/energy/energy_data_meta.json` and an optional client-side `assumptions.json` download.
- Implement client-side logic to load the energy CSVs from `/data/energy/` as before, fetch the metadata JSON for the last-synced timestamp, and compute/dedupe the source links without contacting external URLs.

### Testing
- Ran `npm --prefix ui/partner-hub install` to update dependencies; install completed successfully.
- Started the dev server with `npm --prefix ui/partner-hub run dev` and confirmed Next.js started and served the Energy Tool page.
- Executed an automated Playwright script that opened `http://localhost:3000/partner-hub/tools/energy/`, clicked the `Assumptions & Sources` button, and produced a screenshot of the panel (script completed successfully and screenshot artifact was generated).
- Observed `GET /data/energy/energy_data_meta.json 404` in dev logs because the sync script is wired into the build pipeline and is not automatically run for `next dev`; running `npm run build` will invoke `node scripts/sync-energy-data.mjs` and produce the metadata file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695ed2a4ab948326913c70c4fc60d572)