### PR TITLE
Fix layered architecture lane layout spacing

### DIFF
--- a/ui/partner-hub/components/architecture-explorer/architecture-explorer.tsx
+++ b/ui/partner-hub/components/architecture-explorer/architecture-explorer.tsx
@@ -89,8 +89,8 @@ const resolvePack = (domain: Domain, selection: PackSelection): VendorPack | und
 
 const NODE_WIDTH = 190;
 const NODE_HEIGHT = 90;
-const LANE_SPACING = NODE_HEIGHT + 140;
-const LANE_OFFSET = 40;
+const CANVAS_HEIGHT = 420;
+const LANE_PADDING = NODE_HEIGHT / 2 + 20;
 const LAYOUT_STORAGE_KEY = "partner-hub:architecture-layout-mode";
 
 const getLane = (kind: NodeKind): number => {
@@ -123,6 +123,19 @@ const layoutNodes = (pack: VendorPack, layoutMode: LayoutMode): Node<ReactFlowNo
   const graph = new dagre.graphlib.Graph();
   graph.setDefaultEdgeLabel(() => ({}));
   const isLayered = layoutMode === "layered";
+  const maxLaneIndex = pack.spec.nodes.reduce((max, node) => {
+    const laneIndex = getLane(node.kind);
+    return Math.max(max, laneIndex);
+  }, 0);
+  const laneCount = maxLaneIndex + 1;
+  const availableLaneHeight = CANVAS_HEIGHT - LANE_PADDING * 2;
+  const laneSpacing = laneCount > 1 ? availableLaneHeight / (laneCount - 1) : 0;
+  const lanePositions = new Map<number, number>();
+
+  for (let laneIndex = 0; laneIndex < laneCount; laneIndex += 1) {
+    lanePositions.set(laneIndex, LANE_PADDING + laneIndex * laneSpacing);
+  }
+
   graph.setGraph({
     rankdir: "LR",
     nodesep: isLayered ? 70 : 60,
@@ -131,7 +144,7 @@ const layoutNodes = (pack: VendorPack, layoutMode: LayoutMode): Node<ReactFlowNo
 
   pack.spec.nodes.forEach((node) => {
     const laneIndex = getLane(node.kind);
-    const laneY = LANE_OFFSET + laneIndex * LANE_SPACING + NODE_HEIGHT / 2;
+    const laneY = lanePositions.get(laneIndex) ?? LANE_PADDING;
     graph.setNode(node.id, {
       width: NODE_WIDTH,
       height: NODE_HEIGHT,
@@ -149,9 +162,7 @@ const layoutNodes = (pack: VendorPack, layoutMode: LayoutMode): Node<ReactFlowNo
     const layout = graph.node(node.id) as { x: number; y: number };
     const laneIndex = getLane(node.kind);
     const positionX = layout.x;
-    const positionY = isLayered
-      ? LANE_OFFSET + laneIndex * LANE_SPACING + NODE_HEIGHT / 2
-      : layout.y;
+    const positionY = isLayered ? lanePositions.get(laneIndex) ?? LANE_PADDING : layout.y;
 
     return {
       id: node.id,


### PR DESCRIPTION
### Motivation
- Layered layout used hardcoded `LANE_SPACING` and `LANE_OFFSET` which could push lanes past the 420px canvas and hide nodes.
- Lane positions should be computed from the actual lanes present so all nodes remain visible in layered mode.
- The change should not alter the existing `flow` layout behavior.
- Ensure lanes are positioned inside the viewport with a top/bottom padding.

### Description
- Replaced fixed `LANE_SPACING`/`LANE_OFFSET` with `CANVAS_HEIGHT` and `LANE_PADDING` constants.
- Compute `maxLaneIndex`, `laneCount`, `availableLaneHeight`, and `laneSpacing` and populate a `lanePositions` map.
- Use `lanePositions` when setting dagre node `y` values and when computing final node `position.y` in layered mode.
- Left dagre configuration and `flow` mode unchanged so their layouts remain as before.

### Testing
- Ran `npm run build` at the repository root which failed because `package.json` was not found. (failed)
- Ran `npm run build` in `ui/partner-hub` which began the Next.js build but failed with a webpack error `Can't resolve 'dagre'`. (failed)
- No further automated tests were run because the build failure prevented verifying the `/tools/architecture-explorer` UI for specific packs. (blocked)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696120aee4d88326a6f194246452bb19)