### PR TITLE
Add vendor source checking workflow and local freshness report

### DIFF
--- a/energy/data/UPDATE_WORKFLOW.md
+++ b/energy/data/UPDATE_WORKFLOW.md
@@ -1,0 +1,31 @@
+# Energy Tool dataset update workflow
+
+This repository does **not** auto-discover new models. Use the steps below to refresh existing source links and explicitly add new models.
+
+## Step 1: Check existing sources (local)
+Run the local source checker to validate current `Source_URL` links and generate a freshness report:
+
+```
+node ui/partner-hub/scripts/check-vendor-sources.mjs
+```
+
+This writes `energy/data/vendor_update_report.json` without mutating any datasets.
+
+## Step 2: Add new models (manual)
+If vendors have released new hardware:
+
+1. Add new rows to the appropriate CSV (`energy/data/pure_flashblade_e.csv` or `energy/data/netapp_e_series.csv`).
+2. Add/verify `Source_URL` values for every new row.
+3. Update `energy/data/vendor_sources.json` with any new vendor sources or model coverage notes.
+
+## Step 3: Regenerate derived JSON (if applicable)
+If you maintain compatibility or catalog JSON outputs, run the relevant generator scripts to rebuild them after the CSV changes.
+
+## Step 4: Sync and commit
+1. Run the data sync script used by the UI build:
+
+```
+node ui/partner-hub/scripts/sync-energy-data.mjs
+```
+
+2. Commit CSV changes, updated source manifests, and refreshed reports together.

--- a/energy/data/vendor_sources.json
+++ b/energy/data/vendor_sources.json
@@ -1,0 +1,25 @@
+[
+  {
+    "vendor": "Pure",
+    "product_line": "FlashBlade//E",
+    "url": "https://www.purestorage.com/content/dam/pdf/en/datasheets/ds-pure-storage-flashblade-e.pdf",
+    "notes": "FlashBlade//E datasheet for chassis and XFM power figures.",
+    "modelsCovered": [
+      "EC chassis (fully populated)",
+      "EX chassis (fully populated)",
+      "XFM (External Fabric Module)"
+    ]
+  },
+  {
+    "vendor": "NetApp",
+    "product_line": "E-Series",
+    "url": "https://www.netapp.com/e-series/e2800/",
+    "notes": "E2800 product page power table for controller and disk shelves.",
+    "modelsCovered": [
+      "E2860",
+      "E2824",
+      "E2812",
+      "DE460C 60-bay"
+    ]
+  }
+]

