### PR TITLE
Add Storage VendorPacks: Pure FlashBlade//S and VAST Platform X

### DIFF
--- a/ui/partner-hub/components/architecture-explorer/packs/storage/pure/flashblade-s.ts
+++ b/ui/partner-hub/components/architecture-explorer/packs/storage/pure/flashblade-s.ts
@@ -1,0 +1,104 @@
+import type { VendorPack } from "../../../types";
+
+export const flashbladeS: VendorPack = {
+  id: "pure-storage-flashblade-s",
+  domain: "Storage",
+  vendor: "Pure Storage",
+  product: "FlashBlade",
+  model: "//S (baseline)",
+  pitch:
+    "Scale-out all-flash file and object platform tuned for fast analytics, AI pipelines, and backup/restore workflows.",
+  positioning:
+    "Lead with ultra-fast parallelism and simple scale-out expansion for latency-sensitive data lakes and modern file services.",
+  watchouts: [
+    "Plan for high-throughput networking (100/200GbE) to avoid bottlenecks.",
+    "Separate metadata services from data movers for predictable performance under mixed workloads.",
+    "Validate protection policy requirements when consolidating backup and analytics on the same platform.",
+  ],
+  spec: {
+    nodes: [
+      {
+        id: "client-nodes",
+        kind: "compute",
+        label: "AI/Analytics Clients",
+        description: "GPU and analytics hosts running parallel reads/writes.",
+      },
+      {
+        id: "data-movers",
+        kind: "service",
+        label: "Data Movers",
+        description: "Front-end services handling NFS/SMB/S3 data paths.",
+      },
+      {
+        id: "metadata-services",
+        kind: "service",
+        label: "Metadata Services",
+        description: "Namespace, snapshots, and policy orchestration.",
+      },
+      {
+        id: "flashblade-s",
+        kind: "storage",
+        label: "FlashBlade//S Chassis",
+        description: "Scale-out storage blades with NVMe flash.",
+      },
+      {
+        id: "admin-ops",
+        kind: "external",
+        label: "Ops & Automation",
+        description: "Admins and automation tooling for monitoring and provisioning.",
+      },
+    ],
+    edges: [
+      {
+        id: "client-to-movers",
+        from: "client-nodes",
+        to: "data-movers",
+        label: "NFS/SMB/S3",
+      },
+      {
+        id: "movers-to-blades",
+        from: "data-movers",
+        to: "flashblade-s",
+        label: "Parallel IO",
+      },
+      {
+        id: "metadata-to-blades",
+        from: "metadata-services",
+        to: "flashblade-s",
+        label: "Metadata + policy",
+      },
+      {
+        id: "ops-to-metadata",
+        from: "admin-ops",
+        to: "metadata-services",
+        label: "Provisioning",
+      },
+    ],
+    flows: [
+      {
+        id: "flashblade-data-channel",
+        channel: "data",
+        from: "client-nodes",
+        to: "flashblade-s",
+        path: ["client-nodes", "data-movers", "flashblade-s"],
+        description: "READ/WRITE data channel for datasets and checkpoints.",
+      },
+      {
+        id: "flashblade-metadata-channel",
+        channel: "metadata",
+        from: "client-nodes",
+        to: "metadata-services",
+        path: ["client-nodes", "data-movers", "metadata-services"],
+        description: "CREATE/LIST metadata channel for namespaces and snapshots.",
+      },
+      {
+        id: "flashblade-ops-channel",
+        channel: "mgmt",
+        from: "admin-ops",
+        to: "metadata-services",
+        path: ["admin-ops", "metadata-services"],
+        description: "Policy updates, monitoring, and automation workflows.",
+      },
+    ],
+  },
+};

