### PR TITLE
Add presales export formats for Energy Tool

### DIFF
--- a/ui/partner-hub/README.md
+++ b/ui/partner-hub/README.md
@@ -1,0 +1,23 @@
+# Partner Hub (Energy Tool exports)
+
+## Local development
+1. `cd ui/partner-hub`
+2. `npm install`
+3. `npm run dev`
+4. Visit `http://localhost:3000/tools/energy`
+5. Use **Export…** to download PDF, PPTX, CSV, or JSON.
+
+## API export examples
+Use the JSON export payload as the POST body.
+
+```bash
+curl -X POST http://localhost:3000/api/exports/presales/pdf \
+  -H "Content-Type: application/json" \
+  -d @payload.json \
+  --output energy-presales.pdf
+
+curl -X POST http://localhost:3000/api/exports/presales/pptx \
+  -H "Content-Type: application/json" \
+  -d @payload.json \
+  --output energy-presales.pptx
+```

--- a/ui/partner-hub/app/api/exports/presales/pdf/route.ts
+++ b/ui/partner-hub/app/api/exports/presales/pdf/route.ts
@@ -1,0 +1,137 @@
+import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
+import { z } from "zod";
+
+import { presalesExportSchema } from "../../../../../lib/exports/presalesExportSchema";
+
+export const runtime = "nodejs";
+
+const fmt0 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+const fmt2 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 });
+
+const wrapText = (text: string, maxWidth: number, font: any, size: number) => {
+  const words = text.split(/\s+/);
+  const lines: string[] = [];
+  let line = "";
+  for (const word of words) {
+    const next = line ? `${line} ${word}` : word;
+    if (font.widthOfTextAtSize(next, size) > maxWidth && line) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = next;
+    }
+  }
+  if (line) lines.push(line);
+  return lines;
+};
+
+export async function POST(request: Request) {
+  try {
+    const payload = presalesExportSchema.parse(await request.json());
+    const pdfDoc = await PDFDocument.create();
+    const page = pdfDoc.addPage([612, 792]);
+    const { width, height } = page.getSize();
+    const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+    const fontBold = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+    const margin = 40;
+    let y = height - margin;
+
+    const drawLine = (text: string, size = 12, bold = false, x = margin) => {
+      page.drawText(text, {
+        x,
+        y,
+        size,
+        font: bold ? fontBold : font,
+        color: rgb(0, 0, 0),
+      });
+      y -= size + 6;
+    };
+
+    drawLine("Energy & Sustainability Comparison", 18, true);
+    drawLine(payload.selection.selectedNetAppConfig?.summary ?? "NetApp config not selected", 11);
+    y -= 4;
+
+    const keyRows = payload.rows.filter((row) => {
+      if (payload.meta.viewMode === "energy") {
+        return ["effectiveTb", "kwhPerYear", "annualCost", "rackUnits"].includes(row.key);
+      }
+      if (payload.meta.viewMode === "sustainability") {
+        return ["effectiveTb", "co2eYear", "co2ePerTbYear"].includes(row.key);
+      }
+      return ["effectiveTb", "kwhPerYear", "annualCost", "rackUnits", "co2eYear", "co2ePerTbYear"].includes(row.key);
+    });
+
+    const tableWidth = width - margin * 2;
+    const labelWidth = 190;
+    const colWidth = (tableWidth - labelWidth) / 3;
+    const labelX = margin;
+    const fbX = labelX + labelWidth;
+    const naX = fbX + colWidth;
+    const deltaX = naX + colWidth;
+
+    drawLine("Key totals", 12, true);
+    page.drawText("Metric", { x: labelX, y, size: 10, font: fontBold });
+    page.drawText("FlashBlade", { x: fbX, y, size: 10, font: fontBold });
+    page.drawText("NetApp", { x: naX, y, size: 10, font: fontBold });
+    page.drawText("Delta", { x: deltaX, y, size: 10, font: fontBold });
+    y -= 16;
+
+    keyRows.forEach((row) => {
+      page.drawText(row.label, { x: labelX, y, size: 9, font });
+      page.drawText(row.flashblade, { x: fbX, y, size: 9, font });
+      page.drawText(row.netapp, { x: naX, y, size: 9, font });
+      page.drawText(row.delta, { x: deltaX, y, size: 9, font });
+      y -= 14;
+    });
+
+    y -= 6;
+    drawLine("Assumptions", 11, true);
+    const assumptions = [
+      `FlashBlade Utilization: ${fmt2.format(payload.assumptions.flashblade.utilizationPct)}%`,
+      `FlashBlade PUE: ${fmt2.format(payload.assumptions.flashblade.pue)}`,
+      `FlashBlade $/kWh: $${fmt2.format(payload.assumptions.flashblade.pricePerKwh)}`,
+      `FlashBlade DRR: ${fmt2.format(payload.assumptions.flashblade.drr)}`,
+      `DFM size: ${fmt0.format(payload.assumptions.flashblade.dfmSizeTb)} TB`,
+      `Capacity target: ${fmt2.format(payload.assumptions.flashblade.capacityPb)} PB`,
+      `NetApp Utilization: ${fmt2.format(payload.assumptions.netapp.utilizationPct)}%`,
+      `NetApp PUE: ${fmt2.format(payload.assumptions.netapp.pue)}`,
+      `NetApp $/kWh: $${fmt2.format(payload.assumptions.netapp.pricePerKwh)}`,
+      `NetApp overhead: ${fmt2.format(payload.assumptions.netapp.overheadRawToUsable)}`,
+      `NetApp DRR: ${fmt2.format(payload.assumptions.netapp.drr)}`,
+      `NetApp drive size: ${fmt0.format(payload.assumptions.netapp.driveSizeTb)} TB`,
+      `Grid factor: ${fmt2.format(payload.assumptions.sustainability.gridKgCo2ePerKwh)} kgCO₂e/kWh (${payload.assumptions.sustainability.gridFactorSource})`,
+    ];
+    assumptions.forEach((item) => {
+      page.drawText(item, { x: margin, y, size: 8, font });
+      y -= 12;
+    });
+
+    y -= 4;
+    drawLine("Sources", 11, true);
+    const sourceLines = payload.sources.length
+      ? payload.sources.map((source) => (source.missing ? `MISSING: ${source.label}` : source.url ?? source.label))
+      : ["No sources available"];
+    sourceLines.forEach((line) => {
+      const lines = wrapText(line, width - margin * 2, font, 8);
+      lines.forEach((wrapped) => {
+        if (y < margin + 20) return;
+        page.drawText(wrapped, { x: margin, y, size: 8, font });
+        y -= 10;
+      });
+    });
+
+    const pdfBytes = await pdfDoc.save();
+    const filename = `energy-presales-${payload.meta.generatedAt.slice(0, 10)}.pdf`;
+    return new Response(Buffer.from(pdfBytes), {
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return Response.json({ error: "Invalid payload", issues: err.issues }, { status: 400 });
+    }
+    return Response.json({ error: "Failed to generate PDF export" }, { status: 500 });
+  }
+}

--- a/ui/partner-hub/app/api/exports/presales/pptx/route.ts
+++ b/ui/partner-hub/app/api/exports/presales/pptx/route.ts
@@ -1,0 +1,122 @@
+import PptxGenJS from "pptxgenjs";
+import { z } from "zod";
+
+import { presalesExportSchema } from "../../../../../lib/exports/presalesExportSchema";
+
+export const runtime = "nodejs";
+
+const fmt2 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 });
+const fmt0 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+
+export async function POST(request: Request) {
+  try {
+    const payload = presalesExportSchema.parse(await request.json());
+    const pptx = new PptxGenJS();
+    pptx.layout = "LAYOUT_WIDE";
+
+    const slide = pptx.addSlide();
+    slide.addText("Energy & Sustainability Comparison", {
+      x: 0.5,
+      y: 0.3,
+      w: 12.5,
+      h: 0.6,
+      fontSize: 28,
+      bold: true,
+    });
+    slide.addText(payload.selection.selectedNetAppConfig?.summary ?? "NetApp config not selected", {
+      x: 0.5,
+      y: 0.95,
+      w: 12.5,
+      h: 0.4,
+      fontSize: 14,
+      color: "555555",
+    });
+
+    const keyRows = payload.rows.filter((row) => {
+      if (payload.meta.viewMode === "energy") {
+        return ["effectiveTb", "kwhPerYear", "annualCost", "rackUnits"].includes(row.key);
+      }
+      if (payload.meta.viewMode === "sustainability") {
+        return ["effectiveTb", "co2eYear", "co2ePerTbYear"].includes(row.key);
+      }
+      return ["effectiveTb", "kwhPerYear", "annualCost", "rackUnits", "co2eYear", "co2ePerTbYear"].includes(row.key);
+    });
+
+    const columnText = (valueKey: "flashblade" | "netapp" | "delta") =>
+      keyRows.map((row) => `${row.label}: ${row[valueKey]}`).join("\n");
+
+    const columnY = 1.6;
+    const columnH = 4.4;
+    const columnW = 3.8;
+    slide.addText("FlashBlade", { x: 0.5, y: columnY, w: columnW, h: 0.3, fontSize: 16, bold: true });
+    slide.addText(columnText("flashblade"), {
+      x: 0.5,
+      y: columnY + 0.35,
+      w: columnW,
+      h: columnH,
+      fontSize: 12,
+      color: "333333",
+    });
+    slide.addText("NetApp", { x: 4.35, y: columnY, w: columnW, h: 0.3, fontSize: 16, bold: true });
+    slide.addText(columnText("netapp"), {
+      x: 4.35,
+      y: columnY + 0.35,
+      w: columnW,
+      h: columnH,
+      fontSize: 12,
+      color: "333333",
+    });
+    slide.addText("Delta", { x: 8.2, y: columnY, w: columnW, h: 0.3, fontSize: 16, bold: true });
+    slide.addText(columnText("delta"), {
+      x: 8.2,
+      y: columnY + 0.35,
+      w: columnW,
+      h: columnH,
+      fontSize: 12,
+      color: "333333",
+    });
+
+    const assumptions = [
+      `FB Utilization ${fmt2.format(payload.assumptions.flashblade.utilizationPct)}%`,
+      `FB PUE ${fmt2.format(payload.assumptions.flashblade.pue)}`,
+      `FB $/kWh $${fmt2.format(payload.assumptions.flashblade.pricePerKwh)}`,
+      `FB DRR ${fmt2.format(payload.assumptions.flashblade.drr)}`,
+      `DFM ${fmt0.format(payload.assumptions.flashblade.dfmSizeTb)} TB`,
+      `Capacity ${fmt2.format(payload.assumptions.flashblade.capacityPb)} PB`,
+      `NA Utilization ${fmt2.format(payload.assumptions.netapp.utilizationPct)}%`,
+      `NA PUE ${fmt2.format(payload.assumptions.netapp.pue)}`,
+      `NA $/kWh $${fmt2.format(payload.assumptions.netapp.pricePerKwh)}`,
+      `NA Overhead ${fmt2.format(payload.assumptions.netapp.overheadRawToUsable)}`,
+      `NA DRR ${fmt2.format(payload.assumptions.netapp.drr)}`,
+      `NA Drive ${fmt0.format(payload.assumptions.netapp.driveSizeTb)} TB`,
+      `Grid ${fmt2.format(payload.assumptions.sustainability.gridKgCo2ePerKwh)} kgCO₂e/kWh`,
+    ];
+    slide.addText(`Assumptions: ${assumptions.join(" · ")}`, {
+      x: 0.5,
+      y: 6.15,
+      w: 12.5,
+      h: 0.5,
+      fontSize: 9,
+      color: "666666",
+    });
+
+    const sources = payload.sources.length
+      ? payload.sources.map((source) => (source.missing ? `MISSING: ${source.label}` : source.url ?? source.label))
+      : ["No sources available"];
+    slide.addNotes(`Sources:\n${sources.join("\n")}`);
+
+    const buffer = await pptx.write("nodebuffer");
+    const filename = `energy-presales-${payload.meta.generatedAt.slice(0, 10)}.pptx`;
+    return new Response(Buffer.from(buffer), {
+      headers: {
+        "Content-Type": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return Response.json({ error: "Invalid payload", issues: err.issues }, { status: 400 });
+    }
+    return Response.json({ error: "Failed to generate PPTX export" }, { status: 500 });
+  }
+}

--- a/ui/partner-hub/app/api/exports/presales/presales-export.routes.test.ts
+++ b/ui/partner-hub/app/api/exports/presales/presales-export.routes.test.ts
@@ -1,0 +1,127 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+
+import { POST as pdfPost } from "./pdf/route";
+import { POST as pptxPost } from "./pptx/route";
+
+const samplePayload = {
+  meta: {
+    toolName: "Energy Tool",
+    generatedAt: "2024-01-01T00:00:00Z",
+    viewMode: "energy",
+    dataset: null,
+  },
+  assumptions: {
+    flashblade: {
+      utilizationPct: 50,
+      pue: 1.35,
+      pricePerKwh: 0.12,
+      drr: 2,
+      dfmSizeTb: 48,
+      capacityPb: 4,
+    },
+    netapp: {
+      utilizationPct: 50,
+      pue: 1.35,
+      pricePerKwh: 0.12,
+      overheadRawToUsable: 0.2,
+      drr: 1.3,
+      driveSizeTb: 18,
+      driveSizeSelection: "Compatibility dataset (all drives)",
+    },
+    sustainability: {
+      gridKgCo2ePerKwh: 0.4,
+      gridFactorSource: "default",
+    },
+  },
+  selection: {
+    mode: "auto",
+    selectedNetAppConfig: {
+      controllerModel: "E2800",
+      expansionModel: "DE460C 60-bay",
+      expansionQty: 2,
+      driveSizeTb: 18,
+      rackUnits: 12,
+      effectiveTb: 400,
+      kwhPerYear: 100000,
+      annualCost: 12000,
+      summary: "E2800 + 2 shelves",
+    },
+    matchInfo: {
+      tolerancePct: 10,
+      candidateCount: 4,
+      selectedIndex: 0,
+    },
+  },
+  results: {
+    flashbladeTotals: {
+      effectiveTb: 450,
+      weightedW: 5000,
+      kwhPerYear: 120000,
+      annualCost: 15000,
+      btuPerHour: 17000,
+      rackUnits: 20,
+      co2eKgPerYear: 48000,
+      co2ePerTbYear: 106,
+    },
+    netappTotals: {
+      effectiveTb: 400,
+      weightedW: 4500,
+      kwhPerYear: 100000,
+      annualCost: 12000,
+      btuPerHour: null,
+      rackUnits: 12,
+      co2eKgPerYear: 40000,
+      co2ePerTbYear: 100,
+    },
+    deltaTotals: {
+      effectiveTb: 50,
+      weightedW: 500,
+      kwhPerYear: 20000,
+      annualCost: 3000,
+      btuPerHour: null,
+      rackUnits: 8,
+      co2eKgPerYear: 8000,
+      co2ePerTbYear: 6,
+    },
+  },
+  rows: [
+    {
+      key: "effectiveTb",
+      label: "Effective TB",
+      flashblade: "450",
+      netapp: "400",
+      delta: "50",
+      units: "TB",
+    },
+  ],
+  sources: [{ label: "https://example.com", url: "https://example.com", missing: false }],
+};
+
+describe("presales export routes", () => {
+  it("returns a PDF buffer", async () => {
+    const response = await pdfPost(
+      new Request("http://localhost/api/exports/presales/pdf", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(samplePayload),
+      }),
+    );
+    assert.equal(response.status, 200);
+    const buffer = Buffer.from(await response.arrayBuffer());
+    assert.ok(buffer.length > 0);
+  });
+
+  it("returns a PPTX buffer", async () => {
+    const response = await pptxPost(
+      new Request("http://localhost/api/exports/presales/pptx", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(samplePayload),
+      }),
+    );
+    assert.equal(response.status, 200);
+    const buffer = Buffer.from(await response.arrayBuffer());
+    assert.ok(buffer.length > 0);
+  });
+});

