### PR TITLE
Deterministic lane layout for architecture explorer

### DIFF
--- a/ui/partner-hub/components/architecture-explorer/architecture-explorer.tsx
+++ b/ui/partner-hub/components/architecture-explorer/architecture-explorer.tsx
@@ -89,16 +89,24 @@ const resolvePack = (domain: Domain, selection: PackSelection): VendorPack | und
 
 const NODE_WIDTH = 190;
 const NODE_HEIGHT = 90;
-const LANE_DEFINITIONS: Array<{ id: string; label: string; kinds: NodeKind[] }> = [
-  { id: "client", label: "client/protocol", kinds: ["external", "network"] },
-  { id: "services", label: "metadata/services", kinds: ["system", "service"] },
-  { id: "fabric", label: "fabric/data", kinds: ["database", "storage", "compute"] },
-  { id: "mgmt", label: "mgmt", kinds: [] },
-];
+const LANE_SPACING = NODE_HEIGHT + 140;
+const LANE_OFFSET = 40;
 
-const resolveLaneIndex = (kind: NodeKind): number => {
-  const laneIndex = LANE_DEFINITIONS.findIndex((lane) => lane.kinds.includes(kind));
-  return laneIndex === -1 ? LANE_DEFINITIONS.length - 1 : laneIndex;
+const getLane = (kind: NodeKind): number => {
+  switch (kind) {
+    case "external":
+    case "network":
+      return 0;
+    case "system":
+    case "service":
+      return 1;
+    case "database":
+    case "storage":
+    case "compute":
+      return 2;
+    default:
+      return 3;
+  }
 };
 
 const derivePackSelection = (domain: Domain): PackSelection => {
@@ -113,10 +121,11 @@ const derivePackSelection = (domain: Domain): PackSelection => {
 const layoutNodes = (pack: VendorPack, layoutMode: LayoutMode): Node<ReactFlowNodeData>[] => {
   const graph = new dagre.graphlib.Graph();
   graph.setDefaultEdgeLabel(() => ({}));
+  const isLayered = layoutMode === "layered";
   graph.setGraph({
-    rankdir: layoutMode === "flow" ? "LR" : "TB",
-    nodesep: 60,
-    ranksep: 80,
+    rankdir: "LR",
+    nodesep: isLayered ? 70 : 60,
+    ranksep: isLayered ? 90 : 80,
   });
 
   pack.spec.nodes.forEach((node) => {
@@ -128,18 +137,14 @@ const layoutNodes = (pack: VendorPack, layoutMode: LayoutMode): Node<ReactFlowNo
 
   dagre.layout(graph);
 
-  const laneWidth = NODE_WIDTH + 160;
-  const laneOffset = 40;
-
   return pack.spec.nodes.map((node) => {
     const style = KIND_STYLES[node.kind];
     const layout = graph.node(node.id) as { x: number; y: number };
-    const laneIndex = resolveLaneIndex(node.kind);
-    const positionX =
-      layoutMode === "flow"
-        ? layout.x
-        : laneOffset + laneIndex * laneWidth + NODE_WIDTH / 2;
-    const positionY = layout.y;
+    const laneIndex = getLane(node.kind);
+    const positionX = layout.x;
+    const positionY = isLayered
+      ? LANE_OFFSET + laneIndex * LANE_SPACING + NODE_HEIGHT / 2
+      : layout.y;
 
     return {
       id: node.id,


### PR DESCRIPTION
### Motivation
- Provide a deterministic lane mapping so nodes of the same kind consistently render on the same horizontal band in layered mode.
- Eliminate random vertical jitter between renders by pinning layered Y positions to fixed lane offsets.
- Preserve Dagre ordering left-to-right to reduce edge crossings within each lane.
- Keep an optional mgmt/bottom lane for unmapped kinds.

### Description
- Replace `LANE_DEFINITIONS` and `resolveLaneIndex` with a deterministic `getLane(kind)` helper that returns lane indices 0–3 based on `NodeKind`.
- Introduce `LANE_SPACING` and `LANE_OFFSET` constants and use them to compute layered Y positions instead of relying on random Dagre Y coordinates.
- Configure Dagre with `rankdir: "LR"` and tuned `nodesep`/`ranksep` for layered mode so Dagre orders nodes left-to-right while the Y is pinned by lane in `layoutNodes`.
- Changes applied in `ui/partner-hub/components/architecture-explorer/architecture-explorer.tsx` and `layoutNodes` now uses `getLane`, `LANE_OFFSET`, and `LANE_SPACING` to position nodes.

### Testing
- Started the dev server with `npm run dev` which launched Next.js successfully. 
- Ran a Playwright script to load the explorer and capture a screenshot, but the page failed to render due to a missing `dagre` module resulting in 500 errors. 
- The Playwright script completed and produced screenshot artifacts, but the UI render was not valid because of the module error. 
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69611646e8d48326bf14b58e4bc139b0)