### PR TITLE
Add @types/dagre devDependency to partner-hub

### DIFF
--- a/ui/partner-hub/package.json
+++ b/ui/partner-hub/package.json
@@ -21,6 +21,7 @@
         "reactflow": "^11.11.4"
     },
     "devDependencies": {
+        "@types/dagre": "^0.7.52",
         "@types/node": "^20.9.0",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",


### PR DESCRIPTION
### Motivation
- Ensure TypeScript recognizes imports from `dagre` used in the architecture explorer component. 
- Prevent type errors in `ui/partner-hub` when referencing `dagre` from TypeScript code. 

### Description
- Added `@types/dagre` to `devDependencies` in `ui/partner-hub/package.json`.
- No other source files were modified. 

### Testing
- Ran `npm install` in `ui/partner-hub`, which failed with `403 Forbidden` when fetching `dagre` from the registry so the lockfile could not be updated. 
- Ran `npm run build` in `ui/partner-hub`, which failed with `Module not found: Can't resolve 'dagre'` due to the dependency not being available in `node_modules` (install blocked by registry error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69611c3b75488326bce1dc7e8367bbf7)