### PR TITLE
Add architecture explorer types and PACKS registry

### DIFF
--- a/ui/partner-hub/components/architecture-explorer/registry.ts
+++ b/ui/partner-hub/components/architecture-explorer/registry.ts
@@ -1,0 +1,31 @@
+import { Domain, VendorPack } from "./types";
+
+export const PACKS: VendorPack[] = [];
+
+const DOMAINS: Domain[] = ["Storage", "Compute", "Network"];
+
+export const listDomains = (): Domain[] => [...DOMAINS];
+
+export const packsByDomain = (domain: Domain): VendorPack[] =>
+  PACKS.filter((pack) => pack.domain === domain);
+
+type GroupedPacks = Record<
+  string,
+  Record<string, Record<string, VendorPack>>
+>;
+
+export const groupPacks = (domain: Domain): GroupedPacks => {
+  return packsByDomain(domain).reduce<GroupedPacks>((acc, pack) => {
+    if (!acc[pack.vendor]) {
+      acc[pack.vendor] = {};
+    }
+
+    if (!acc[pack.vendor][pack.product]) {
+      acc[pack.vendor][pack.product] = {};
+    }
+
+    acc[pack.vendor][pack.product][pack.model] = pack;
+
+    return acc;
+  }, {});
+};

--- a/ui/partner-hub/components/architecture-explorer/types.ts
+++ b/ui/partner-hub/components/architecture-explorer/types.ts
@@ -1,0 +1,56 @@
+export type Domain = "Storage" | "Compute" | "Network";
+
+export type ViewMode = "overview" | "topology" | "flows";
+
+export type FlowChannel = "data" | "metadata" | "mgmt";
+
+export type NodeKind =
+  | "system"
+  | "service"
+  | "database"
+  | "storage"
+  | "compute"
+  | "network"
+  | "external";
+
+export interface VendorPack {
+  id: string;
+  domain: Domain;
+  vendor: string;
+  product: string;
+  model: string;
+  spec: ArchitectureSpec;
+  tags?: string[];
+}
+
+export interface ArchitectureSpec {
+  nodes: ArchitectureNode[];
+  edges: ArchitectureEdge[];
+  flows: ArchitectureFlow[];
+}
+
+export interface ArchitectureNode {
+  id: string;
+  kind: NodeKind;
+  label: string;
+  description?: string;
+  metadata?: Record<string, string>;
+}
+
+export interface ArchitectureEdge {
+  id: string;
+  from: string;
+  to: string;
+  label?: string;
+  metadata?: Record<string, string>;
+}
+
+export interface ArchitectureFlow {
+  id: string;
+  channel: FlowChannel;
+  from: string;
+  to: string;
+  path?: string[];
+  description?: string;
+  metadata?: Record<string, string>;
+}


### PR DESCRIPTION
### Motivation

- Provide a small, scalable taxonomy for architecture exploration with `Domain` values (`Storage`, `Compute`, `Network`) to drive UI organization.
- Introduce a `VendorPack` model that captures marketing-style identity (`vendor`, `product`, `model`) so packs can be displayed without embedding vendor-specific logic.
- Define an `ArchitectureSpec` containing `nodes`, `edges`, and `flows` (with `data`/`metadata`/`mgmt` channels) to describe topologies and data paths.
- Offer a central `PACKS` registry and grouping helpers so UI code can query packs by domain → vendor → product → model instead of hardcoding vendor comparisons.

### Description

- Added `ui/partner-hub/components/architecture-explorer/types.ts` exporting `Domain`, `ViewMode`, `FlowChannel`, `NodeKind`, `VendorPack`, and `ArchitectureSpec` plus node/edge/flow interfaces.
- Added `ui/partner-hub/components/architecture-explorer/registry.ts` exporting `PACKS`, `listDomains()`, `packsByDomain(domain)`, and `groupPacks(domain)` which groups packs into a `domain → vendor → product → model` structure.
- Implemented a `GroupedPacks` type (`Record<string, Record<string, Record<string, VendorPack>>>`) for typed grouping results.
- Kept the implementation vendor-agnostic so UI can render packs without special-casing particular vendors or models.

### Testing

- No automated tests were run for these changes.
- No type-check or build commands were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6960effd3b948326aba03037ef9d4239)