--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ChangeEvent } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   enumerateNetApp,
@@ -24,6 +24,7 @@ import {
   loadNetAppDriveCompat,
   type NetAppDriveCompat,
 } from "@/lib/energy/netapp-drive-compat";
+import { presalesExportSchema, type PresalesExportPayload } from "@/lib/exports/presalesExportSchema";
 
 const fmt0 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
 const fmt1 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
@@ -119,6 +120,9 @@ export function EnergyTool() {
   const [vendorReportError, setVendorReportError] = useState<string | null>(null);
   const [sourceCheckHint, setSourceCheckHint] = useState<string | null>(null);
   const [view, setView] = useState<ViewMode>("energy");
+  const [exportChoice, setExportChoice] = useState("");
+  const [exportError, setExportError] = useState<string | null>(null);
+  const [exportLoading, setExportLoading] = useState<string | null>(null);
 
   const [inputs, setInputs] = useState<Inputs>(() => ({
     dfmTb: 48,
@@ -607,6 +611,16 @@ export function EnergyTool() {
     co2eYear: "CO₂e / year",
     co2ePerTbYear: "CO₂e per effective TB-year (kgCO₂e)",
   };
+  const rowUnits: Record<RowKey, string | null> = {
+    effectiveTb: "TB",
+    weightedW: "W",
+    kwhPerYear: "kWh/year",
+    annualCost: "USD/year",
+    btuPerHour: "BTU/hour",
+    rackUnits: "RU",
+    co2eYear: "tCO₂e/year",
+    co2ePerTbYear: "kgCO₂e/TB-year",
+  };
 
   const fbRowValues: Partial<Record<RowKey, string>> | null = fb
     ? {
@@ -664,10 +678,32 @@ export function EnergyTool() {
       ],
     );
 
-  const handleDownloadAssumptions = () => {
-    const payload = {
-      lastSyncedISO: energyMeta?.lastSyncedISO ?? null,
-      mode,
+  const buildNetAppSummary = (candidate: NetAppCandidate | null) => {
+    if (!candidate) return "No NetApp configuration selected";
+    const shelfLabel = `${candidate.expansionQty} shelf${candidate.expansionQty === 1 ? "" : "es"}`;
+    return `${candidate.controllerModel} + ${shelfLabel}`;
+  };
+
+  const buildPresalesExportPayload = (): PresalesExportPayload => {
+    const rowKeys = [...comparePrimaryKeys, ...compareSecondaryKeys];
+    const selectedIndex = selectedCandidate
+      ? candidates.findIndex((candidate) => candidateKey(candidate) === candidateKey(selectedCandidate))
+      : -1;
+    const payload: PresalesExportPayload = {
+      meta: {
+        toolName: "Energy Tool",
+        generatedAt: new Date().toISOString(),
+        viewMode: view,
+        dataset: energyMeta
+          ? {
+              lastSyncedISO: energyMeta.lastSyncedISO ?? null,
+              sourceFiles: energyMeta.sourceFiles ?? null,
+              copiedFiles: energyMeta.copiedFiles ?? null,
+              sha256: energyMeta.sha256 ?? null,
+              reportFiles: energyMeta.reportFiles ?? null,
+            }
+          : null,
+      },
       assumptions: {
         flashblade: {
           utilizationPct: inputs.pureUtilPct,
@@ -689,51 +725,190 @@ export function EnergyTool() {
         },
         sustainability: {
           gridKgCo2ePerKwh,
+          gridFactorSource,
         },
       },
-      selectedNetApp: selectedCandidate
-        ? {
-            controllerModel: selectedCandidate.controllerModel,
-            expansionModel: selectedCandidate.expansionModel,
-            expansionShelves: selectedCandidate.expansionQty,
-            driveSizeTb: inputs.naDriveSizeTb,
-            rackUnits: selectedCandidate.rackUnits ?? null,
-          }
-        : null,
+      selection: {
+        mode,
+        selectedNetAppConfig: selectedCandidate
+          ? {
+              controllerModel: selectedCandidate.controllerModel,
+              expansionModel: selectedCandidate.expansionModel,
+              expansionQty: selectedCandidate.expansionQty,
+              driveSizeTb: inputs.naDriveSizeTb,
+              rackUnits: selectedCandidate.rackUnits ?? null,
+              effectiveTb: selectedCandidate.effectiveTb,
+              kwhPerYear: selectedCandidate.kwhYearWithPue,
+              annualCost: selectedCandidate.annualEnergyCost,
+              summary: buildNetAppSummary(selectedCandidate),
+            }
+          : null,
+        matchInfo:
+          mode === "auto" && selectedCandidate
+            ? {
+                tolerancePct: inputs.tolPct,
+                candidateCount: candidates.length,
+                selectedIndex: selectedIndex >= 0 ? selectedIndex : 0,
+              }
+            : null,
+      },
       results: fb
         ? {
-            flashblade: {
-              rackUnits: fb.rackUnits ?? null,
+            flashbladeTotals: {
               effectiveTb: fb.effectiveTb,
+              weightedW: fb.weightedW,
+              kwhPerYear: fb.kwhWithPue,
+              annualCost: fb.annualCost,
+              btuPerHour: fb.btuPerHour,
+              rackUnits: fb.rackUnits ?? null,
               co2eKgPerYear: fbCo2eKgPerYear,
-              co2eKgPerTbYear: fbCo2ePerTbYear,
+              co2ePerTbYear: fbCo2ePerTbYear,
             },
-            netapp: selectedCandidate
+            netappTotals: selectedCandidate
               ? {
-                  rackUnits: selectedCandidate.rackUnits ?? null,
                   effectiveTb: selectedCandidate.effectiveTb,
+                  weightedW: selectedCandidate.weightedW,
+                  kwhPerYear: selectedCandidate.kwhYearWithPue,
+                  annualCost: selectedCandidate.annualEnergyCost,
+                  btuPerHour: null,
+                  rackUnits: selectedCandidate.rackUnits ?? null,
                   co2eKgPerYear: netappCo2eKgPerYear,
-                  co2eKgPerTbYear: netappCo2ePerTbYear,
+                  co2ePerTbYear: netappCo2ePerTbYear,
                 }
               : null,
-            delta: {
-              rackUnits: savings?.deltaRackUnits ?? null,
+            deltaTotals: {
               effectiveTb: savings?.deltaEffectiveTb ?? null,
+              weightedW: savings?.deltaW ?? null,
+              kwhPerYear: savings?.deltaKwh ?? null,
+              annualCost: savings?.deltaCost ?? null,
+              btuPerHour: null,
+              rackUnits: savings?.deltaRackUnits ?? null,
               co2eKgPerYear: deltaCo2eKgPerYear,
-              co2eKgPerTbYear: deltaCo2ePerTbYear,
+              co2ePerTbYear: deltaCo2ePerTbYear,
             },
           }
         : null,
-      sources: sourceList.map((item) => (item.type === "link" ? item.url : item.label)),
+      rows: rowKeys.map((key) => ({
+        key,
+        label: rowLabels[key],
+        flashblade: fbRowValues?.[key] ?? "—",
+        netapp: netappRowValues?.[key] ?? "—",
+        delta: deltaRowValues[key] ?? "—",
+        units: rowUnits[key] ?? null,
+      })),
+      sources: sourceList.map((item) => ({
+        label: item.label,
+        url: item.type === "link" ? item.url ?? null : null,
+        missing: item.type === "missing",
+      })),
     };
+    return presalesExportSchema.parse(payload);
+  };
 
+  const downloadJson = (payload: PresalesExportPayload, filename: string) => {
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
-    link.download = "assumptions.json";
+    link.download = filename;
     link.click();
     URL.revokeObjectURL(url);
+  };
+
+  const escapeCsvCell = (value: string) => {
+    if (value.includes("\"")) {
+      value = value.replace(/\"/g, "\"\"");
+    }
+    if (value.includes(",") || value.includes("\n") || value.includes("\"")) {
+      return `"${value}"`;
+    }
+    return value;
+  };
+
+  const downloadCsv = (payload: PresalesExportPayload, filename: string) => {
+    const header = ["Row", "FlashBlade", "NetApp", "Delta", "Units", "Notes"];
+    const lines = [header.join(",")];
+    payload.rows.forEach((row) => {
+      lines.push(
+        [
+          escapeCsvCell(row.label),
+          escapeCsvCell(row.flashblade),
+          escapeCsvCell(row.netapp),
+          escapeCsvCell(row.delta),
+          escapeCsvCell(row.units ?? ""),
+          escapeCsvCell(row.notes ?? ""),
+        ].join(","),
+      );
+    });
+    const blob = new Blob([lines.join("\n")], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const buildExportFilename = (extension: string, payload: PresalesExportPayload) => {
+    const datePart = payload.meta.generatedAt.slice(0, 10);
+    const summary = payload.selection.selectedNetAppConfig?.summary ?? "netapp";
+    const safeSummary = summary.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)+/g, "");
+    return `energy-presales-${datePart}-${safeSummary}.${extension}`;
+  };
+
+  const requestExportFile = async (type: "pdf" | "pptx", payload: PresalesExportPayload) => {
+    setExportLoading(type);
+    try {
+      const res = await fetch(`${basePath}/api/exports/presales/${type}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        throw new Error(`Export failed (${res.status})`);
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = buildExportFilename(type, payload);
+      link.click();
+      URL.revokeObjectURL(url);
+    } finally {
+      setExportLoading(null);
+    }
+  };
+
+  const handleDownloadAssumptions = () => {
+    const payload = buildPresalesExportPayload();
+    downloadJson(payload, "assumptions.json");
+  };
+
+  const handleExportChange = async (event: ChangeEvent<HTMLSelectElement>) => {
+    const selection = event.target.value;
+    setExportChoice(selection);
+    if (!selection) return;
+    try {
+      setExportError(null);
+      const payload = buildPresalesExportPayload();
+      if (selection === "csv") {
+        downloadCsv(payload, buildExportFilename("csv", payload));
+        return;
+      }
+      if (selection === "json") {
+        downloadJson(payload, buildExportFilename("json", payload));
+        return;
+      }
+      if (selection === "pdf" || selection === "pptx") {
+        await requestExportFile(selection, payload);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Export failed";
+      setExportError(message);
+      window.alert(message);
+    } finally {
+      setExportChoice("");
+    }
   };
 
   const handleCheckSources = async () => {
@@ -762,6 +937,7 @@ export function EnergyTool() {
     () => mode === "auto" && candidates.slice(0, 8).some((candidate) => candidate.rackUnits == null),
     [candidates, mode],
   );
+  const exportDisabled = loading || exportLoading != null || !fb || !selectedCandidate;
 
   return (
     <div className="space-y-6">
@@ -1023,6 +1199,21 @@ export function EnergyTool() {
               >
                 Assumptions &amp; Sources
               </button>
+              <select
+                className="h-10 rounded-md border border-border bg-background px-3 text-sm font-semibold text-foreground transition hover:bg-muted/50 disabled:opacity-50"
+                aria-label="Export"
+                value={exportChoice}
+                onChange={handleExportChange}
+                disabled={exportDisabled}
+              >
+                <option value="" disabled>
+                  Export…
+                </option>
+                <option value="pdf">PDF one-pager</option>
+                <option value="pptx">PPTX slide</option>
+                <option value="csv">CSV (totals + delta)</option>
+                <option value="json">JSON (assumptions + results)</option>
+              </select>
               <button
                 type="button"
                 className="inline-flex h-10 items-center justify-center rounded-md border border-border bg-background px-4 text-sm font-semibold text-foreground transition hover:bg-muted/50"
@@ -1031,7 +1222,9 @@ export function EnergyTool() {
                 Check sources (local)
               </button>
               {loading ? <span className="text-xs text-foreground/60">Loading datasets…</span> : null}
+              {exportLoading ? <span className="text-xs text-foreground/60">Exporting {exportLoading}…</span> : null}
               {computeError ? <span className="text-xs font-semibold text-red-600">{computeError}</span> : null}
+              {exportError ? <span className="text-xs font-semibold text-red-600">{exportError}</span> : null}
               {sourceCheckHint ? <span className="text-xs text-foreground/60">{sourceCheckHint}</span> : null}
             </div>
           </CardContent>

--- a/ui/partner-hub/lib/exports/presalesExportSchema.test.ts
+++ b/ui/partner-hub/lib/exports/presalesExportSchema.test.ts
@@ -1,0 +1,104 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+
+import { presalesExportSchema } from "./presalesExportSchema";
+
+describe("presalesExportSchema", () => {
+  it("accepts a valid presales export payload", () => {
+    const samplePayload = {
+      meta: {
+        toolName: "Energy Tool",
+        generatedAt: "2024-01-01T00:00:00Z",
+        viewMode: "energy",
+        dataset: null,
+      },
+      assumptions: {
+        flashblade: {
+          utilizationPct: 50,
+          pue: 1.35,
+          pricePerKwh: 0.12,
+          drr: 2,
+          dfmSizeTb: 48,
+          capacityPb: 4,
+        },
+        netapp: {
+          utilizationPct: 50,
+          pue: 1.35,
+          pricePerKwh: 0.12,
+          overheadRawToUsable: 0.2,
+          drr: 1.3,
+          driveSizeTb: 18,
+          driveSizeSelection: "Compatibility dataset (all drives)",
+        },
+        sustainability: {
+          gridKgCo2ePerKwh: 0.4,
+          gridFactorSource: "default",
+        },
+      },
+      selection: {
+        mode: "auto",
+        selectedNetAppConfig: {
+          controllerModel: "E2800",
+          expansionModel: "DE460C 60-bay",
+          expansionQty: 2,
+          driveSizeTb: 18,
+          rackUnits: 12,
+          effectiveTb: 400,
+          kwhPerYear: 100000,
+          annualCost: 12000,
+          summary: "E2800 + 2 shelves",
+        },
+        matchInfo: {
+          tolerancePct: 10,
+          candidateCount: 4,
+          selectedIndex: 0,
+        },
+      },
+      results: {
+        flashbladeTotals: {
+          effectiveTb: 450,
+          weightedW: 5000,
+          kwhPerYear: 120000,
+          annualCost: 15000,
+          btuPerHour: 17000,
+          rackUnits: 20,
+          co2eKgPerYear: 48000,
+          co2ePerTbYear: 106,
+        },
+        netappTotals: {
+          effectiveTb: 400,
+          weightedW: 4500,
+          kwhPerYear: 100000,
+          annualCost: 12000,
+          btuPerHour: null,
+          rackUnits: 12,
+          co2eKgPerYear: 40000,
+          co2ePerTbYear: 100,
+        },
+        deltaTotals: {
+          effectiveTb: 50,
+          weightedW: 500,
+          kwhPerYear: 20000,
+          annualCost: 3000,
+          btuPerHour: null,
+          rackUnits: 8,
+          co2eKgPerYear: 8000,
+          co2ePerTbYear: 6,
+        },
+      },
+      rows: [
+        {
+          key: "effectiveTb",
+          label: "Effective TB",
+          flashblade: "450",
+          netapp: "400",
+          delta: "50",
+          units: "TB",
+        },
+      ],
+      sources: [{ label: "https://example.com", url: "https://example.com", missing: false }],
+    };
+
+    assert.doesNotThrow(() => presalesExportSchema.parse(samplePayload));
+  });
+});

--- a/ui/partner-hub/lib/exports/presalesExportSchema.ts
+++ b/ui/partner-hub/lib/exports/presalesExportSchema.ts
@@ -1,0 +1,122 @@
+import { z } from "zod";
+
+export const presalesExportRowSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  flashblade: z.string(),
+  netapp: z.string(),
+  delta: z.string(),
+  units: z.string().nullable().optional(),
+  notes: z.string().nullable().optional(),
+});
+
+export const presalesExportSchema = z.object({
+  meta: z.object({
+    toolName: z.string(),
+    generatedAt: z.string(),
+    viewMode: z.enum(["energy", "sustainability", "both"]),
+    dataset: z
+      .object({
+        lastSyncedISO: z.string().nullable().optional(),
+        sourceFiles: z.array(z.string()).nullable().optional(),
+        copiedFiles: z.array(z.string()).nullable().optional(),
+        sha256: z.record(z.string()).nullable().optional(),
+        reportFiles: z.array(z.string()).nullable().optional(),
+      })
+      .nullable()
+      .optional(),
+  }),
+  assumptions: z.object({
+    flashblade: z.object({
+      utilizationPct: z.number(),
+      pue: z.number(),
+      pricePerKwh: z.number(),
+      drr: z.number(),
+      dfmSizeTb: z.number(),
+      capacityPb: z.number(),
+    }),
+    netapp: z.object({
+      utilizationPct: z.number(),
+      pue: z.number(),
+      pricePerKwh: z.number(),
+      overheadRawToUsable: z.number(),
+      drr: z.number(),
+      driveSizeTb: z.number(),
+      driveSizeSelection: z.string(),
+    }),
+    sustainability: z.object({
+      gridKgCo2ePerKwh: z.number(),
+      gridFactorSource: z.string(),
+    }),
+  }),
+  selection: z.object({
+    mode: z.enum(["auto", "manual"]),
+    selectedNetAppConfig: z
+      .object({
+        controllerModel: z.string(),
+        expansionModel: z.string(),
+        expansionQty: z.number(),
+        driveSizeTb: z.number(),
+        rackUnits: z.number().nullable(),
+        effectiveTb: z.number(),
+        kwhPerYear: z.number(),
+        annualCost: z.number(),
+        summary: z.string(),
+      })
+      .nullable(),
+    matchInfo: z
+      .object({
+        tolerancePct: z.number(),
+        candidateCount: z.number(),
+        selectedIndex: z.number(),
+      })
+      .nullable()
+      .optional(),
+  }),
+  results: z
+    .object({
+      flashbladeTotals: z.object({
+        effectiveTb: z.number().nullable(),
+        weightedW: z.number().nullable(),
+        kwhPerYear: z.number().nullable(),
+        annualCost: z.number().nullable(),
+        btuPerHour: z.number().nullable(),
+        rackUnits: z.number().nullable(),
+        co2eKgPerYear: z.number().nullable(),
+        co2ePerTbYear: z.number().nullable(),
+      }),
+      netappTotals: z
+        .object({
+          effectiveTb: z.number().nullable(),
+          weightedW: z.number().nullable(),
+          kwhPerYear: z.number().nullable(),
+          annualCost: z.number().nullable(),
+          btuPerHour: z.number().nullable(),
+          rackUnits: z.number().nullable(),
+          co2eKgPerYear: z.number().nullable(),
+          co2ePerTbYear: z.number().nullable(),
+        })
+        .nullable(),
+      deltaTotals: z.object({
+        effectiveTb: z.number().nullable(),
+        weightedW: z.number().nullable(),
+        kwhPerYear: z.number().nullable(),
+        annualCost: z.number().nullable(),
+        btuPerHour: z.number().nullable(),
+        rackUnits: z.number().nullable(),
+        co2eKgPerYear: z.number().nullable(),
+        co2ePerTbYear: z.number().nullable(),
+      }),
+    })
+    .nullable(),
+  rows: z.array(presalesExportRowSchema),
+  sources: z.array(
+    z.object({
+      label: z.string(),
+      url: z.string().nullable().optional(),
+      missing: z.boolean(),
+    }),
+  ),
+});
+
+export type PresalesExportPayload = z.infer<typeof presalesExportSchema>;

--- a/ui/partner-hub/package.json
+++ b/ui/partner-hub/package.json
@@ -7,7 +7,7 @@
         "build": "node scripts/sync-energy-data.mjs && next build && node scripts/post-export.mjs",
         "start": "next start",
         "lint": "next lint",
-        "test": "tsc --noEmit false --module commonjs --moduleResolution node --target ES2020 --outDir .tmp-tests lib/energy/energy-calc.ts lib/energy/energy-calc.test.ts && node --test .tmp-tests/energy-calc.test.js",
+        "test": "tsc --noEmit false --module commonjs --moduleResolution node --target ES2020 --outDir .tmp-tests --rootDir . lib/energy/energy-calc.ts lib/energy/energy-calc.test.ts lib/exports/presalesExportSchema.ts lib/exports/presalesExportSchema.test.ts app/api/exports/presales/pdf/route.ts app/api/exports/presales/pptx/route.ts app/api/exports/presales/presales-export.routes.test.ts && node --test .tmp-tests/lib/energy/energy-calc.test.js .tmp-tests/lib/exports/presalesExportSchema.test.js .tmp-tests/app/api/exports/presales/presales-export.routes.test.js",
         "build:export": "node scripts/sync-energy-data.mjs && next build && node scripts/post-export.mjs"
     },
     "dependencies": {
@@ -17,9 +17,12 @@
         "lucide-react": "^0.365.0",
         "next": "^14.0.0",
         "next-themes": "^0.2.1",
+        "pdf-lib": "^1.17.1",
+        "pptxgenjs": "^3.12.0",
         "react": "^18.3.1",
         "react-dom": "^18.0.0",
-        "reactflow": "^11.11.4"
+        "reactflow": "^11.11.4",
+        "zod": "^3.23.8"
     },
     "devDependencies": {
         "@types/dagre": "^0.7.52",


### PR DESCRIPTION
### Motivation
- Provide presales-friendly exports (PDF, PPTX, CSV, JSON) from the Energy Tool using the current UI state and computed totals.
- Keep all exports derived from a single client-side payload and reuse existing computed outputs without changing calculation logic.
- Offer server-generated PDF/PPTX and client-generated CSV/JSON to support quick one-page and slide summaries for presales conversations.
- Share a single validated schema to avoid client/server drift and make exports deterministic.

### Description
- Added a shared `zod` schema and TS type in `ui/partner-hub/lib/exports/presalesExportSchema.ts` and a unit test in `presalesExportSchema.test.ts` to validate the export payload shape.
- Implemented a client-side payload builder `buildPresalesExportPayload()` and local download helpers (`downloadJson`, `downloadCsv`) inside `EnergyTool` (`ui/partner-hub/components/energy/energy-tool.tsx`), and refactored the existing JSON download to reuse the new builder.
- Added an `Export…` control to the Energy Tool action bar which supports `PDF`, `PPTX`, `CSV`, and `JSON`, and added server API routes `app/api/exports/presales/pdf/route.ts` and `app/api/exports/presales/pptx/route.ts` to generate PDF (via `pdf-lib`) and PPTX (via `pptxgenjs`).
- Added integration tests for the server routes (`presales-export.routes.test.ts`) and a README with local run and `curl` examples, and updated `package.json` to add `pdf-lib`, `pptxgenjs`, and `zod` plus test wiring.

### Testing
- Added automated tests: `lib/exports/presalesExportSchema.test.ts` and `app/api/exports/presales/presales-export.routes.test.ts` which validate the schema and assert the API routes return non-empty buffers.
- No automated tests were executed in this environment because `npm install` failed with a `403 Forbidden` when fetching `@types/dagre` from the npm registry.
- TypeScript test wiring was added to `ui/partner-hub/package.json` under the `test` script to run the new tests when dependencies are available.
- Manual verification instructions are provided in `ui/partner-hub/README.md` for local dev and `curl` examples for the PDF/PPTX endpoints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69645a5dc2808326a0758c5a5a19ad28)