### PR TITLE
Fix CO₂e per‑TB null guards in energy-tool.tsx

### DIFF
--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -537,9 +537,12 @@ export function EnergyTool() {
 
   const fbCo2eKgPerYear = fb ? fb.kwhWithPue * gridKgCo2ePerKwh : null;
   const netappCo2eKgPerYear = selectedCandidate ? selectedCandidate.kwhYearWithPue * gridKgCo2ePerKwh : null;
-  const fbCo2ePerTbYear = fb && fb.effectiveTb > 0 ? fbCo2eKgPerYear / fb.effectiveTb : null;
+  const fbCo2ePerTbYear =
+    fb != null && fbCo2eKgPerYear != null && fb.effectiveTb > 0 ? fbCo2eKgPerYear / fb.effectiveTb : null;
   const netappCo2ePerTbYear =
-    selectedCandidate && selectedCandidate.effectiveTb > 0 ? netappCo2eKgPerYear / selectedCandidate.effectiveTb : null;
+    selectedCandidate != null && netappCo2eKgPerYear != null && selectedCandidate.effectiveTb > 0
+      ? netappCo2eKgPerYear / selectedCandidate.effectiveTb
+      : null;
   const deltaCo2eKgPerYear =
     fbCo2eKgPerYear != null && netappCo2eKgPerYear != null ? fbCo2eKgPerYear - netappCo2eKgPerYear : null;
   const deltaCo2ePerTbYear =


### PR DESCRIPTION
### Motivation
- Remove a build-breaking TypeScript error by making per‑TB CO₂e calculations provably non‑null to the compiler. 
- Ensure `fbCo2eKgPerYear` / `netappCo2eKgPerYear` and their parent objects cannot cause a nullable access error in the CO₂e per‑TB calculation block. 
- Fix the class of errors reported (`fb` / `fbCo2eKgPerYear` possibly `null`, and ensure no misspelling of `gridKgCo2ePerKwh`) while keeping runtime behavior identical. 
- Make a minimal in‑place change with no TS disables or `as any` casts.

### Description
- Updated the `fbCo2ePerTbYear` guard to `fb != null && fbCo2eKgPerYear != null && fb.effectiveTb > 0` so TypeScript can prove non‑null before division. 
- Updated the NetApp per‑TB guard to `selectedCandidate != null && netappCo2eKgPerYear != null && selectedCandidate.effectiveTb > 0` to match the same null-safety pattern. 
- Kept all other logic and file contents intact and made no other changes to calculations or formatting. 
- Ensured no `as any` or `// @ts-ignore` was introduced and `gridKgCo2ePerKwh` usage remains consistent.

### Testing
- Ran `rg -n "gridKgCo2ePerwh"` against the modified file and found zero occurrences of the misspelling. 
- Attempted `npm run build` to validate TypeScript, but the job failed due to a missing `/workspace/accountlist/package.json` so a full build could not be completed in this environment. 
- Local TypeScript lint/compile should be exercised in the normal CI or developer environment to confirm no remaining TS errors. 
- No automated tests in the repository were changed by this PR and no other test suites were executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6961b95f1f5c8326ace0eb4242ed487e)