### PR TITLE
chore: override glob to address npm audit vulnerability

### DIFF
--- a/ui/partner-hub/package-lock.json
+++ b/ui/partner-hub/package-lock.json
@@ -27,6 +27,9 @@
                 "postcss": "^8.4.31",
                 "tailwindcss": "^3.4.0",
                 "typescript": "^5.3.0"
+            },
+            "overrides": {
+                "glob": "^10.4.6"
             }
         },
         "node_modules/@alloc/quick-lru": {

--- a/ui/partner-hub/package.json
+++ b/ui/partner-hub/package.json
@@ -29,5 +29,8 @@
         "postcss": "^8.4.31",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.3.0"
+    },
+    "overrides": {
+        "glob": "^10.4.6"
     }
 }


### PR DESCRIPTION
### Motivation
- Address a high-severity `glob` GHSA advisory (10.2.0–10.4.5) pulled in via `eslint-config-next` / `@next/eslint-plugin-next`.
- Force a patched `glob` version (>= `10.4.6`) for the partner-hub Next.js app to suppress the audit finding.

### Description
- Added an `overrides` block to `ui/partner-hub/package.json` with `"glob": "^10.4.6"` to pin the patched release.
- Updated `ui/partner-hub/package-lock.json` to include the same `overrides` entry so the lockfile reflects the change.

### Testing
- Ran `npm install` in `ui/partner-hub`, which failed with a `403 Forbidden` from the registry so the install could not complete.
- Ran `npm audit`, which failed due to an audit endpoint error from the registry and could not confirm advisory resolution.
- Ran `npm run build`, which started the Next.js build but failed due to an existing TypeScript error in `components/architecture-explorer/architecture-explorer.tsx` and not because of the `glob` change.
- The repository files modified are `ui/partner-hub/package.json` and `ui/partner-hub/package-lock.json` and those changes were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6960f68be33883268cc28f56dd789f6d)