### PR TITLE
Add rack unit metrics to energy tool

### DIFF
--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -506,10 +506,12 @@ export function EnergyTool() {
     const deltaW = fb.weightedW - selectedCandidate.weightedW;
     const deltaKwh = fb.kwhWithPue - selectedCandidate.kwhYearWithPue;
     const deltaCost = fb.annualCost - selectedCandidate.annualEnergyCost;
+    const deltaRackUnits = fb.rackUnits - selectedCandidate.rackUnits;
     return {
       deltaW,
       deltaKwh,
       deltaCost,
+      deltaRackUnits,
       pctCost: fb.annualCost > 0 ? (deltaCost / fb.annualCost) * 100 : null,
     };
   }, [fb, selectedCandidate]);
@@ -866,6 +868,7 @@ export function EnergyTool() {
                 <Metric label="kWh / year (with PUE)" value={fmt0.format(fb.kwhWithPue)} />
                 <Metric label="Annual energy cost" value={`$${fmt0.format(fb.annualCost)}`} />
                 <Metric label="BTU / hour" value={fmt0.format(fb.btuPerHour)} />
+                <Metric label="Rack units" value={fmt0.format(fb.rackUnits)} />
                 <div className="pt-2 text-xs text-foreground/60">
                   Composition: {fb.ecQty}×EC, {fb.exQty}×EX, {fb.xfmQty}×XFM
                 </div>
@@ -897,6 +900,7 @@ export function EnergyTool() {
                             <tr>
                               <th className="py-2 pr-3 font-semibold">Controller</th>
                               <th className="py-2 pr-3 font-semibold">Exp shelves</th>
+                              <th className="py-2 pr-3 font-semibold">RU</th>
                               <th className="py-2 pr-3 font-semibold">Eff TB</th>
                               <th className="py-2 pr-3 font-semibold">Δ vs target</th>
                               <th className="py-2 pr-3 font-semibold">Annual $</th>
@@ -938,6 +942,7 @@ export function EnergyTool() {
                                     </div>
                                   </td>
                                   <td className="py-2 pr-3">{c.expansionQty}</td>
+                                  <td className="py-2 pr-3">{fmt0.format(c.rackUnits)}</td>
                                   <td className="py-2 pr-3">{fmt0.format(c.effectiveTb)}</td>
                                   <td className="py-2 pr-3">{fmt2.format(c.pctDiffFromTarget)}%</td>
                                   <td className="py-2 pr-3">${fmt0.format(c.annualEnergyCost)}</td>
@@ -982,6 +987,7 @@ export function EnergyTool() {
                       ["Weighted IT load (W)", fmt0.format(fb.weightedW)],
                       ["kWh / year (with PUE)", fmt0.format(fb.kwhWithPue)],
                       ["Annual energy cost", `$${fmt0.format(fb.annualCost)}`],
+                      ["Rack units", fmt0.format(fb.rackUnits)],
                     ]}
                   />
                   <MiniCompare
@@ -991,6 +997,7 @@ export function EnergyTool() {
                       ["Weighted IT load (W)", fmt0.format(selectedCandidate.weightedW)],
                       ["kWh / year (with PUE)", fmt0.format(selectedCandidate.kwhYearWithPue)],
                       ["Annual energy cost", `$${fmt0.format(selectedCandidate.annualEnergyCost)}`],
+                      ["Rack units", fmt0.format(selectedCandidate.rackUnits)],
                     ]}
                   />
                   <MiniCompare
@@ -1000,6 +1007,7 @@ export function EnergyTool() {
                       ["Δ kWh / year", fmt0.format(savings?.deltaKwh ?? 0)],
                       ["Δ annual cost", `$${fmt0.format(savings?.deltaCost ?? 0)}`],
                       ["Δ cost %", savings?.pctCost == null ? "—" : `${fmt1.format(savings.pctCost)}%`],
+                      ["Δ rack units", fmt0.format(savings?.deltaRackUnits ?? 0)],
                     ]}
                   />
                 </div>

--- a/ui/partner-hub/lib/energy/energy-calc.ts
+++ b/ui/partner-hub/lib/energy/energy-calc.ts
@@ -20,6 +20,7 @@ export type PureRow = CsvRow & {
   Min_EX_Chassis: number;
   Min_XFMs: number;
   Max_Total_Chassis: number;
+  Rack_Units: number;
 };
 
 export type NetAppRow = CsvRow & {
@@ -33,6 +34,7 @@ export type PowerModel = {
   model: string;
   typicalW: number;
   idleW: number;
+  rackUnits: number;
   weightedW: (util: number) => number;
 };
 
@@ -58,6 +60,7 @@ export function loadPure(rows: CsvRow[]): PureRow[] {
       Min_EX_Chassis: toInt(r.Min_EX_Chassis, 1),
       Min_XFMs: toInt(r.Min_XFMs, 2),
       Max_Total_Chassis: toInt(r.Max_Total_Chassis, 999),
+      Rack_Units: toFloat(r.Rack_Units),
     };
     return out;
   });
@@ -124,6 +127,7 @@ function compPower(pureRows: PureRow[], dfmTb: number, nameContains: string): Po
     model: String(r.Model ?? ""),
     typicalW: r.Typical_W,
     idleW: r.Idle_W,
+    rackUnits: r.Rack_Units,
     weightedW: (util) => r.Idle_W + util * (r.Typical_W - r.Idle_W),
   };
 }
