### PR TITLE
Persist architecture layout mode in localStorage (client-safe)

### DIFF
--- a/ui/partner-hub/components/architecture-explorer/architecture-explorer.tsx
+++ b/ui/partner-hub/components/architecture-explorer/architecture-explorer.tsx
@@ -91,6 +91,7 @@ const NODE_WIDTH = 190;
 const NODE_HEIGHT = 90;
 const LANE_SPACING = NODE_HEIGHT + 140;
 const LANE_OFFSET = 40;
+const LAYOUT_STORAGE_KEY = "partner-hub:architecture-layout-mode";
 
 const getLane = (kind: NodeKind): number => {
   switch (kind) {
@@ -129,7 +130,13 @@ const layoutNodes = (pack: VendorPack, layoutMode: LayoutMode): Node<ReactFlowNo
   });
 
   pack.spec.nodes.forEach((node) => {
-    graph.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+    const laneIndex = getLane(node.kind);
+    const laneY = LANE_OFFSET + laneIndex * LANE_SPACING + NODE_HEIGHT / 2;
+    graph.setNode(node.id, {
+      width: NODE_WIDTH,
+      height: NODE_HEIGHT,
+      ...(isLayered ? { y: laneY } : {}),
+    });
   });
   pack.spec.edges.forEach((edge) => {
     graph.setEdge(edge.from, edge.to);
@@ -430,6 +437,19 @@ export function ArchitectureExplorer() {
     if (walkthroughStepIndex < walkthroughSteps.length) return;
     setWalkthroughStepIndex(0);
   }, [walkthroughStepIndex, walkthroughSteps.length]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem(LAYOUT_STORAGE_KEY);
+    if (stored === "flow" || stored === "layered") {
+      setLayoutMode(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(LAYOUT_STORAGE_KEY, layoutMode);
+  }, [layoutMode]);
 
   const handleSelectNode = (side: "left" | "right") => (node: ArchitectureNode) => {
     setSelectedNode({ side, nodeId: node.id });


### PR DESCRIPTION
### Motivation
- Remember the user-selected diagram layout across page reloads so preferences persist per-user.
- Keep the implementation safe for static/SSR builds by avoiding unguarded access to `window`/`localStorage` at runtime.
- Default to the existing `layered` layout when no stored preference is present.
- Keep a pragmatic layered layout that aligns nodes to lanes without complex Dagre swimlane constraints.

### Description
- Added a `LAYOUT_STORAGE_KEY` constant and client-only `useEffect` hooks that read/write `localStorage` to persist `layoutMode` with `typeof window` guards.
- Updated `layoutNodes` to pre-seed layered nodes with a lane-based `y` value so Dagre computes `x` ordering and the code snaps nodes back to their lane after layout.
- Left the default `layoutMode` as `"layered"` when nothing is stored and expose the existing layout toggle to update the persisted value.
- Changes restricted to `ui/partner-hub/components/architecture-explorer/architecture-explorer.tsx` and are safe for static export.

### Testing
- No automated tests were run as part of this change.
- CI will exercise repository test suites when the PR is opened (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696119e361bc8326903adb7c41a99670)