### PR TITLE
Replace legacy Architecture Explorer route with shared component

### DIFF
--- a/ui/partner-hub/app/(routes)/architecture-explorer/page.tsx
+++ b/ui/partner-hub/app/(routes)/architecture-explorer/page.tsx
@@ -1,48 +1,5 @@
-import Link from "next/link";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-
-const architectures = [
-  {
-    title: "Hybrid Cloud Landing Zone",
-    detail: "Validated design for hybrid storage tiers and DR readiness.",
-  },
-  {
-    title: "AI/ML Data Pipeline",
-    detail: "Reference architecture for GPU clusters with high-throughput storage.",
-  },
-  {
-    title: "Core Data Center Refresh",
-    detail: "Modernization blueprint for block and file consolidation.",
-  },
-];
+import { ArchitectureExplorer } from "@/components/architecture-explorer/architecture-explorer";
 
 export default function ArchitectureExplorerPage() {
-  return (
-    <section className="space-y-6">
-      <header className="space-y-2">
-        <h1 className="text-2xl font-semibold">Architecture Explorer</h1>
-        <p className="text-sm text-foreground/70">
-          Browse reference architectures and deployment patterns for presales discovery.
-        </p>
-      </header>
-      <div className="grid gap-4 md:grid-cols-2">
-        {architectures.map((architecture) => (
-          <Card key={architecture.title}>
-            <CardHeader>
-              <CardTitle className="text-base">{architecture.title}</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-foreground/70">
-              <p>{architecture.detail}</p>
-              <Link
-                href="#"
-                className="text-xs font-semibold uppercase tracking-wide text-primary hover:underline"
-              >
-                Open blueprint
-              </Link>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-    </section>
-  );
+  return <ArchitectureExplorer />;
 }


### PR DESCRIPTION
### Motivation
- Remove the old inline Architecture Explorer implementation and consolidate on the single canonical component to avoid duplicated code.
- Ensure the legacy route renders the new experience provided by the shared implementation under `ui/partner-hub/components/architecture-explorer/`.
- Keep existing navigation URLs stable while unifying the entrypoints to the new component.

### Description
- Replaced the inline page implementation in `ui/partner-hub/app/(routes)/architecture-explorer/page.tsx` to import and render `ArchitectureExplorer` from `@/components/architecture-explorer/architecture-explorer`.
- Removed the hard-coded architecture list and card markup from the legacy page so the route now delegates to the shared component.
- Consolidates the Architecture Explorer codebase to the canonical implementation located at `ui/partner-hub/components/architecture-explorer/`.

### Testing
- No automated tests were run against this change.
- Repository status and the modified file were verified with `git status` and a successful commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6960f2dd63bc8326a0c2d16e94d19abf)