--- a/ui/partner-hub/components/architecture-explorer/packs/storage/vast/vast-platform-x.ts
+++ b/ui/partner-hub/components/architecture-explorer/packs/storage/vast/vast-platform-x.ts
@@ -1,0 +1,122 @@
+import type { VendorPack } from "../../../types";
+
+export const vastPlatformX: VendorPack = {
+  id: "vast-data-vast-platform-x",
+  domain: "Storage",
+  vendor: "VAST Data",
+  product: "VAST Platform",
+  model: "X (baseline)",
+  pitch:
+    "Unified file/object platform delivering low-latency parallel access with global namespace and storage efficiency.",
+  positioning:
+    "Position for large-scale AI and analytics environments needing a single namespace across flash and capacity tiers.",
+  watchouts: [
+    "Plan for balanced CBOX/DBOX scaling to keep metadata and data throughput aligned.",
+    "Confirm client protocol mix (NFS/SMB/S3) aligns with performance targets.",
+    "Reserve network capacity for east-west traffic between enclosures.",
+  ],
+  spec: {
+    nodes: [
+      {
+        id: "app-cluster",
+        kind: "compute",
+        label: "AI/Analytics Cluster",
+        description: "GPU and analytics applications generating parallel IO.",
+      },
+      {
+        id: "client-gateway",
+        kind: "service",
+        label: "VAST Client Gateway",
+        description: "Client protocol services for NFS/SMB/S3.",
+      },
+      {
+        id: "metadata-engine",
+        kind: "service",
+        label: "Metadata Engine",
+        description: "Global namespace, snapshots, and policy control.",
+      },
+      {
+        id: "cbox",
+        kind: "storage",
+        label: "CBOX (NVMe)",
+        description: "Performance tier for hot data and metadata.",
+      },
+      {
+        id: "dbox",
+        kind: "storage",
+        label: "DBOX (Capacity)",
+        description: "Capacity tier for cold data and snapshots.",
+      },
+      {
+        id: "ops-team",
+        kind: "external",
+        label: "Ops & Observability",
+        description: "Admins, automation, and monitoring tooling.",
+      },
+    ],
+    edges: [
+      {
+        id: "apps-to-gateway",
+        from: "app-cluster",
+        to: "client-gateway",
+        label: "NFS/SMB/S3",
+      },
+      {
+        id: "gateway-to-metadata",
+        from: "client-gateway",
+        to: "metadata-engine",
+        label: "Namespace ops",
+      },
+      {
+        id: "gateway-to-cbox",
+        from: "client-gateway",
+        to: "cbox",
+        label: "Data IO",
+      },
+      {
+        id: "metadata-to-cbox",
+        from: "metadata-engine",
+        to: "cbox",
+        label: "Metadata storage",
+      },
+      {
+        id: "cbox-to-dbox",
+        from: "cbox",
+        to: "dbox",
+        label: "Tiering",
+      },
+      {
+        id: "ops-to-metadata",
+        from: "ops-team",
+        to: "metadata-engine",
+        label: "Policy + monitoring",
+      },
+    ],
+    flows: [
+      {
+        id: "vast-data-channel",
+        channel: "data",
+        from: "app-cluster",
+        to: "cbox",
+        path: ["app-cluster", "client-gateway", "cbox"],
+        description: "READ/WRITE data channel for model training and analytics.",
+      },
+      {
+        id: "vast-metadata-channel",
+        channel: "metadata",
+        from: "app-cluster",
+        to: "metadata-engine",
+        path: ["app-cluster", "client-gateway", "metadata-engine"],
+        description: "CREATE/LIST metadata channel for namespace operations.",
+      },
+      {
+        id: "vast-tiering-channel",
+        channel: "mgmt",
+        from: "metadata-engine",
+        to: "dbox",
+        path: ["metadata-engine", "cbox", "dbox"],
+        description: "Policy-driven tiering and lifecycle management.",
+      },
+    ],
+  },
+};

--- a/ui/partner-hub/components/architecture-explorer/registry.ts
+++ b/ui/partner-hub/components/architecture-explorer/registry.ts
@@ -1,6 +1,8 @@
+import { flashbladeS } from "./packs/storage/pure/flashblade-s";
+import { vastPlatformX } from "./packs/storage/vast/vast-platform-x";
 import { Domain, VendorPack } from "./types";
 
-export const PACKS: VendorPack[] = [];
+export const PACKS: VendorPack[] = [flashbladeS, vastPlatformX];
 
 const DOMAINS: Domain[] = ["Storage", "Compute", "Network"];
 

--- a/ui/partner-hub/components/architecture-explorer/types.ts
+++ b/ui/partner-hub/components/architecture-explorer/types.ts
@@ -19,6 +19,9 @@ export interface VendorPack {
   vendor: string;
   product: string;
   model: string;
+  pitch: string;
+  positioning: string;
+  watchouts: string[];
   spec: ArchitectureSpec;
   tags?: string[];
 }


### PR DESCRIPTION
### Motivation
- Provide ready-to-render vendor packs for the Storage domain so the architecture explorer can display vendor-specific topologies and flows.
- Capture marketing and operational context for vendor packs by adding `pitch`, `positioning`, and `watchouts` fields to the pack type.
- Ensure newly added packs are discoverable by the explorer by registering them in the central `PACKS` registry.

### Description
- Added `ui/partner-hub/components/architecture-explorer/packs/storage/pure/flashblade-s.ts` which defines a `VendorPack` for Pure Storage FlashBlade//S with nodes, edges, and flows including `READ/WRITE` (data) and `CREATE/LIST` (metadata) channels.
- Added `ui/partner-hub/components/architecture-explorer/packs/storage/vast/vast-platform-x.ts` which defines a `VendorPack` for VAST Data Platform X with nodes, edges, and flows including `READ/WRITE` (data) and `CREATE/LIST` (metadata) channels and a tiering management flow.
- Extended the `VendorPack` interface in `types.ts` to include `pitch`, `positioning`, and `watchouts` fields.
- Imported and registered the two new packs in `registry.ts` by adding `flashbladeS` and `vastPlatformX` to the `PACKS` array.

### Testing
- No automated tests were run against these changes.
- No CI or type-check build was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6960f074def08326ad3c6feb6fde0073)