--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -27,6 +27,7 @@ type EnergyMeta = {
   sourceFiles?: string[];
   copiedFiles?: string[];
   sha256?: Record<string, string>;
+  reportFiles?: string[];
 };
 
 type Inputs = {
@@ -52,6 +53,32 @@ type ManualInputs = {
   expansionQty: number;
 };
 
+type VendorReportEntry = {
+  url: string;
+  status?: number;
+  finalUrl?: string;
+  etag?: string | null;
+  lastModified?: string | null;
+  contentHash?: string | null;
+  error?: string;
+  previous?: {
+    status?: number;
+    finalUrl?: string;
+    etag?: string | null;
+    lastModified?: string | null;
+    contentHash?: string | null;
+  };
+};
+
+type VendorUpdateReport = {
+  checkedAtISO: string;
+  ok: VendorReportEntry[];
+  redirected: VendorReportEntry[];
+  changed: VendorReportEntry[];
+  missing: VendorReportEntry[];
+  error: VendorReportEntry[];
+};
+
 const defaults: Omit<Inputs, "dfmTb" | "capacityPb"> = {
   pureUtilPct: 50,
   purePue: 1.35,
@@ -75,6 +102,9 @@ export function EnergyTool() {
   const [energyMeta, setEnergyMeta] = useState<EnergyMeta | null>(null);
   const [metaError, setMetaError] = useState<string | null>(null);
   const [assumptionsOpen, setAssumptionsOpen] = useState(false);
+  const [vendorReport, setVendorReport] = useState<VendorUpdateReport | null>(null);
+  const [vendorReportError, setVendorReportError] = useState<string | null>(null);
+  const [sourceCheckHint, setSourceCheckHint] = useState<string | null>(null);
 
   const [inputs, setInputs] = useState<Inputs>(() => ({
     dfmTb: 48,
@@ -134,6 +164,35 @@ export function EnergyTool() {
         setLoadError(err instanceof Error ? err.message : "Failed to load energy datasets");
       } finally {
         setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [basePath]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        setVendorReportError(null);
+        const res = await fetch(`${basePath}/data/energy/vendor_update_report.json`);
+        if (res.status === 404) {
+          if (!cancelled) setVendorReport(null);
+          return;
+        }
+        if (!res.ok) {
+          throw new Error(`Failed to load vendor update report (${res.status})`);
+        }
+        const data = (await res.json()) as VendorUpdateReport;
+        if (!cancelled) {
+          setVendorReport(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setVendorReportError(err instanceof Error ? err.message : "Failed to load vendor update report");
+        }
       }
     })();
 
@@ -395,6 +454,26 @@ export function EnergyTool() {
     URL.revokeObjectURL(url);
   };
 
+  const handleCheckSources = async () => {
+    const command = "node ui/partner-hub/scripts/check-vendor-sources.mjs";
+    try {
+      await navigator.clipboard.writeText(command);
+      setSourceCheckHint(`Run locally: ${command} (command copied)`);
+    } catch {
+      setSourceCheckHint(`Run locally: ${command}`);
+    }
+  };
+
+  const reportSections: Array<[string, VendorReportEntry[]]> = vendorReport
+    ? [
+        ["Changed", vendorReport.changed],
+        ["Redirected", vendorReport.redirected],
+        ["Missing", vendorReport.missing],
+        ["Errors", vendorReport.error],
+        ["OK", vendorReport.ok],
+      ]
+    : [];
+
   return (
     <div className="space-y-6">
       <header className="space-y-2">
@@ -580,8 +659,16 @@ export function EnergyTool() {
               >
                 Assumptions &amp; Sources
               </button>
+              <button
+                type="button"
+                className="inline-flex h-10 items-center justify-center rounded-md border border-border bg-background px-4 text-sm font-semibold text-foreground transition hover:bg-muted/50"
+                onClick={handleCheckSources}
+              >
+                Check sources (local)
+              </button>
               {loading ? <span className="text-xs text-foreground/60">Loading datasets…</span> : null}
               {computeError ? <span className="text-xs font-semibold text-red-600">{computeError}</span> : null}
+              {sourceCheckHint ? <span className="text-xs text-foreground/60">{sourceCheckHint}</span> : null}
             </div>
           </CardContent>
         </Card>
@@ -833,6 +920,62 @@ export function EnergyTool() {
                 </ul>
               ) : (
                 <p className="text-foreground/60">No source links available for the current selection.</p>
+              )}
+            </section>
+
+            <section className="space-y-3">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-foreground/60">D) Source freshness (local)</h3>
+              {vendorReport ? (
+                <div className="space-y-3 text-xs text-foreground/70">
+                  <p>
+                    Last checked: {vendorReport.checkedAtISO} ·{" "}
+                    {vendorReport.ok.length} ok, {vendorReport.redirected.length} redirected,{" "}
+                    {vendorReport.changed.length} changed, {vendorReport.missing.length} missing,{" "}
+                    {vendorReport.error.length} error
+                  </p>
+                  {reportSections.map(([label, entries]) => (
+                    <div key={label} className="space-y-1">
+                      <div className="text-[11px] font-semibold uppercase tracking-wide text-foreground/60">
+                        {label}
+                      </div>
+                      {entries.length > 0 ? (
+                        <ul className="space-y-1">
+                          {entries.map((entry) => (
+                            <li key={`${label}-${entry.url}`}>
+                              <a
+                                className="text-primary underline-offset-2 hover:underline"
+                                href={entry.url}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                {entry.url}
+                              </a>
+                              {entry.finalUrl && entry.finalUrl !== entry.url ? (
+                                <>
+                                  <span className="text-foreground/50"> → </span>
+                                  <a
+                                    className="text-primary underline-offset-2 hover:underline"
+                                    href={entry.finalUrl}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                  >
+                                    {entry.finalUrl}
+                                  </a>
+                                </>
+                              ) : null}
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className="text-foreground/50">None.</p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              ) : vendorReportError ? (
+                <p className="text-foreground/60">{vendorReportError}</p>
+              ) : (
+                <p className="text-foreground/60">Run the local source check to see freshness status.</p>
               )}
             </section>
           </CardContent>

--- a/ui/partner-hub/scripts/check-vendor-sources.mjs
+++ b/ui/partner-hub/scripts/check-vendor-sources.mjs
@@ -1,0 +1,259 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..", "..", "..");
+const dataDir = path.join(repoRoot, "energy", "data");
+const reportPath = path.join(dataDir, "vendor_update_report.json");
+
+const csvFiles = ["pure_flashblade_e.csv", "netapp_e_series.csv"];
+const jsonNamePattern = /(compat|catalog)/i;
+
+const parseCsv = (text) => {
+  const rows = [];
+  let row = [];
+  let field = "";
+  let inQuotes = false;
+
+  const pushField = () => {
+    row.push(field);
+    field = "";
+  };
+
+  const pushRow = () => {
+    if (row.length === 1 && row[0] === "" && rows.length > 0) return;
+    rows.push(row);
+    row = [];
+  };
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+
+    if (inQuotes) {
+      if (ch === '"') {
+        const next = text[i + 1];
+        if (next === '"') {
+          field += '"';
+          i += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += ch;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inQuotes = true;
+      continue;
+    }
+
+    if (ch === ",") {
+      pushField();
+      continue;
+    }
+
+    if (ch === "\n") {
+      pushField();
+      pushRow();
+      continue;
+    }
+
+    if (ch === "\r") {
+      continue;
+    }
+
+    field += ch;
+  }
+
+  pushField();
+  pushRow();
+
+  if (rows.length === 0) return [];
+  const header = rows[0].map((h) => h.trim());
+  return rows
+    .slice(1)
+    .filter((r) => r.some((cell) => String(cell ?? "").trim() !== ""))
+    .map((r) => {
+      const obj = {};
+      header.forEach((key, idx) => {
+        obj[key] = (r[idx] ?? "").trim();
+      });
+      return obj;
+    });
+};
+
+const collectUrlsFromJson = (value, urls) => {
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectUrlsFromJson(item, urls));
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, val] of Object.entries(value)) {
+      if (/source[_-]?url/i.test(key) && typeof val === "string") {
+        urls.add(val);
+      } else {
+        collectUrlsFromJson(val, urls);
+      }
+    }
+  }
+};
+
+const readJsonFiles = async (dir) => {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const results = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await readJsonFiles(fullPath)));
+    } else if (entry.isFile() && entry.name.endsWith(".json") && jsonNamePattern.test(entry.name)) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+};
+
+const readPreviousReport = async () => {
+  try {
+    const text = await fs.readFile(reportPath, "utf8");
+    const data = JSON.parse(text);
+    const entries = [
+      ...(data.ok ?? []),
+      ...(data.redirected ?? []),
+      ...(data.changed ?? []),
+      ...(data.missing ?? []),
+      ...(data.error ?? []),
+    ];
+    const map = new Map();
+    entries.forEach((entry) => {
+      if (entry?.url) map.set(entry.url, entry);
+    });
+    return map;
+  } catch (err) {
+    if (err && err.code === "ENOENT") return new Map();
+    throw err;
+  }
+};
+
+const fetchWithTimeout = async (url, options = {}) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15000);
+  try {
+    const res = await fetch(url, { ...options, signal: controller.signal, redirect: "follow" });
+    return res;
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const hashBuffer = (buf) => crypto.createHash("sha256").update(buf).digest("hex");
+
+const checkUrl = async (url) => {
+  let headRes;
+  try {
+    headRes = await fetchWithTimeout(url, { method: "HEAD" });
+  } catch (err) {
+    return { url, error: `HEAD failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+
+  let getRes;
+  let bodyBuffer = null;
+  if (headRes.ok || headRes.status === 405 || headRes.status === 403) {
+    try {
+      getRes = await fetchWithTimeout(url, { method: "GET" });
+      bodyBuffer = Buffer.from(await getRes.arrayBuffer());
+    } catch (err) {
+      return {
+        url,
+        status: headRes.status,
+        finalUrl: headRes.url ?? url,
+        etag: headRes.headers.get("etag"),
+        lastModified: headRes.headers.get("last-modified"),
+        error: `GET failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  const res = getRes ?? headRes;
+  return {
+    url,
+    status: res.status,
+    finalUrl: res.url ?? url,
+    etag: res.headers.get("etag"),
+    lastModified: res.headers.get("last-modified"),
+    contentHash: bodyBuffer ? hashBuffer(bodyBuffer) : null,
+  };
+};
+
+const categorize = (entry, previous) => {
+  if (entry.error) return "error";
+  if (entry.status === 404 || entry.status === 410) return "missing";
+  if (!entry.status || entry.status >= 400) return "error";
+  const changed =
+    previous &&
+    ((previous.contentHash && entry.contentHash && previous.contentHash !== entry.contentHash) ||
+      (previous.etag && entry.etag && previous.etag !== entry.etag) ||
+      (previous.lastModified && entry.lastModified && previous.lastModified !== entry.lastModified));
+  if (changed) return "changed";
+  if (entry.finalUrl && entry.finalUrl !== entry.url) return "redirected";
+  return "ok";
+};
+
+const main = async () => {
+  const urls = new Set();
+
+  for (const file of csvFiles) {
+    const text = await fs.readFile(path.join(dataDir, file), "utf8");
+    const rows = parseCsv(text);
+    rows.forEach((row) => {
+      const value = row.Source_URL;
+      if (typeof value === "string" && value.trim()) {
+        urls.add(value.trim());
+      }
+    });
+  }
+
+  const jsonFiles = await readJsonFiles(dataDir);
+  for (const file of jsonFiles) {
+    const text = await fs.readFile(file, "utf8");
+    const data = JSON.parse(text);
+    collectUrlsFromJson(data, urls);
+  }
+
+  const previousReport = await readPreviousReport();
+  const report = {
+    checkedAtISO: new Date().toISOString(),
+    ok: [],
+    redirected: [],
+    changed: [],
+    missing: [],
+    error: [],
+  };
+
+  for (const url of urls) {
+    const entry = await checkUrl(url);
+    const previous = previousReport.get(url);
+    if (previous) {
+      entry.previous = {
+        status: previous.status,
+        finalUrl: previous.finalUrl,
+        etag: previous.etag,
+        lastModified: previous.lastModified,
+        contentHash: previous.contentHash,
+      };
+    }
+    const bucket = categorize(entry, previous);
+    report[bucket].push(entry);
+  }
+
+  await fs.writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  console.log(`Wrote ${reportPath}`);
+};
+
+main().catch((err) => {
+  console.error("Failed to check vendor sources:", err);
+  process.exitCode = 1;
+});

--- a/ui/partner-hub/scripts/sync-energy-data.mjs
+++ b/ui/partner-hub/scripts/sync-energy-data.mjs
@@ -8,6 +8,7 @@ const sourceFiles = [
   "energy/data/netapp_e_series.csv",
   "energy/data/pure_flashblade_e.csv",
 ];
+const reportFile = "energy/data/vendor_update_report.json";
 
 const destDir = path.join(cwd, "public", "data", "energy");
 
@@ -21,6 +22,7 @@ const main = async () => {
 
   const copiedFiles = [];
   const sha256 = {};
+  const reportFiles = [];
 
   for (const rel of sourceFiles) {
     const sourcePath = path.join(repoRoot, rel);
@@ -30,11 +32,26 @@ const main = async () => {
     sha256[path.basename(rel)] = await readFileSha256(destPath);
   }
 
+  const reportSourcePath = path.join(repoRoot, reportFile);
+  try {
+    await fs.access(reportSourcePath);
+    const reportDestPath = path.join(destDir, path.basename(reportFile));
+    await fs.copyFile(reportSourcePath, reportDestPath);
+    copiedFiles.push(path.join("ui", "partner-hub", "public", "data", "energy", path.basename(reportFile)));
+    sha256[path.basename(reportFile)] = await readFileSha256(reportDestPath);
+    reportFiles.push(reportFile);
+  } catch (err) {
+    if (err && err.code !== "ENOENT") {
+      throw err;
+    }
+  }
+
   const meta = {
     lastSyncedISO: new Date().toISOString(),
     sourceFiles,
     copiedFiles,
     sha256,
+    reportFiles,
   };
 
   const metaPath = path.join(destDir, "energy_data_meta.json");


### PR DESCRIPTION
### Motivation
- Provide a reliable, auditable workflow to check and track freshness of vendor `Source_URL` links for the Energy Tool datasets.  
- Surface source link status in the UI while preserving existing static-export constraints and avoiding any automatic discovery of new models.  
- Keep dataset mutation explicit and manual: checks only produce a report and do not alter CSV/JSON dataset files.  
- Include vendor provenance so maintainers can document which sources and models are covered.

### Description
- Add a vendor manifest at `energy/data/vendor_sources.json` listing known vendors, product lines, `url`, `notes`, and optional `modelsCovered`.  
- Introduce `ui/partner-hub/scripts/check-vendor-sources.mjs` which reads `Source_URL`s from CSVs and compatibility/catalog JSONs, performs HEAD/GET checks, computes status/etag/last-modified/content hash, and writes `energy/data/vendor_update_report.json` without mutating datasets.  
- Expose a `Check sources (local)` action in the Energy Tool UI (`ui/partner-hub/components/energy/energy-tool.tsx`) that copies the local-check command and displays a summarized view of `vendor_update_report.json` when present.  
- Document the explicit add-new-model workflow in `energy/data/UPDATE_WORKFLOW.md` and update the build sync script `ui/partner-hub/scripts/sync-energy-data.mjs` to copy the optional report into `public/data/energy` and include it in `energy_data_meta.json`.

### Testing
- Started the UI dev server with `npm run dev` and used an automated Playwright visit to open the Energy Tool and capture a screenshot, which verified the app loads and the Assumptions & Sources panel is reachable.  
- The UI attempted to fetch `vendor_update_report.json` and received a `404` (no report present), and the UI correctly shows guidance to run the local check; this is the expected behavior when the report has not yet been generated.  
- No destructive operations were executed during tests and the new script can be run locally via `node ui/partner-hub/scripts/check-vendor-sources.mjs` to produce `energy/data/vendor_update_report.json` (not run in CI here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695fd597da788326b766878f63f11533)