### PR TITLE
Harden rack unit handling in energy tool

### DIFF
--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -596,12 +596,12 @@ export function EnergyTool() {
       ]
     : [];
 
-  const hasMissingRackUnits = useMemo(() => {
-    if (fb?.rackUnits == null) return true;
-    if (selectedCandidate?.rackUnits == null) return true;
-    if (mode === "auto" && candidates.some((candidate) => candidate.rackUnits == null)) return true;
-    return false;
-  }, [candidates, fb?.rackUnits, mode, selectedCandidate?.rackUnits]);
+  const fbRackUnitsMissing = fb?.rackUnits == null;
+  const selectedRackUnitsMissing = selectedCandidate?.rackUnits == null;
+  const candidateTableRackUnitsMissing = useMemo(
+    () => mode === "auto" && candidates.slice(0, 8).some((candidate) => candidate.rackUnits == null),
+    [candidates, mode],
+  );
 
   return (
     <div className="space-y-6">
@@ -895,11 +895,6 @@ export function EnergyTool() {
                 <div className="pt-2 text-xs text-foreground/60">
                   Composition: {fb.ecQty}×EC, {fb.exQty}×EX, {fb.xfmQty}×XFM
                 </div>
-                {hasMissingRackUnits ? (
-                  <div className="text-xs text-foreground/60">
-                    Rack unit data is missing for one or more rows; values are shown as —.
-                  </div>
-                ) : null}
               </CardContent>
             </Card>
 
@@ -928,7 +923,7 @@ export function EnergyTool() {
                             <tr>
                               <th className="py-2 pr-3 font-semibold">Controller</th>
                               <th className="py-2 pr-3 font-semibold">Exp shelves</th>
-                              <th className="py-2 pr-3 font-semibold whitespace-nowrap">Total RU</th>
+                              <th className="py-2 pr-3 font-semibold whitespace-nowrap">Total rack units</th>
                               <th className="py-2 pr-3 font-semibold">Eff TB</th>
                               <th className="py-2 pr-3 font-semibold">Δ vs target</th>
                               <th className="py-2 pr-3 font-semibold">Annual $</th>
@@ -983,6 +978,11 @@ export function EnergyTool() {
                         <p className="mt-2 text-[11px] text-foreground/60">
                           Click a NetApp row to see a side-by-side comparison.
                         </p>
+                        {candidateTableRackUnitsMissing ? (
+                          <p className="mt-1 text-[11px] text-foreground/60">
+                            Some candidate rows are missing rack unit data, so totals display as —.
+                          </p>
+                        ) : null}
                       </div>
                     )}
                   </>
@@ -994,6 +994,11 @@ export function EnergyTool() {
               </CardContent>
             </Card>
           </div>
+          {fbRackUnitsMissing || selectedRackUnitsMissing ? (
+            <p className="text-xs text-foreground/60">
+              Rack unit data is missing for one or more selected rows, so totals display as —.
+            </p>
+          ) : null}
 
           <Card>
             <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">

--- a/ui/partner-hub/lib/energy/energy-calc.test.ts
+++ b/ui/partner-hub/lib/energy/energy-calc.test.ts
@@ -72,10 +72,20 @@ describe("fbPower", () => {
     assert.equal(result.exQty, 2);
     assert.equal(result.xfmQty, 2);
     assert.equal(result.rackUnits, 26);
-    assert.ok(Math.abs(result.weightedW - 300) < 1e-6);
-    assert.ok(Math.abs(result.kwhIt - 2628) < 1e-6);
-    assert.ok(Math.abs(result.kwhWithPue - 3153.6) < 1e-6);
-    assert.ok(Math.abs(result.annualCost - 315.36) < 1e-6);
+    assert.deepEqual(
+      {
+        weightedW: result.weightedW,
+        kwhIt: result.kwhIt,
+        kwhWithPue: result.kwhWithPue,
+        annualCost: result.annualCost,
+      },
+      {
+        weightedW: 300,
+        kwhIt: 2628,
+        kwhWithPue: 3153.6,
+        annualCost: 315.36,
+      },
+    );
     assert.ok(Math.abs(result.btuPerHour - 1023.6) < 1e-6);
     assert.ok(Math.abs(result.effectiveTb - 10000) < 1e-6);
   });
@@ -98,6 +108,14 @@ describe("NetApp candidates", () => {
     assert.ok(Math.abs(candidate.kwhYearWithPue - 3942) < 1e-6);
     assert.ok(Math.abs(candidate.annualEnergyCost - 394.2) < 1e-6);
     assert.ok(Math.abs(candidate.effectiveTb - 2695.68) < 1e-6);
+  });
+
+  it("returns null rack units when any NetApp RU input is missing", () => {
+    const rows = makeNetAppRows();
+    rows[0] = { ...rows[0], Rack_Units: null };
+    const candidate = buildNetAppCandidate(rows, "C1", "DE460C 60-bay", 2, 0.5, 1.2, 0.1, 0.2, 1.3, 18);
+    assert.equal(candidate.rackUnits, null);
+    assert.ok(Math.abs(candidate.weightedW - 375) < 1e-6);
   });
 
   it("computes rack units in enumerateNetApp", () => {

--- a/ui/partner-hub/lib/energy/energy-calc.ts
+++ b/ui/partner-hub/lib/energy/energy-calc.ts
@@ -67,6 +67,7 @@ export function loadPure(rows: CsvRow[]): PureRow[] {
       Min_EX_Chassis: toInt(r.Min_EX_Chassis, 1),
       Min_XFMs: toInt(r.Min_XFMs, 2),
       Max_Total_Chassis: toInt(r.Max_Total_Chassis, 999),
+      // Rack_Units is optional in source CSVs; keep null so the UI shows — and can warn intentionally.
       Rack_Units: toOptionalFloat(r.Rack_Units),
     };
     return out;
@@ -80,6 +81,7 @@ export function loadNetApp(rows: CsvRow[]): NetAppRow[] {
       Typical_W: toFloat(r.Typical_W),
       Idle_W: toFloat(r.Idle_W),
       Drives_per_unit: toFloat(r.Drives_per_unit),
+      // Rack_Units is optional in source CSVs; keep null so the UI shows — and can warn intentionally.
       Rack_Units: toOptionalFloat(r.Rack_Units),
     };
     return out;
@@ -250,6 +252,7 @@ type NetAppShelfPower = {
 };
 
 function getExpansionShelf(netappRows: NetAppRow[]): NetAppShelfPower {
+  // Auto-mode assumes DE460C expansion shelves for enumeration; update here if supported shelves expand.
   const expRows = netappRows.filter(
     (r) => r.Component_Type === "Expansion_Shelf" && String(r.Model ?? "").includes("DE460C"),
   );


### PR DESCRIPTION
### Motivation

- Make handling of missing `Rack_Units` in source CSVs explicit and intentional so the UI shows `—` rather than silently misreporting or crashing.  
- Avoid noisy or false-positive RU warnings in the totals/candidates UI while still surfacing meaningful missing-data notices.  
- Ensure RU is present and consistently named wherever a “selected candidate” payload/result is emitted or displayed.  
- Clarify auto-mode assumptions (DE460C expansion shelf) so the enumeration behavior is obvious and maintainable.

### Description

- Documented that `Rack_Units` is optional in CSV loaders by returning `null` via `toOptionalFloat` in `loadPure` and `loadNetApp` so the UI deliberately shows `—` for missing RU.  
- Added an inline comment to `getExpansionShelf` noting that auto-mode assumes `DE460C` expansion shelves and where to update the logic if other shelves are supported.  
- Tightened UI logic in `energy-tool.tsx` to show rack-unit warnings only where they matter, normalized the label to `Total rack units` (was `Total RU`/`Total RU`), and added targeted messages near the candidate table and totals card.  
- Extended `ui/partner-hub/lib/energy/energy-calc.test.ts` with a snapshot-style assertion that groups prior energy outputs and added a test that asserts NetApp candidates return `null` RU when required RU inputs are missing.

### Testing

- Added unit tests in `ui/partner-hub/lib/energy/energy-calc.test.ts` covering RU-null behavior and snapshot-style checks for energy outputs.  
- Attempted to run the tests via `node --test ui/partner-hub/lib/energy/energy-calc.test.ts`, but execution failed in this environment due to module resolution/ESM import issues, so the test run could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6961a4cbd104832696a2c4f68c5b827f)