@@ -143,6 +147,7 @@ export type FbPowerResult = {
   annualCost: number;
   btuPerHour: number;
   effectiveTb: number;
+  rackUnits: number;
   components: {
     EC: { qty: number; model: string; idleWPer: number; typicalWPer: number; weightedWPer: number };
     EX: { qty: number; model: string; idleWPer: number; typicalWPer: number; weightedWPer: number };
@@ -168,6 +173,7 @@ export function fbPower(
   const kwhIt = kwhYear(w);
   const kwhWithPue = kwhIt * pue;
   const annualCost = kwhWithPue * price;
+  const rackUnits = ecQty * ecP.rackUnits + exQty * exP.rackUnits + xfmQty * xfmP.rackUnits;
 
   return {
     dfmTb,
@@ -181,6 +187,7 @@ export function fbPower(
     annualCost,
     btuPerHour: btuPerHour(w),
     effectiveTb: capacityPb * 1000 * drr,
+    rackUnits,
     components: {
       EC: {
         qty: ecQty,
@@ -213,6 +220,7 @@ export type NetAppCandidate = {
   controllerQty: number;
   expansionQty: number;
   effectiveTb: number;
+  rackUnits: number;
   pctDiffFromTarget: number;
   weightedW: number;
   kwhYearWithPue: number;
@@ -227,6 +235,7 @@ type NetAppShelfPower = {
   typicalW: number;
   idleW: number;
   drives: number;
+  rackUnits: number;
   weightedW: (util: number) => number;
 };
 
@@ -241,6 +250,7 @@ function getExpansionShelf(netappRows: NetAppRow[]): NetAppShelfPower {
     typicalW: exp.Typical_W,
     idleW: exp.Idle_W,
     drives: toInt(exp.Drives_per_unit),
+    rackUnits: exp.Rack_Units,
     weightedW: (u: number) => exp.Idle_W + u * (exp.Typical_W - exp.Idle_W),
   };
 }
@@ -257,6 +267,7 @@ function getExpansionShelfByModel(netappRows: NetAppRow[], expansionModel: strin
     typicalW: exp.Typical_W,
     idleW: exp.Idle_W,
     drives: toInt(exp.Drives_per_unit),
+    rackUnits: exp.Rack_Units,
     weightedW: (u: number) => exp.Idle_W + u * (exp.Typical_W - exp.Idle_W),
   };
 }
@@ -298,6 +309,7 @@ export function buildNetAppCandidate(
   const w = ctrlWeighted(util) + expansionQty * exp.weightedW(util);
   const kwhPue = kwhYear(w) * pue;
   const annual = kwhPue * price;
+  const rackUnits = ctrl.Rack_Units + expansionQty * exp.rackUnits;
 
   return {
     controllerModel,
@@ -305,6 +317,7 @@ export function buildNetAppCandidate(
     controllerQty: 1,
     expansionQty,
     effectiveTb: eff,
+    rackUnits,
     pctDiffFromTarget: 0,
     weightedW: w,
     kwhYearWithPue: kwhPue,
@@ -347,6 +360,7 @@ export function enumerateNetApp(
       const kwhPue = kwhYear(w) * pue;
       const annual = kwhPue * price;
       const pct = targetEffTb > 0 ? ((eff - targetEffTb) / targetEffTb) * 100 : 0;
+      const rackUnits = ctrl.Rack_Units + expQty * exp.rackUnits;
 
       if (Math.abs(pct) <= tolFrac * 100 + 1e-9) {
         out.push({
@@ -355,6 +369,7 @@ export function enumerateNetApp(
           controllerQty: 1,
           expansionQty: expQty,
           effectiveTb: eff,
+          rackUnits,
           pctDiffFromTarget: pct,
           weightedW: w,
           kwhYearWithPue: kwhPue,


### PR DESCRIPTION
### Motivation

- Add end-to-end Rack Units (RU) support so RU is parsed from vendor CSVs, included in energy calculations, and surfaced in the UI totals and comparisons.
- Provide RU totals for FlashBlade configurations and RU for NetApp candidates to allow side-by-side RU comparison and Δ RU reporting.
- Keep existing power/kWh/$/BTU behavior unchanged while extending types and results to carry RU.

### Description

- Parse and propagate RU from CSVs and types in `ui/partner-hub/lib/energy/energy-calc.ts` by adding `Rack_Units` to `PureRow` and reading it in `loadPure`, and adding `rackUnits` to `PowerModel` populated by `compPower`.
- Compute FlashBlade RU in `fbPower` (`FbPowerResult.rackUnits = ecQty*EC_RU + exQty*EX_RU + xfmQty*XFM_RU`) and include it in the returned result.
- Extend NetApp candidate calculations by adding `rackUnits` to `NetAppCandidate`, adding `rackUnits` to `NetAppShelfPower`, and computing `rackUnits = ctrl.Rack_Units + expansionQty * exp.rackUnits` in `buildNetAppCandidate` and `enumerateNetApp`.
- Surface RU in the UI (`ui/partner-hub/components/energy/energy-tool.tsx`) by adding a `Rack units` metric to FlashBlade totals, an `RU` column to the NetApp candidates table, and RU plus `Δ rack units` to the side-by-side comparison (formatted with existing `fmt0`).

### Testing

- Attempted to install UI dependencies with `npm --prefix ui/partner-hub install`, but the install failed with a 403 from the npm registry so no build/test run was completed.
- No automated TypeScript build or test suite was executed after the change due to the dependency install failure.
- Manual/workflow smoke checks were not run as part of this automated change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69619f561c508326a541ace791772b53)