### PR TITLE
Add walkthrough scaffolding to Architecture Explorer

### DIFF
--- a/ui/partner-hub/components/architecture-explorer/architecture-explorer.tsx
+++ b/ui/partner-hub/components/architecture-explorer/architecture-explorer.tsx
@@ -23,7 +23,14 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { groupPacks, listDomains } from "./registry";
-import type { ArchitectureNode, Domain, FlowChannel, NodeKind, VendorPack } from "./types";
+import type {
+  ArchitectureNode,
+  Domain,
+  FlowChannel,
+  NodeKind,
+  VendorPack,
+  WalkthroughStep,
+} from "./types";
 
 type ExplorerMode = "compare" | "single" | "walkthrough";
 
@@ -123,6 +130,7 @@ const layoutNodes = (nodes: ArchitectureNode[]): Node<ReactFlowNodeData>[] => {
 const buildFlowEdges = (
   pack: VendorPack,
   selectedChannel: FlowChannel,
+  highlightedEdgeIds?: Set<string>,
 ): Edge[] => {
   const edgeMap = new Map(
     pack.spec.edges.map((edge) => [`${edge.from}->${edge.to}`, edge.id]),
@@ -142,8 +150,11 @@ const buildFlowEdges = (
     if (edgeId) flowEdgeIds.add(edgeId);
   }
 
+  const activeEdgeIds =
+    highlightedEdgeIds && highlightedEdgeIds.size > 0 ? highlightedEdgeIds : flowEdgeIds;
+
   return pack.spec.edges.map((edge) => {
-    const isActive = flowEdgeIds.has(edge.id);
+    const isActive = activeEdgeIds.has(edge.id);
     return {
       id: edge.id,
       source: edge.from,
@@ -177,33 +188,44 @@ const buildTalkTrack = (pack: VendorPack, node: ArchitectureNode | undefined) =>
 const FlowCanvas = ({
   pack,
   selectedChannel,
+  highlightedNodeIds,
+  highlightedEdgeIds,
   onNodeSelect,
   selectedNodeId,
 }: {
   pack: VendorPack;
   selectedChannel: FlowChannel;
+  highlightedNodeIds?: Set<string>;
+  highlightedEdgeIds?: Set<string>;
   selectedNodeId?: string;
   onNodeSelect: (node: ArchitectureNode) => void;
 }) => {
   const nodes = useMemo(() => layoutNodes(pack.spec.nodes), [pack]);
 
-  const edges = useMemo(() => buildFlowEdges(pack, selectedChannel), [pack, selectedChannel]);
+  const edges = useMemo(
+    () => buildFlowEdges(pack, selectedChannel, highlightedEdgeIds),
+    [pack, selectedChannel, highlightedEdgeIds],
+  );
 
   const displayNodes = useMemo(() => {
     return nodes.map((node) => {
       const baseStyle = (node.style ?? {}) as CSSProperties;
       const isSelected = node.id === selectedNodeId;
+      const isHighlighted = highlightedNodeIds?.has(node.id) ?? false;
 
       return {
         ...node,
         style: {
           ...baseStyle,
-          borderWidth: isSelected ? 3 : 2,
-          boxShadow: isSelected ? "0 0 0 3px rgba(59,130,246,0.3)" : "none",
+          borderWidth: isSelected || isHighlighted ? 3 : 2,
+          borderColor:
+            isHighlighted || isSelected ? "hsl(var(--primary))" : baseStyle.borderColor,
+          boxShadow:
+            isSelected || isHighlighted ? "0 0 0 3px rgba(59,130,246,0.3)" : "none",
         },
       } as Node<ReactFlowNodeData>;
     });
-  }, [nodes, selectedNodeId]);
+  }, [nodes, selectedNodeId, highlightedNodeIds]);
 
   const [flowInstance, setFlowInstance] = useState<
     ReactFlowInstance<Node<ReactFlowNodeData>, Edge> | null
@@ -329,6 +351,7 @@ export function ArchitectureExplorer() {
   const [domain, setDomain] = useState<Domain>(domains[0] ?? "Storage");
   const [mode, setMode] = useState<ExplorerMode>("compare");
   const [selectedChannel, setSelectedChannel] = useState<FlowChannel>("data");
+  const [walkthroughStepIndex, setWalkthroughStepIndex] = useState(0);
 
   const initialSelection = useMemo(() => derivePackSelection(domain), [domain]);
   const [selectionState, setSelectionState] = useState<SelectionState>({
@@ -347,16 +370,41 @@ export function ArchitectureExplorer() {
 
   const leftPack = resolvePack(domain, selectionState.left);
   const rightPack = resolvePack(domain, selectionState.right);
+  const walkthroughSteps = useMemo<WalkthroughStep[]>(
+    () => leftPack?.walkthrough ?? [],
+    [leftPack],
+  );
+  const activeWalkthroughStep = walkthroughSteps[walkthroughStepIndex];
+
+  useEffect(() => {
+    if (mode !== "walkthrough") return;
+    setWalkthroughStepIndex(0);
+  }, [mode, leftPack?.id]);
+
+  useEffect(() => {
+    if (walkthroughStepIndex < walkthroughSteps.length) return;
+    setWalkthroughStepIndex(0);
+  }, [walkthroughStepIndex, walkthroughSteps.length]);
 
   const handleSelectNode = (side: "left" | "right") => (node: ArchitectureNode) => {
     setSelectedNode({ side, nodeId: node.id });
   };
 
-  const activePack = selectedNode?.side === "right" ? rightPack : leftPack;
+  const activePack =
+    mode === "walkthrough" ? leftPack : selectedNode?.side === "right" ? rightPack : leftPack;
   const activeNode = useMemo(() => {
     if (!activePack || !selectedNode) return undefined;
     return activePack.spec.nodes.find((node) => node.id === selectedNode.nodeId);
   }, [activePack, selectedNode]);
+
+  const highlightedNodeIds = useMemo(
+    () => new Set(activeWalkthroughStep?.nodeIds ?? []),
+    [activeWalkthroughStep],
+  );
+  const highlightedEdgeIds = useMemo(
+    () => new Set(activeWalkthroughStep?.edgeIds ?? []),
+    [activeWalkthroughStep],
+  );
 
   const connectedNodes = useMemo(() => {
     if (!activePack || !activeNode) return [];
@@ -392,6 +440,9 @@ export function ArchitectureExplorer() {
 
     return buildTalkTrack(activePack, activeNode);
   }, [activePack, activeNode]);
+
+  const walkthroughScript =
+    activeWalkthroughStep?.script ?? "No walkthrough steps are available for this pack yet.";
 
   const gridCols = mode === "compare" ? "lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_320px]" : "lg:grid-cols-[minmax(0,1fr)_320px]";
 
@@ -474,6 +525,8 @@ export function ArchitectureExplorer() {
                 <FlowCanvas
                   pack={leftPack}
                   selectedChannel={selectedChannel}
+                  highlightedNodeIds={mode === "walkthrough" ? highlightedNodeIds : undefined}
+                  highlightedEdgeIds={mode === "walkthrough" ? highlightedEdgeIds : undefined}
                   selectedNodeId={selectedNode?.side === "left" ? selectedNode.nodeId : undefined}
                   onNodeSelect={handleSelectNode("left")}
                 />
@@ -490,11 +543,42 @@ export function ArchitectureExplorer() {
           {mode === "walkthrough" ? (
             <Card>
               <CardHeader className="pb-2">
-                <CardTitle className="text-base">Walkthrough — coming next</CardTitle>
+                <CardTitle className="text-base">Walkthrough</CardTitle>
               </CardHeader>
-              <CardContent className="space-y-2 text-sm text-foreground/70">
-                <p>Step-by-step walkthroughs are in progress.</p>
-                <p>We will add scripted stages, callouts, and checkpoints for each flow.</p>
+              <CardContent className="space-y-4 text-sm text-foreground/70">
+                <div className="space-y-1">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+                    Step {walkthroughSteps.length ? walkthroughStepIndex + 1 : 0} of{" "}
+                    {walkthroughSteps.length}
+                  </p>
+                  <p className="text-sm font-semibold text-foreground">
+                    {activeWalkthroughStep?.title ?? "No walkthrough steps available"}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="ghost"
+                    className="h-8 px-3 text-xs"
+                    onClick={() =>
+                      setWalkthroughStepIndex((prev) => Math.max(prev - 1, 0))
+                    }
+                    disabled={walkthroughStepIndex === 0}
+                  >
+                    Back
+                  </Button>
+                  <Button
+                    variant="primary"
+                    className="h-8 px-3 text-xs"
+                    onClick={() =>
+                      setWalkthroughStepIndex((prev) =>
+                        Math.min(prev + 1, Math.max(walkthroughSteps.length - 1, 0)),
+                      )
+                    }
+                    disabled={walkthroughStepIndex >= walkthroughSteps.length - 1}
+                  >
+                    Next
+                  </Button>
+                </div>
               </CardContent>
             </Card>
           ) : null}
@@ -522,12 +606,14 @@ export function ArchitectureExplorer() {
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="h-[420px]">
-                  <FlowCanvas
-                    pack={rightPack}
-                    selectedChannel={selectedChannel}
-                    selectedNodeId={selectedNode?.side === "right" ? selectedNode.nodeId : undefined}
-                    onNodeSelect={handleSelectNode("right")}
-                  />
+                <FlowCanvas
+                  pack={rightPack}
+                  selectedChannel={selectedChannel}
+                  highlightedNodeIds={mode === "walkthrough" ? highlightedNodeIds : undefined}
+                  highlightedEdgeIds={mode === "walkthrough" ? highlightedEdgeIds : undefined}
+                  selectedNodeId={selectedNode?.side === "right" ? selectedNode.nodeId : undefined}
+                  onNodeSelect={handleSelectNode("right")}
+                />
                 </CardContent>
               </Card>
             ) : (
@@ -550,22 +636,43 @@ export function ArchitectureExplorer() {
                 {activePack ? `${activePack.vendor} · ${activePack.product}` : "Select a pack"}
               </span>
               <h2 className="text-lg font-semibold text-foreground">
-                {activeNode?.label ?? "Click a node to begin"}
+                {mode === "walkthrough"
+                  ? activeWalkthroughStep?.title ?? "Walkthrough script"
+                  : activeNode?.label ?? "Click a node to begin"}
               </h2>
             </div>
 
             <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">Component bullets</p>
-              <ul className="mt-2 list-disc space-y-1 pl-5">
-                {componentBullets.map((bullet) => (
-                  <li key={bullet}>{bullet}</li>
-                ))}
-              </ul>
+              {mode === "walkthrough" ? (
+                <>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+                    Walkthrough cues
+                  </p>
+                  <p className="mt-2 text-sm text-foreground/80">
+                    Highlight the nodes and edges shown in this step, then advance to continue.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+                    Component bullets
+                  </p>
+                  <ul className="mt-2 list-disc space-y-1 pl-5">
+                    {componentBullets.map((bullet) => (
+                      <li key={bullet}>{bullet}</li>
+                    ))}
+                  </ul>
+                </>
+              )}
             </div>
 
             <div className="rounded-lg border border-border/60 bg-muted/30 p-3">
-              <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">Talk track</p>
-              <p className="mt-2 whitespace-pre-line text-foreground/80">{talkTrack}</p>
+              <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+                {mode === "walkthrough" ? "Walkthrough script" : "Talk track"}
+              </p>
+              <p className="mt-2 whitespace-pre-line text-foreground/80">
+                {mode === "walkthrough" ? walkthroughScript : talkTrack}
+              </p>
             </div>
           </CardContent>
         </Card>

--- a/ui/partner-hub/components/architecture-explorer/packs/storage/pure/flashblade-s.ts
+++ b/ui/partner-hub/components/architecture-explorer/packs/storage/pure/flashblade-s.ts
@@ -15,6 +15,42 @@ export const flashbladeS: VendorPack = {
     "Separate metadata services from data movers for predictable performance under mixed workloads.",
     "Validate protection policy requirements when consolidating backup and analytics on the same platform.",
   ],
+  walkthrough: [
+    {
+      id: "fb-step-1",
+      title: "Parallel clients",
+      script: "Start with the AI/analytics clients generating high-concurrency file and object traffic.",
+      nodeIds: ["client-nodes"],
+    },
+    {
+      id: "fb-step-2",
+      title: "Protocol front-end",
+      script: "Data movers handle NFS/SMB/S3 sessions before fanning traffic into the chassis.",
+      nodeIds: ["data-movers"],
+      edgeIds: ["client-to-movers"],
+    },
+    {
+      id: "fb-step-3",
+      title: "FlashBlade//S core",
+      script: "Highlight the FlashBlade//S chassis delivering parallel IO at scale.",
+      nodeIds: ["flashblade-s"],
+      edgeIds: ["movers-to-blades"],
+    },
+    {
+      id: "fb-step-4",
+      title: "Metadata control plane",
+      script: "Metadata services keep namespaces, snapshots, and policy aligned.",
+      nodeIds: ["metadata-services"],
+      edgeIds: ["metadata-to-blades"],
+    },
+    {
+      id: "fb-step-5",
+      title: "Ops automation",
+      script: "Ops and automation teams drive provisioning and governance flows.",
+      nodeIds: ["admin-ops"],
+      edgeIds: ["ops-to-metadata"],
+    },
+  ],
   spec: {
     nodes: [
       {

--- a/ui/partner-hub/components/architecture-explorer/packs/storage/vast/vast-platform-x.ts
+++ b/ui/partner-hub/components/architecture-explorer/packs/storage/vast/vast-platform-x.ts
@@ -15,6 +15,42 @@ export const vastPlatformX: VendorPack = {
     "Confirm client protocol mix (NFS/SMB/S3) aligns with performance targets.",
     "Reserve network capacity for east-west traffic between enclosures.",
   ],
+  walkthrough: [
+    {
+      id: "vast-step-1",
+      title: "AI/analytics clients",
+      script: "Begin with the AI/analytics cluster driving parallel read/write demand.",
+      nodeIds: ["app-cluster"],
+    },
+    {
+      id: "vast-step-2",
+      title: "Client gateway",
+      script: "The gateway terminates NFS/SMB/S3 and fans traffic into the platform.",
+      nodeIds: ["client-gateway"],
+      edgeIds: ["apps-to-gateway"],
+    },
+    {
+      id: "vast-step-3",
+      title: "Metadata engine",
+      script: "Metadata services keep the global namespace and policy control centralized.",
+      nodeIds: ["metadata-engine"],
+      edgeIds: ["gateway-to-metadata"],
+    },
+    {
+      id: "vast-step-4",
+      title: "Performance tier",
+      script: "CBOX delivers NVMe performance for hot data and metadata.",
+      nodeIds: ["cbox"],
+      edgeIds: ["gateway-to-cbox", "metadata-to-cbox"],
+    },
+    {
+      id: "vast-step-5",
+      title: "Capacity tier",
+      script: "DBOX provides efficient capacity for snapshots and colder datasets.",
+      nodeIds: ["dbox"],
+      edgeIds: ["cbox-to-dbox"],
+    },
+  ],
   spec: {
     nodes: [
       {

--- a/ui/partner-hub/components/architecture-explorer/types.ts
+++ b/ui/partner-hub/components/architecture-explorer/types.ts
@@ -24,6 +24,7 @@ export interface VendorPack {
   watchouts: string[];
   spec: ArchitectureSpec;
   tags?: string[];
+  walkthrough?: WalkthroughStep[];
 }
 
 export interface ArchitectureSpec {
@@ -56,4 +57,12 @@ export interface ArchitectureFlow {
   path?: string[];
   description?: string;
   metadata?: Record<string, string>;
+}
+
+export interface WalkthroughStep {
+  id: string;
+  title: string;
+  script: string;
+  nodeIds?: string[];
+  edgeIds?: string[];
 }

--- a/ui/partner-hub/package-lock.json
+++ b/ui/partner-hub/package-lock.json
@@ -927,7 +927,6 @@
             "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -988,7 +987,6 @@
             "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.52.0",
                 "@typescript-eslint/types": "8.52.0",
@@ -1527,7 +1525,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1957,7 +1954,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -2278,7 +2274,6 @@
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -2719,7 +2714,6 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -2889,7 +2883,6 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -4256,7 +4249,6 @@
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -5025,7 +5017,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -5227,7 +5218,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -5240,7 +5230,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -6146,7 +6135,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -6316,7 +6304,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"


### PR DESCRIPTION
### Motivation

- Introduce guided walkthroughs to highlight architecture nodes and edges and provide an instructor script for presales demos.
- Allow packs to optionally define step sequences so vendor-specific narratives can drive UI highlights.

### Description

- Add a `WalkthroughStep` type and an optional `walkthrough?: WalkthroughStep[]` field to `VendorPack` in `types.ts`.
- Seed five minimal walkthrough steps for Pure FlashBlade and VAST Platform in their respective pack files.
- Implement a `walkthrough` mode in `architecture-explorer.tsx` with Next/Back controls, step state, and wiring to highlight nodes and edges via `FlowCanvas` and `buildFlowEdges`.
- Update the Instructor Panel to show the current walkthrough step title and script while preserving existing talk-track behavior for other modes.

### Testing

- Ran `npm install` in `ui/partner-hub`, which completed successfully.
- Started the dev server with `npm run dev` and Next.js launched and served the app locally.
- Attempted an automated end-to-end check with Playwright to open the explorer and click `Walkthrough`, but the Chromium run crashed and the E2E check failed.
- No unit test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6960f3c3bed883269bc3bf02e67c9b8d)