### PR TITLE
Energy tool: toggle behavior and controls layout

### DIFF
--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -119,6 +119,7 @@ export function EnergyTool() {
   const [vendorReport, setVendorReport] = useState<VendorUpdateReport | null>(null);
   const [vendorReportError, setVendorReportError] = useState<string | null>(null);
   const [sourceCheckHint, setSourceCheckHint] = useState<string | null>(null);
+  const [checkSourcesActive, setCheckSourcesActive] = useState(false);
   const [view, setView] = useState<ViewMode>("energy");
   const [exportChoice, setExportChoice] = useState("");
   const [exportError, setExportError] = useState<string | null>(null);
@@ -913,6 +914,12 @@ export function EnergyTool() {
 
   const handleCheckSources = async () => {
     const command = "node ui/partner-hub/scripts/check-vendor-sources.mjs";
+    if (checkSourcesActive) {
+      setCheckSourcesActive(false);
+      setSourceCheckHint(null);
+      return;
+    }
+    setCheckSourcesActive(true);
     try {
       await navigator.clipboard.writeText(command);
       setSourceCheckHint(`Run locally: ${command} (command copied)`);
@@ -938,6 +945,13 @@ export function EnergyTool() {
     [candidates, mode],
   );
   const exportDisabled = loading || exportLoading != null || !fb || !selectedCandidate;
+  const toggleButtonClass = (isActive: boolean) =>
+    [
+      "inline-flex h-10 w-full items-center justify-center rounded-md border px-4 text-sm font-semibold transition-colors",
+      isActive
+        ? "border-primary bg-primary text-primary-foreground hover:bg-primary/90 ring-1 ring-primary/30"
+        : "border-border bg-background text-foreground hover:bg-muted/50",
+    ].join(" ");
 
   return (
     <div className="space-y-6">
@@ -1172,55 +1186,63 @@ export function EnergyTool() {
               </div>
             ) : null}
 
-            <div className="flex flex-wrap items-center gap-2">
-              {mode === "auto" ? (
+            <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+              <div className="grid gap-2">
+                {mode === "auto" ? (
+                  <button
+                    type="button"
+                    className="inline-flex h-10 w-full items-center justify-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+                    onClick={runModel}
+                    disabled={loading || pureRows.length === 0 || netappRows.length === 0}
+                  >
+                    Recalculate
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="inline-flex h-10 w-full items-center justify-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+                    onClick={runManual}
+                    disabled={manualApplyDisabled}
+                  >
+                    Apply manual config
+                  </button>
+                )}
                 <button
                   type="button"
-                  className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
-                  onClick={runModel}
-                  disabled={loading || pureRows.length === 0 || netappRows.length === 0}
+                  className={toggleButtonClass(assumptionsOpen)}
+                  onClick={() => setAssumptionsOpen((prev) => !prev)}
+                  aria-pressed={assumptionsOpen}
                 >
-                  Recalculate
+                  Assumptions &amp; Sources
                 </button>
-              ) : (
                 <button
                   type="button"
-                  className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
-                  onClick={runManual}
-                  disabled={manualApplyDisabled}
+                  className={toggleButtonClass(checkSourcesActive)}
+                  onClick={handleCheckSources}
+                  aria-pressed={checkSourcesActive}
                 >
-                  Apply manual config
+                  Check Sources (local)
                 </button>
-              )}
-              <button
-                type="button"
-                className="inline-flex h-10 items-center justify-center rounded-md border border-border bg-background px-4 text-sm font-semibold text-foreground transition hover:bg-muted/50"
-                onClick={() => setAssumptionsOpen((prev) => !prev)}
-              >
-                Assumptions &amp; Sources
-              </button>
-              <select
-                className="h-10 rounded-md border border-border bg-background px-3 text-sm font-semibold text-foreground transition hover:bg-muted/50 disabled:opacity-50"
-                aria-label="Export"
-                value={exportChoice}
-                onChange={handleExportChange}
-                disabled={exportDisabled}
-              >
-                <option value="" disabled>
-                  Export…
-                </option>
-                <option value="pdf">PDF one-pager</option>
-                <option value="pptx">PPTX slide</option>
-                <option value="csv">CSV (totals + delta)</option>
-                <option value="json">JSON (assumptions + results)</option>
-              </select>
-              <button
-                type="button"
-                className="inline-flex h-10 items-center justify-center rounded-md border border-border bg-background px-4 text-sm font-semibold text-foreground transition hover:bg-muted/50"
-                onClick={handleCheckSources}
-              >
-                Check sources (local)
-              </button>
+              </div>
+              <div className="grid gap-2 sm:justify-items-end">
+                <select
+                  className="h-10 w-full min-w-[220px] rounded-md border border-border bg-background px-3 text-sm font-semibold text-foreground transition hover:bg-muted/50 disabled:opacity-50 sm:w-[260px]"
+                  aria-label="Export"
+                  value={exportChoice}
+                  onChange={handleExportChange}
+                  disabled={exportDisabled}
+                >
+                  <option value="" disabled>
+                    Export…
+                  </option>
+                  <option value="pdf">PDF one-pager</option>
+                  <option value="pptx">PPTX slide</option>
+                  <option value="csv">CSV (totals + delta)</option>
+                  <option value="json">JSON (assumptions + results)</option>
+                </select>
+              </div>
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
               {loading ? <span className="text-xs text-foreground/60">Loading datasets…</span> : null}
               {exportLoading ? <span className="text-xs text-foreground/60">Exporting {exportLoading}…</span> : null}
               {computeError ? <span className="text-xs font-semibold text-red-600">{computeError}</span> : null}


### PR DESCRIPTION
### Motivation
- Make the “Assumptions & Sources” and “Check Sources (local)” controls behave as true toggles with immediate visual state feedback.
- Re-layout the controls in the “NetApp baseline inputs” card so action buttons are stacked vertically and the Export dropdown is right-aligned in a separate column.
- Preserve existing behaviors (recalculate/apply manual config, export actions, and status/hint text) while relocating status text under the controls to avoid layout breakage.
- Add an explicit toggle state for the local source check so the command/hint can be turned off.

### Description
- Added `checkSourcesActive` state and updated `handleCheckSources` to toggle off (clearing `sourceCheckHint`) or on (copying the command and setting the hint) as required.
- Introduced a shared `toggleButtonClass` helper and applied `aria-pressed` plus active/inactive Tailwind classes to the “Assumptions & Sources” and “Check Sources (local)” buttons to provide blue/pressed styling when selected and gray hover when not.
- Replaced the existing action row with a two-column grid (`sm:grid-cols-[minmax(0,1fr)_auto]`) where the left column is a vertical, full-width button stack (`Recalculate` / `Apply manual config`, `Assumptions & Sources`, `Check Sources (local)`) and the right column holds the right-aligned Export `<select>`, and moved status/hint spans into a separate row below the grid.
- All changes made in `ui/partner-hub/components/energy/energy-tool.tsx` only.

### Testing
- Attempted `npm install` in `ui/partner-hub` to run the frontend for visual verification, but the install failed with a 403 from the npm registry, preventing a local UI run.
- No automated unit or integration tests were executed against the modified component during this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696468fc01408326936882dcf7221b3c)