### PR TITLE
Add NetApp drive compatibility dataset and wire manual NetApp inputs

### DIFF
--- a/energy/data/netapp_drive_compat.json
+++ b/energy/data/netapp_drive_compat.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "updatedAtISO": "2025-02-14T00:00:00Z",
+  "controllers": [
+    {
+      "model": "E2860",
+      "expansionShelves": [
+        {
+          "model": "DE460C 60-bay",
+          "supportedDriveSizesTB": [8, 12, 16],
+          "maxExpansionQty": 10
+        }
+      ]
+    }
+  ]
+}

--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -5,7 +5,6 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   enumerateNetApp,
   fbPower,
-  getNetAppControllerModels,
   getTracks,
   buildNetAppCandidate,
   loadCsv,
@@ -17,6 +16,14 @@ import {
   type NetAppRow,
   type PureRow,
 } from "@/lib/energy/energy-calc";
+import {
+  getControllerModels,
+  getDriveSizes,
+  getExpansionModels,
+  getMaxExpansionQty,
+  loadNetAppDriveCompat,
+  type NetAppDriveCompat,
+} from "@/lib/energy/netapp-drive-compat";
 
 const fmt0 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
 const fmt1 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
@@ -50,6 +57,7 @@ type NetAppMode = "auto" | "manual";
 
 type ManualInputs = {
   controllerModel: string;
+  expansionModel: string;
   expansionQty: number;
 };
 
@@ -97,8 +105,10 @@ export function EnergyTool() {
   const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
   const [pureRows, setPureRows] = useState<PureRow[]>([]);
   const [netappRows, setNetappRows] = useState<NetAppRow[]>([]);
+  const [netappCompat, setNetappCompat] = useState<NetAppDriveCompat | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [compatError, setCompatError] = useState<string | null>(null);
   const [energyMeta, setEnergyMeta] = useState<EnergyMeta | null>(null);
   const [metaError, setMetaError] = useState<string | null>(null);
   const [assumptionsOpen, setAssumptionsOpen] = useState(false);
@@ -114,6 +124,7 @@ export function EnergyTool() {
   const [mode, setMode] = useState<NetAppMode>("auto");
   const [manualInputs, setManualInputs] = useState<ManualInputs>({
     controllerModel: "",
+    expansionModel: "",
     expansionQty: 0,
   });
 
@@ -164,6 +175,28 @@ export function EnergyTool() {
         setLoadError(err instanceof Error ? err.message : "Failed to load energy datasets");
       } finally {
         setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [basePath]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        setCompatError(null);
+        const compat = await loadNetAppDriveCompat(basePath);
+        if (!cancelled) {
+          setNetappCompat(compat);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setCompatError(err instanceof Error ? err.message : "Failed to load NetApp compatibility data");
+          setNetappCompat(null);
+        }
       }
     })();
 
