### PR TITLE
Handle missing Rack_Units (RU): surface as “—”, propagate through calc/UI, and add tests

### DIFF
--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -28,6 +28,7 @@ import {
 const fmt0 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
 const fmt1 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
 const fmt2 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 });
+const formatRackUnits = (value: number | null | undefined) => (value == null ? "—" : fmt0.format(value));
 
 type EnergyMeta = {
   lastSyncedISO?: string;
@@ -506,7 +507,10 @@ export function EnergyTool() {
     const deltaW = fb.weightedW - selectedCandidate.weightedW;
     const deltaKwh = fb.kwhWithPue - selectedCandidate.kwhYearWithPue;
     const deltaCost = fb.annualCost - selectedCandidate.annualEnergyCost;
-    const deltaRackUnits = fb.rackUnits - selectedCandidate.rackUnits;
+    const deltaRackUnits =
+      fb.rackUnits != null && selectedCandidate.rackUnits != null
+        ? fb.rackUnits - selectedCandidate.rackUnits
+        : null;
     return {
       deltaW,
       deltaKwh,
@@ -546,6 +550,18 @@ export function EnergyTool() {
             expansionModel: selectedCandidate.expansionModel,
             expansionShelves: selectedCandidate.expansionQty,
             driveSizeTb: inputs.naDriveSizeTb,
+            rackUnits: selectedCandidate.rackUnits ?? null,
+          }
+        : null,
+      results: fb
+        ? {
+            flashblade: {
+              rackUnits: fb.rackUnits ?? null,
+            },
+            netapp: selectedCandidate ? { rackUnits: selectedCandidate.rackUnits ?? null } : null,
+            delta: {
+              rackUnits: savings?.deltaRackUnits ?? null,
+            },
           }
         : null,
       sources: sourceList.map((item) => (item.type === "link" ? item.url : item.label)),
@@ -579,6 +595,13 @@ export function EnergyTool() {
         ["OK", vendorReport.ok],
       ]
     : [];
+
+  const hasMissingRackUnits = useMemo(() => {
+    if (fb?.rackUnits == null) return true;
+    if (selectedCandidate?.rackUnits == null) return true;
+    if (mode === "auto" && candidates.some((candidate) => candidate.rackUnits == null)) return true;
+    return false;
+  }, [candidates, fb?.rackUnits, mode, selectedCandidate?.rackUnits]);
 
   return (
     <div className="space-y-6">
@@ -868,10 +891,15 @@ export function EnergyTool() {
                 <Metric label="kWh / year (with PUE)" value={fmt0.format(fb.kwhWithPue)} />
                 <Metric label="Annual energy cost" value={`$${fmt0.format(fb.annualCost)}`} />
                 <Metric label="BTU / hour" value={fmt0.format(fb.btuPerHour)} />
-                <Metric label="Rack units" value={fmt0.format(fb.rackUnits)} />
+                <Metric label="Total rack units" value={formatRackUnits(fb.rackUnits)} />
                 <div className="pt-2 text-xs text-foreground/60">
                   Composition: {fb.ecQty}×EC, {fb.exQty}×EX, {fb.xfmQty}×XFM
                 </div>
+                {hasMissingRackUnits ? (
+                  <div className="text-xs text-foreground/60">
+                    Rack unit data is missing for one or more rows; values are shown as —.
+                  </div>
+                ) : null}
               </CardContent>
             </Card>
 
@@ -900,7 +928,7 @@ export function EnergyTool() {
                             <tr>
                               <th className="py-2 pr-3 font-semibold">Controller</th>
                               <th className="py-2 pr-3 font-semibold">Exp shelves</th>
-                              <th className="py-2 pr-3 font-semibold">RU</th>
+                              <th className="py-2 pr-3 font-semibold whitespace-nowrap">Total RU</th>
                               <th className="py-2 pr-3 font-semibold">Eff TB</th>
                               <th className="py-2 pr-3 font-semibold">Δ vs target</th>
                               <th className="py-2 pr-3 font-semibold">Annual $</th>
@@ -942,7 +970,7 @@ export function EnergyTool() {
                                     </div>
                                   </td>
                                   <td className="py-2 pr-3">{c.expansionQty}</td>
-                                  <td className="py-2 pr-3">{fmt0.format(c.rackUnits)}</td>
+                                  <td className="py-2 pr-3">{formatRackUnits(c.rackUnits)}</td>
                                   <td className="py-2 pr-3">{fmt0.format(c.effectiveTb)}</td>
                                   <td className="py-2 pr-3">{fmt2.format(c.pctDiffFromTarget)}%</td>
                                   <td className="py-2 pr-3">${fmt0.format(c.annualEnergyCost)}</td>
@@ -987,7 +1015,7 @@ export function EnergyTool() {
                       ["Weighted IT load (W)", fmt0.format(fb.weightedW)],
                       ["kWh / year (with PUE)", fmt0.format(fb.kwhWithPue)],
                       ["Annual energy cost", `$${fmt0.format(fb.annualCost)}`],
-                      ["Rack units", fmt0.format(fb.rackUnits)],
+                      ["Total rack units", formatRackUnits(fb.rackUnits)],
                     ]}
                   />
                   <MiniCompare
@@ -997,7 +1025,7 @@ export function EnergyTool() {
                       ["Weighted IT load (W)", fmt0.format(selectedCandidate.weightedW)],
                       ["kWh / year (with PUE)", fmt0.format(selectedCandidate.kwhYearWithPue)],
                       ["Annual energy cost", `$${fmt0.format(selectedCandidate.annualEnergyCost)}`],
-                      ["Rack units", fmt0.format(selectedCandidate.rackUnits)],
+                      ["Total rack units", formatRackUnits(selectedCandidate.rackUnits)],
                     ]}
                   />
                   <MiniCompare
@@ -1007,7 +1035,7 @@ export function EnergyTool() {
                       ["Δ kWh / year", fmt0.format(savings?.deltaKwh ?? 0)],
                       ["Δ annual cost", `$${fmt0.format(savings?.deltaCost ?? 0)}`],
                       ["Δ cost %", savings?.pctCost == null ? "—" : `${fmt1.format(savings.pctCost)}%`],
-                      ["Δ rack units", fmt0.format(savings?.deltaRackUnits ?? 0)],
+                      ["Δ rack units", savings?.deltaRackUnits == null ? "—" : fmt0.format(savings.deltaRackUnits)],
                     ]}
                   />
                 </div>

--- a/ui/partner-hub/lib/energy/energy-calc.test.ts
+++ b/ui/partner-hub/lib/energy/energy-calc.test.ts
@@ -1,0 +1,114 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+
+import { buildNetAppCandidate, enumerateNetApp, fbPower, type NetAppRow, type PureRow } from "./energy-calc";
+
+const makePureRows = (): PureRow[] => [
+  {
+    Model: "FB EC chassis 1",
+    DFM_Size_TB: 48,
+    Typical_W: 100,
+    Idle_W: 50,
+    Min_Usable_PB: 4,
+    Capacity_Increment_PB: 1,
+    Min_EC_Chassis: 2,
+    Min_EX_Chassis: 1,
+    Min_XFMs: 2,
+    Max_Total_Chassis: 10,
+    Rack_Units: 7,
+  },
+  {
+    Model: "FB EX chassis 1",
+    DFM_Size_TB: 48,
+    Typical_W: 80,
+    Idle_W: 40,
+    Min_Usable_PB: 4,
+    Capacity_Increment_PB: 1,
+    Min_EC_Chassis: 2,
+    Min_EX_Chassis: 1,
+    Min_XFMs: 2,
+    Max_Total_Chassis: 10,
+    Rack_Units: 4,
+  },
+  {
+    Model: "FB XFM",
+    DFM_Size_TB: 48,
+    Typical_W: 20,
+    Idle_W: 10,
+    Min_Usable_PB: 4,
+    Capacity_Increment_PB: 1,
+    Min_EC_Chassis: 2,
+    Min_EX_Chassis: 1,
+    Min_XFMs: 2,
+    Max_Total_Chassis: 10,
+    Rack_Units: 2,
+  },
+];
+
+const makeNetAppRows = (): NetAppRow[] => [
+  {
+    Component_Type: "Controller_Shelf",
+    Model: "C1",
+    Typical_W: 200,
+    Idle_W: 100,
+    Drives_per_unit: 24,
+    Rack_Units: 4,
+  },
+  {
+    Component_Type: "Expansion_Shelf",
+    Model: "DE460C 60-bay",
+    Typical_W: 150,
+    Idle_W: 75,
+    Drives_per_unit: 60,
+    Rack_Units: 4,
+  },
+];
+
+describe("fbPower", () => {
+  it("computes rack units and preserves energy outputs", () => {
+    const result = fbPower(makePureRows(), 48, 5, 0.5, 1.2, 0.1, 2);
+
+    assert.equal(result.ecQty, 2);
+    assert.equal(result.exQty, 2);
+    assert.equal(result.xfmQty, 2);
+    assert.equal(result.rackUnits, 26);
+    assert.ok(Math.abs(result.weightedW - 300) < 1e-6);
+    assert.ok(Math.abs(result.kwhIt - 2628) < 1e-6);
+    assert.ok(Math.abs(result.kwhWithPue - 3153.6) < 1e-6);
+    assert.ok(Math.abs(result.annualCost - 315.36) < 1e-6);
+    assert.ok(Math.abs(result.btuPerHour - 1023.6) < 1e-6);
+    assert.ok(Math.abs(result.effectiveTb - 10000) < 1e-6);
+  });
+
+  it("returns null rack units when any component is missing RU", () => {
+    const rows = makePureRows();
+    rows[2] = { ...rows[2], Rack_Units: null };
+    const result = fbPower(rows, 48, 5, 0.5, 1.2, 0.1, 2);
+    assert.equal(result.rackUnits, null);
+    assert.ok(Math.abs(result.weightedW - 300) < 1e-6);
+  });
+});
+
+describe("NetApp candidates", () => {
+  it("computes rack units in buildNetAppCandidate", () => {
+    const candidate = buildNetAppCandidate(makeNetAppRows(), "C1", "DE460C 60-bay", 2, 0.5, 1.2, 0.1, 0.2, 1.3, 18);
+
+    assert.equal(candidate.rackUnits, 12);
+    assert.ok(Math.abs(candidate.weightedW - 375) < 1e-6);
+    assert.ok(Math.abs(candidate.kwhYearWithPue - 3942) < 1e-6);
+    assert.ok(Math.abs(candidate.annualEnergyCost - 394.2) < 1e-6);
+    assert.ok(Math.abs(candidate.effectiveTb - 2695.68) < 1e-6);
+  });
+
+  it("computes rack units in enumerateNetApp", () => {
+    const targetEffTb = 2695.68;
+    const candidates = enumerateNetApp(makeNetAppRows(), targetEffTb, 0.5, 1.2, 0.1, 0.2, 1.3, 18, 0.5);
+    const match = candidates.find((candidate) => candidate.expansionQty === 2);
+
+    assert.ok(match);
+    assert.equal(match?.rackUnits, 12);
+    assert.ok(Math.abs((match?.weightedW ?? 0) - 375) < 1e-6);
+    assert.ok(Math.abs((match?.kwhYearWithPue ?? 0) - 3942) < 1e-6);
+    assert.ok(Math.abs((match?.annualEnergyCost ?? 0) - 394.2) < 1e-6);
+  });
+});

--- a/ui/partner-hub/lib/energy/energy-calc.ts
+++ b/ui/partner-hub/lib/energy/energy-calc.ts
@@ -5,6 +5,13 @@ const toFloat = (v: unknown, fallback = 0) => {
   return Number.isFinite(n) ? n : fallback;
 };
 
+const toOptionalFloat = (v: unknown): number | null => {
+  if (v == null) return null;
+  if (typeof v === "string" && v.trim() === "") return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+};
+
 const toInt = (v: unknown, fallback = 0) => {
   const n = Math.trunc(Number(v));
   return Number.isFinite(n) ? n : fallback;
@@ -20,21 +27,21 @@ export type PureRow = CsvRow & {
   Min_EX_Chassis: number;
   Min_XFMs: number;
   Max_Total_Chassis: number;
-  Rack_Units: number;
+  Rack_Units: number | null;
 };
 
 export type NetAppRow = CsvRow & {
   Typical_W: number;
   Idle_W: number;
   Drives_per_unit: number;
-  Rack_Units: number;
+  Rack_Units: number | null;
 };
 
 export type PowerModel = {
   model: string;
   typicalW: number;
   idleW: number;
-  rackUnits: number;
+  rackUnits: number | null;
   weightedW: (util: number) => number;
 };
 
@@ -60,7 +67,7 @@ export function loadPure(rows: CsvRow[]): PureRow[] {
       Min_EX_Chassis: toInt(r.Min_EX_Chassis, 1),
       Min_XFMs: toInt(r.Min_XFMs, 2),
       Max_Total_Chassis: toInt(r.Max_Total_Chassis, 999),
-      Rack_Units: toFloat(r.Rack_Units),
+      Rack_Units: toOptionalFloat(r.Rack_Units),
     };
     return out;
   });
@@ -73,7 +80,7 @@ export function loadNetApp(rows: CsvRow[]): NetAppRow[] {
       Typical_W: toFloat(r.Typical_W),
       Idle_W: toFloat(r.Idle_W),
       Drives_per_unit: toFloat(r.Drives_per_unit),
-      Rack_Units: toFloat(r.Rack_Units),
+      Rack_Units: toOptionalFloat(r.Rack_Units),
     };
     return out;
   });
@@ -147,7 +154,7 @@ export type FbPowerResult = {
   annualCost: number;
   btuPerHour: number;
   effectiveTb: number;
-  rackUnits: number;
+  rackUnits: number | null;
   components: {
     EC: { qty: number; model: string; idleWPer: number; typicalWPer: number; weightedWPer: number };
     EX: { qty: number; model: string; idleWPer: number; typicalWPer: number; weightedWPer: number };
@@ -173,7 +180,10 @@ export function fbPower(
   const kwhIt = kwhYear(w);
   const kwhWithPue = kwhIt * pue;
   const annualCost = kwhWithPue * price;
-  const rackUnits = ecQty * ecP.rackUnits + exQty * exP.rackUnits + xfmQty * xfmP.rackUnits;
+  const rackUnits =
+    ecP.rackUnits != null && exP.rackUnits != null && xfmP.rackUnits != null
+      ? ecQty * ecP.rackUnits + exQty * exP.rackUnits + xfmQty * xfmP.rackUnits
+      : null;
 
   return {
     dfmTb,
@@ -220,7 +230,7 @@ export type NetAppCandidate = {
   controllerQty: number;
   expansionQty: number;
   effectiveTb: number;
-  rackUnits: number;
+  rackUnits: number | null;
   pctDiffFromTarget: number;
   weightedW: number;
   kwhYearWithPue: number;
@@ -235,7 +245,7 @@ type NetAppShelfPower = {
   typicalW: number;
   idleW: number;
   drives: number;
-  rackUnits: number;
+  rackUnits: number | null;
   weightedW: (util: number) => number;
 };
 
@@ -309,7 +319,8 @@ export function buildNetAppCandidate(
   const w = ctrlWeighted(util) + expansionQty * exp.weightedW(util);
   const kwhPue = kwhYear(w) * pue;
   const annual = kwhPue * price;
-  const rackUnits = ctrl.Rack_Units + expansionQty * exp.rackUnits;
+  const rackUnits =
+    ctrl.Rack_Units != null && exp.rackUnits != null ? ctrl.Rack_Units + expansionQty * exp.rackUnits : null;
 
   return {
     controllerModel,
@@ -360,7 +371,8 @@ export function enumerateNetApp(
       const kwhPue = kwhYear(w) * pue;
       const annual = kwhPue * price;
       const pct = targetEffTb > 0 ? ((eff - targetEffTb) / targetEffTb) * 100 : 0;
-      const rackUnits = ctrl.Rack_Units + expQty * exp.rackUnits;
+      const rackUnits =
+        ctrl.Rack_Units != null && exp.rackUnits != null ? ctrl.Rack_Units + expQty * exp.rackUnits : null;
 
       if (Math.abs(pct) <= tolFrac * 100 + 1e-9) {
         out.push({

--- a/ui/partner-hub/package.json
+++ b/ui/partner-hub/package.json
@@ -7,6 +7,7 @@
         "build": "node scripts/sync-energy-data.mjs && next build && node scripts/post-export.mjs",
         "start": "next start",
         "lint": "next lint",
+        "test": "tsc --noEmit false --module commonjs --moduleResolution node --target ES2020 --outDir .tmp-tests lib/energy/energy-calc.ts lib/energy/energy-calc.test.ts && node --test .tmp-tests/energy-calc.test.js",
         "build:export": "node scripts/sync-energy-data.mjs && next build && node scripts/post-export.mjs"
     },
     "dependencies": {


### PR DESCRIPTION
### Motivation

- Ensure Rack Units (RU) are always represented in the calculator and UI and avoid silently treating missing CSV RU values as 0.  
- Make RU visible and unambiguous across totals, candidate lists, comparisons and delta so capacity planning is clearer.  
- Keep existing energy formulas and numeric outputs unchanged while adding RU as an additional result/metric.  

### Description

- Treat CSV `Rack_Units` as optional by adding `toOptionalFloat` and changing `Rack_Units`/`PowerModel.rackUnits`/result fields to `number | null` in `ui/partner-hub/lib/energy/energy-calc.ts`.  
- Compute `FbPowerResult.rackUnits` as null if any component RU is missing and compute NetApp candidate `rackUnits` as null when controller or expansion RU is missing, preserving all existing power/energy calculations.  
- UI changes in `ui/partner-hub/components/energy/energy-tool.tsx` include `formatRackUnits` to show missing RU as `—`, relabel RU to `Total RU` (table header, totals card, comparison), show a small warning when RU data is incomplete, and include RU values in the `assumptions.json` export.  
- Added calculator unit tests in `ui/partner-hub/lib/energy/energy-calc.test.ts` (Node test runner) and a `test` script in `package.json` that compiles via `tsc` then runs the tests.  

### Testing

- Ran `npm test` (compiles with `tsc` then executes the Node tests) and all tests passed (4 assertions across fbPower, buildNetAppCandidate, enumerateNetApp).  
- Type-checking of the modified calculator and tests was performed via `tsc` as part of the test run and succeeded.  
- Started the Next.js dev server (`npm run dev`) to verify the app boots in the development environment.  
- Attempted an automated UI screenshot with Playwright but Chromium crashed in this environment, so visual verification was limited to manual dev-server checks described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6961a15280f0832683196548b7402f7d)