@@ -228,7 +261,43 @@ export function EnergyTool() {
 
   const tracks = useMemo(() => getTracks(pureRows), [pureRows]);
   const capacities = useMemo(() => validCaps(pureRows, inputs.dfmTb, 20), [pureRows, inputs.dfmTb]);
-  const controllerModels = useMemo(() => getNetAppControllerModels(netappRows), [netappRows]);
+  const controllerModels = useMemo(() => getControllerModels(netappCompat), [netappCompat]);
+  const expansionModels = useMemo(
+    () => getExpansionModels(netappCompat, manualInputs.controllerModel),
+    [netappCompat, manualInputs.controllerModel],
+  );
+  const driveSizes = useMemo(
+    () => getDriveSizes(netappCompat, manualInputs.controllerModel, manualInputs.expansionModel),
+    [netappCompat, manualInputs.controllerModel, manualInputs.expansionModel],
+  );
+  const maxExpansionQty = useMemo(
+    () => getMaxExpansionQty(netappCompat, manualInputs.controllerModel, manualInputs.expansionModel),
+    [netappCompat, manualInputs.controllerModel, manualInputs.expansionModel],
+  );
+  const allDriveSizes = useMemo(() => {
+    if (!netappCompat) return [];
+    const sizes = new Set<number>();
+    for (const controller of netappCompat.controllers) {
+      for (const shelf of controller.expansionShelves) {
+        for (const size of shelf.supportedDriveSizesTB) {
+          sizes.add(size);
+        }
+      }
+    }
+    return Array.from(sizes).sort((a, b) => a - b);
+  }, [netappCompat]);
+  const driveSizeOptions = mode === "manual" ? driveSizes : allDriveSizes;
+  const manualDriveSizeMissing =
+    mode === "manual" &&
+    manualInputs.controllerModel.length > 0 &&
+    manualInputs.expansionModel.length > 0 &&
+    driveSizes.length === 0;
+  const manualApplyDisabled =
+    loading ||
+    manualInputs.controllerModel.length === 0 ||
+    manualInputs.expansionModel.length === 0 ||
+    manualDriveSizeMissing ||
+    netappRows.length === 0;
 
   const runModel = () => {
     try {
@@ -273,12 +342,13 @@ export function EnergyTool() {
   };
 
   const runManual = () => {
-    if (!manualInputs.controllerModel) return;
+    if (!manualInputs.controllerModel || !manualInputs.expansionModel) return;
     try {
       setComputeError(null);
       const candidate = buildNetAppCandidate(
         netappRows,
         manualInputs.controllerModel,
+        manualInputs.expansionModel,
         manualInputs.expansionQty,
         inputs.naUtilPct / 100,
         inputs.naPue,
@@ -302,20 +372,46 @@ export function EnergyTool() {
   }, [pureRows.length, netappRows.length]);
 
   useEffect(() => {
-    if (controllerModels.length > 0 && !manualInputs.controllerModel) {
-      setManualInputs((prev) => ({ ...prev, controllerModel: controllerModels[0] }));
+    if (controllerModels.length === 0) return;
+    const controllerModel = manualInputs.controllerModel || controllerModels[0];
+    const controllerExpansionModels = getExpansionModels(netappCompat, controllerModel);
+    const expansionModel = manualInputs.expansionModel || controllerExpansionModels[0] || "";
+    const sizes = getDriveSizes(netappCompat, controllerModel, expansionModel);
+    const nextMax = getMaxExpansionQty(netappCompat, controllerModel, expansionModel);
+    setManualInputs((prev) => ({
+      ...prev,
+      controllerModel,
+      expansionModel,
+      expansionQty: nextMax != null ? Math.min(prev.expansionQty, nextMax) : prev.expansionQty,
+    }));
+    if (sizes.length > 0 && !sizes.includes(inputs.naDriveSizeTb)) {
+      setInputs((prev) => ({ ...prev, naDriveSizeTb: sizes[0] }));
     }
-  }, [controllerModels, manualInputs.controllerModel]);
+  }, [
+    controllerModels,
+    inputs.naDriveSizeTb,
+    manualInputs.controllerModel,
+    manualInputs.expansionModel,
+    netappCompat,
+  ]);
 
   useEffect(() => {
-    if (mode === "manual" && manualInputs.controllerModel && netappRows.length > 0) {
+    if (
+      mode === "manual" &&
+      manualInputs.controllerModel &&
+      manualInputs.expansionModel &&
+      !manualDriveSizeMissing &&
+      netappRows.length > 0
+    ) {
       runManual();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     mode,
     manualInputs.controllerModel,
+    manualInputs.expansionModel,
     manualInputs.expansionQty,
+    manualDriveSizeMissing,
     inputs.naUtilPct,
     inputs.naPue,
     inputs.naPrice,
@@ -324,6 +420,13 @@ export function EnergyTool() {
     inputs.naDriveSizeTb,
     netappRows.length,
   ]);
+
+  useEffect(() => {
+    if (driveSizeOptions.length === 0) return;
+    if (!driveSizeOptions.includes(inputs.naDriveSizeTb)) {
+      setInputs((prev) => ({ ...prev, naDriveSizeTb: driveSizeOptions[0] }));
+    }
+  }, [driveSizeOptions, inputs.naDriveSizeTb]);
 
   const band = useMemo(() => {
     if (!fb) return null;
@@ -431,7 +534,8 @@ export function EnergyTool() {
           overheadRawToUsable: inputs.naOverhead,
           drr: inputs.naDrr,
           driveSizeTb: inputs.naDriveSizeTb,
-          driveSizeSelection: "User-selected drive size input",
+          driveSizeSelection:
+            mode === "manual" ? "Compatibility dataset (controller + shelf pairing)" : "Compatibility dataset (all drives)",
         },
       },
       selectedNetApp: selectedCandidate
@@ -588,7 +692,23 @@ export function EnergyTool() {
               <NumberInput label="$ / kWh" value={inputs.naPrice} step={0.001} onChange={(v) => setInputs((p) => ({ ...p, naPrice: v }))} />
               <NumberInput label="Overhead (raw→usable)" value={inputs.naOverhead} step={0.01} onChange={(v) => setInputs((p) => ({ ...p, naOverhead: v }))} />
               <NumberInput label="DRR" value={inputs.naDrr} step={0.1} onChange={(v) => setInputs((p) => ({ ...p, naDrr: v }))} />
-              <NumberInput label="Drive size (TB)" value={inputs.naDriveSizeTb} step={1} onChange={(v) => setInputs((p) => ({ ...p, naDriveSizeTb: v }))} />
+              <div className="space-y-1">
+                <label className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+                  Drive size (TB)
+                </label>
+                <select
+                  className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm"
+                  value={inputs.naDriveSizeTb}
+                  onChange={(e) => setInputs((p) => ({ ...p, naDriveSizeTb: Number(e.target.value) }))}
+                  disabled={loading || driveSizeOptions.length === 0}
+                >
+                  {driveSizeOptions.map((size) => (
+                    <option key={size} value={size}>
+                      {size}
+                    </option>
+                  ))}
+                </select>
+              </div>
               {mode === "auto" ? (
                 <NumberInput label="Auto-match tolerance (±%)" value={inputs.tolPct} step={0.1} onChange={(v) => setInputs((p) => ({ ...p, tolPct: v }))} />
               ) : null}
@@ -607,10 +727,54 @@ export function EnergyTool() {
                     <select
                       className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm"
                       value={manualInputs.controllerModel}
-                      onChange={(e) => setManualInputs((prev) => ({ ...prev, controllerModel: e.target.value }))}
+                      onChange={(e) => {
+                        const controllerModel = e.target.value;
+                        const nextExpansionModels = getExpansionModels(netappCompat, controllerModel);
+                        const expansionModel = nextExpansionModels[0] ?? "";
+                        const sizes = getDriveSizes(netappCompat, controllerModel, expansionModel);
+                        const nextMax = getMaxExpansionQty(netappCompat, controllerModel, expansionModel);
+                        setManualInputs((prev) => ({
+                          ...prev,
+                          controllerModel,
+                          expansionModel,
+                          expansionQty: nextMax != null ? Math.min(prev.expansionQty, nextMax) : prev.expansionQty,
+                        }));
+                        if (sizes.length > 0) {
+                          setInputs((prev) => ({ ...prev, naDriveSizeTb: sizes[0] }));
+                        }
+                      }}
                       disabled={loading || controllerModels.length === 0}
                     >
                       {controllerModels.map((model) => (
+                        <option key={model} value={model}>
+                          {model}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="space-y-1">
+                    <label className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+                      Expansion shelf model
+                    </label>
+                    <select
+                      className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm"
+                      value={manualInputs.expansionModel}
+                      onChange={(e) => {
+                        const expansionModel = e.target.value;
+                        const sizes = getDriveSizes(netappCompat, manualInputs.controllerModel, expansionModel);
+                        const nextMax = getMaxExpansionQty(netappCompat, manualInputs.controllerModel, expansionModel);
+                        setManualInputs((prev) => ({
+                          ...prev,
+                          expansionModel,
+                          expansionQty: nextMax != null ? Math.min(prev.expansionQty, nextMax) : prev.expansionQty,
+                        }));
+                        if (sizes.length > 0) {
+                          setInputs((prev) => ({ ...prev, naDriveSizeTb: sizes[0] }));
+                        }
+                      }}
+                      disabled={loading || expansionModels.length === 0}
+                    >
+                      {expansionModels.map((model) => (
                         <option key={model} value={model}>
                           {model}
                         </option>
@@ -622,10 +786,25 @@ export function EnergyTool() {
                     value={manualInputs.expansionQty}
                     step={1}
                     onChange={(value) =>
-                      setManualInputs((prev) => ({ ...prev, expansionQty: Math.max(0, value) }))
+                      setManualInputs((prev) => ({
+                        ...prev,
+                        expansionQty:
+                          maxExpansionQty != null ? Math.min(Math.max(0, value), maxExpansionQty) : Math.max(0, value),
+                      }))
                     }
                   />
                 </div>
+                {manualDriveSizeMissing ? (
+                  <div className="mt-2 rounded-md border border-amber-300/70 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+                    No compatibility data for {manualInputs.controllerModel}/{manualInputs.expansionModel}. Update
+                    netapp_drive_compat.json.
+                  </div>
+                ) : null}
+                {compatError ? (
+                  <div className="mt-2 rounded-md border border-amber-300/70 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+                    {compatError}
+                  </div>
+                ) : null}
                 <p className="mt-2 text-xs text-foreground/60">
                   Manual configs use the same power and capacity model as auto-matched candidates.
                 </p>
@@ -647,7 +826,7 @@ export function EnergyTool() {
                   type="button"
                   className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
                   onClick={runManual}
-                  disabled={loading || manualInputs.controllerModel.length === 0 || netappRows.length === 0}
+                  disabled={manualApplyDisabled}
                 >
                   Apply manual config
                 </button>
@@ -877,7 +1056,10 @@ export function EnergyTool() {
                     <li>$ / kWh: ${fmt2.format(inputs.naPrice)}</li>
                     <li>Overhead (raw→usable): {fmt2.format(inputs.naOverhead)}</li>
                     <li>DRR: {fmt2.format(inputs.naDrr)}</li>
-                    <li>Drive size selection: {fmt0.format(inputs.naDriveSizeTb)} TB (user input)</li>
+                    <li>
+                      Drive size selection: {fmt0.format(inputs.naDriveSizeTb)} TB{" "}
+                      {mode === "manual" ? "(compat pairing)" : "(compat list)"}
+                    </li>
                     <li>
                       Selected config:{" "}
                       {selectedCandidate

--- a/ui/partner-hub/lib/energy/energy-calc.ts
+++ b/ui/partner-hub/lib/energy/energy-calc.ts
@@ -222,8 +222,6 @@ export type NetAppCandidate = {
   kwhPerEffectiveTbYear: number | null;
 };
 
-const allowedNetAppControllers = new Set(["E2860", "E5760", "E4060"]);
-
 type NetAppShelfPower = {
   model: string;
   typicalW: number;
@@ -247,10 +245,24 @@ function getExpansionShelf(netappRows: NetAppRow[]): NetAppShelfPower {
   };
 }
 
-function getControllerRows(netappRows: NetAppRow[]): NetAppRow[] {
-  return netappRows.filter(
-    (r) => r.Component_Type === "Controller_Shelf" && allowedNetAppControllers.has(String(r.Model ?? "")),
+function getExpansionShelfByModel(netappRows: NetAppRow[], expansionModel: string): NetAppShelfPower {
+  const exp = netappRows.find(
+    (row) => row.Component_Type === "Expansion_Shelf" && String(row.Model ?? "") === expansionModel,
   );
+  if (!exp) {
+    throw new Error(`Unknown expansion shelf model: ${expansionModel}`);
+  }
+  return {
+    model: String(exp.Model),
+    typicalW: exp.Typical_W,
+    idleW: exp.Idle_W,
+    drives: toInt(exp.Drives_per_unit),
+    weightedW: (u: number) => exp.Idle_W + u * (exp.Typical_W - exp.Idle_W),
+  };
+}
+
+function getControllerRows(netappRows: NetAppRow[]): NetAppRow[] {
+  return netappRows.filter((r) => r.Component_Type === "Controller_Shelf");
 }
 
 export function getNetAppControllerModels(netappRows: NetAppRow[]): string[] {
@@ -261,6 +273,7 @@ export function getNetAppControllerModels(netappRows: NetAppRow[]): string[] {
 export function buildNetAppCandidate(
   netappRows: NetAppRow[],
   controllerModel: string,
+  expansionModel: string,
   expansionQty: number,
   util: number,
   pue: number,
@@ -269,7 +282,7 @@ export function buildNetAppCandidate(
   drr: number,
   driveTb: number,
 ): NetAppCandidate {
-  const exp = getExpansionShelf(netappRows);
+  const exp = getExpansionShelfByModel(netappRows, expansionModel);
   const ctrl = getControllerRows(netappRows).find((row) => String(row.Model) === controllerModel);
   if (!ctrl) {
     throw new Error(`Unknown controller model: ${controllerModel}`);

--- a/ui/partner-hub/lib/energy/netapp-drive-compat.ts
+++ b/ui/partner-hub/lib/energy/netapp-drive-compat.ts
@@ -1,0 +1,63 @@
+export type NetAppDriveCompat = {
+  version: number;
+  updatedAtISO: string;
+  controllers: NetAppDriveController[];
+};
+
+export type NetAppDriveController = {
+  model: string;
+  expansionShelves: NetAppExpansionShelf[];
+  sourceUrl?: string;
+};
+
+export type NetAppExpansionShelf = {
+  model: string;
+  supportedDriveSizesTB: number[];
+  maxExpansionQty?: number;
+  sourceUrl?: string;
+};
+
+export async function loadNetAppDriveCompat(basePath: string): Promise<NetAppDriveCompat> {
+  const res = await fetch(`${basePath}/data/energy/netapp_drive_compat.json`);
+  if (!res.ok) {
+    throw new Error(`Failed to load NetApp compatibility data (${res.status})`);
+  }
+  return (await res.json()) as NetAppDriveCompat;
+}
+
+export function getControllerModels(compat: NetAppDriveCompat | null): string[] {
+  if (!compat) return [];
+  return compat.controllers.map((controller) => controller.model).sort((a, b) => a.localeCompare(b));
+}
+
+export function getExpansionModels(compat: NetAppDriveCompat | null, controllerModel: string): string[] {
+  if (!compat) return [];
+  const controller = compat.controllers.find((item) => item.model === controllerModel);
+  if (!controller) return [];
+  return controller.expansionShelves.map((shelf) => shelf.model).sort((a, b) => a.localeCompare(b));
+}
+
+export function getDriveSizes(
+  compat: NetAppDriveCompat | null,
+  controllerModel: string,
+  expansionModel: string,
+): number[] {
+  if (!compat) return [];
+  const controller = compat.controllers.find((item) => item.model === controllerModel);
+  if (!controller) return [];
+  const shelf = controller.expansionShelves.find((item) => item.model === expansionModel);
+  if (!shelf) return [];
+  return [...shelf.supportedDriveSizesTB].sort((a, b) => a - b);
+}
+
+export function getMaxExpansionQty(
+  compat: NetAppDriveCompat | null,
+  controllerModel: string,
+  expansionModel: string,
+): number | undefined {
+  if (!compat) return undefined;
+  const controller = compat.controllers.find((item) => item.model === controllerModel);
+  if (!controller) return undefined;
+  const shelf = controller.expansionShelves.find((item) => item.model === expansionModel);
+  return shelf?.maxExpansionQty;
+}

--- a/ui/partner-hub/public/data/energy/energy_data_meta.json
+++ b/ui/partner-hub/public/data/energy/energy_data_meta.json
@@ -1,15 +1,19 @@
 {
-  "lastSyncedISO": "2026-01-08T13:58:14.055Z",
+  "lastSyncedISO": "2026-01-08T17:32:20.402Z",
   "sourceFiles": [
     "energy/data/netapp_e_series.csv",
+    "energy/data/netapp_drive_compat.json",
     "energy/data/pure_flashblade_e.csv"
   ],
   "copiedFiles": [
-    "ui\\partner-hub\\public\\data\\energy\\netapp_e_series.csv",
-    "ui\\partner-hub\\public\\data\\energy\\pure_flashblade_e.csv"
+    "ui/partner-hub/public/data/energy/netapp_e_series.csv",
+    "ui/partner-hub/public/data/energy/netapp_drive_compat.json",
+    "ui/partner-hub/public/data/energy/pure_flashblade_e.csv"
   ],
   "sha256": {
     "netapp_e_series.csv": "1089d3fa909cae1bed9f77d77eb93855828ed7d460a08d9b24c4b824682258cd",
+    "netapp_drive_compat.json": "562cf4db6b5ccf58dd9bb9eca6847043b9e5b6f1b0e216ebf7f5b774a90b07eb",
     "pure_flashblade_e.csv": "c7cd7000559aaf4b3e8ca08925f241c6b2957247c5f031d4e94bf16319e2338e"
-  }
+  },
+  "reportFiles": []
 }

--- a/ui/partner-hub/public/data/energy/netapp_drive_compat.json
+++ b/ui/partner-hub/public/data/energy/netapp_drive_compat.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "updatedAtISO": "2025-02-14T00:00:00Z",
+  "controllers": [
+    {
+      "model": "E2860",
+      "expansionShelves": [
+        {
+          "model": "DE460C 60-bay",
+          "supportedDriveSizesTB": [8, 12, 16],
+          "maxExpansionQty": 10
+        }
+      ]
+    }
+  ]
+}

--- a/ui/partner-hub/scripts/sync-energy-data.mjs
+++ b/ui/partner-hub/scripts/sync-energy-data.mjs
@@ -6,6 +6,7 @@ const cwd = process.cwd();
 const repoRoot = path.resolve(cwd, "..", "..");
 const sourceFiles = [
   "energy/data/netapp_e_series.csv",
+  "energy/data/netapp_drive_compat.json",
   "energy/data/pure_flashblade_e.csv",
 ];
 const reportFile = "energy/data/vendor_update_report.json";


### PR DESCRIPTION
### Motivation
- Replace free-form NetApp drive size and hard-coded expansion/controller logic with a spreadsheet-driven compatibility source of truth so manual configs only allow valid pairings.
- Surface clear UI warnings and block manual calculations when a controller/shelf pairing is missing compatibility data.
- Preserve existing auto-match behavior while ensuring manual overrides compute using the selected controller + expansion shelf + drive size.
- Ensure the compatibility data is available for the static export by syncing it into the partner-hub public data directory.

### Description
- Add a compatibility JSON data file at `energy/data/netapp_drive_compat.json` and copy it to `ui/partner-hub/public/data/energy/netapp_drive_compat.json` via the sync script by updating `ui/partner-hub/scripts/sync-energy-data.mjs` and `energy_data_meta.json`.
- Add typed loader/helpers in `ui/partner-hub/lib/energy/netapp-drive-compat.ts` including `loadNetAppDriveCompat`, `getControllerModels`, `getExpansionModels`, `getDriveSizes`, and `getMaxExpansionQty` to query the compatibility dataset.
- Update the manual UI in `ui/partner-hub/components/energy/energy-tool.tsx` to load the compat JSON, populate the Controller and Expansion Shelf dropdowns from the dataset, replace the free Drive size `NumberInput` with a compatibility-driven `<select>`, auto-reset dependent selections on change, show a clear inline banner when a pairing is missing, and disable the manual `Apply manual config` button while compatibility data is missing.
- Update computation wiring in `ui/partner-hub/lib/energy/energy-calc.ts` to remove the controller allowlist, introduce `getExpansionShelfByModel`, and make `buildNetAppCandidate` accept and use the selected `expansionModel` (manual mode uses the chosen shelf); auto-match enumeration logic remains unchanged.

### Testing
- Executed `node ui/partner-hub/scripts/sync-energy-data.mjs` to copy datasets into `ui/partner-hub/public/data/energy`, which completed successfully.
- Verified `ui/partner-hub/public/data/energy/energy_data_meta.json` contains the new `netapp_drive_compat.json` entry and its `sha256` hash.
- No unit tests or `npm run build` were executed as part of this change.
- Type-level/runtime assertions in the browser were not run in CI (manual runtime validation recommended).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695fe93abbbc8326a6a3e2075092bc50)