### PR TITLE
Adjust energy tool controls layout

### DIFF
--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -1186,47 +1186,47 @@ export function EnergyTool() {
               </div>
             ) : null}
 
-            <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
-              <div className="grid gap-2">
-                {mode === "auto" ? (
-                  <button
-                    type="button"
-                    className="inline-flex h-10 w-full items-center justify-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
-                    onClick={runModel}
-                    disabled={loading || pureRows.length === 0 || netappRows.length === 0}
-                  >
-                    Recalculate
-                  </button>
-                ) : (
-                  <button
-                    type="button"
-                    className="inline-flex h-10 w-full items-center justify-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
-                    onClick={runManual}
-                    disabled={manualApplyDisabled}
-                  >
-                    Apply manual config
-                  </button>
-                )}
+            {/* Controls: full-width vertical buttons + export below (right-aligned) */}
+            <div className="grid gap-2">
+              {mode === "auto" ? (
                 <button
                   type="button"
-                  className={toggleButtonClass(assumptionsOpen)}
-                  onClick={() => setAssumptionsOpen((prev) => !prev)}
-                  aria-pressed={assumptionsOpen}
+                  className="inline-flex h-10 w-full items-center justify-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+                  onClick={runModel}
+                  disabled={loading || pureRows.length === 0 || netappRows.length === 0}
                 >
-                  Assumptions &amp; Sources
+                  Recalculate
                 </button>
+              ) : (
                 <button
                   type="button"
-                  className={toggleButtonClass(checkSourcesActive)}
-                  onClick={handleCheckSources}
-                  aria-pressed={checkSourcesActive}
+                  className="inline-flex h-10 w-full items-center justify-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+                  onClick={runManual}
+                  disabled={manualApplyDisabled}
                 >
-                  Check Sources (local)
+                  Apply manual config
                 </button>
-              </div>
-              <div className="grid gap-2 sm:justify-items-end">
+              )}
+              <button
+                type="button"
+                className={toggleButtonClass(assumptionsOpen)}
+                onClick={() => setAssumptionsOpen((prev) => !prev)}
+                aria-pressed={assumptionsOpen}
+              >
+                Assumptions &amp; Sources
+              </button>
+              <button
+                type="button"
+                className={toggleButtonClass(checkSourcesActive)}
+                onClick={handleCheckSources}
+                aria-pressed={checkSourcesActive}
+              >
+                Check Sources (local)
+              </button>
+              {/* Export: below buttons, right-aligned. Full width on small screens. */}
+              <div className="flex justify-end">
                 <select
-                  className="h-10 w-full min-w-[220px] rounded-md border border-border bg-background px-3 text-sm font-semibold text-foreground transition hover:bg-muted/50 disabled:opacity-50 sm:w-[260px]"
+                  className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm font-semibold text-foreground transition hover:bg-muted/50 disabled:opacity-50 sm:w-[260px]"
                   aria-label="Export"
                   value={exportChoice}
                   onChange={handleExportChange}


### PR DESCRIPTION
### Motivation
- Improve the Energy tool control arrangement by stacking the primary action buttons vertically for better small-screen and single-column layouts.
- Place the export selector beneath the buttons and right-align it so the controls read top-to-bottom and the export action remains visually distinct.
- Simplify export sizing so it fits reliably in the new stacked layout while preserving existing behavior and accessibility attributes.

### Description
- Replaced the two-column `grid` (with `sm:grid-cols-[minmax(0,1fr)_auto]`) with a single vertical `div` using `grid gap-2` in `ui/partner-hub/components/energy/energy-tool.tsx`.
- Moved the Export `<select>` into a right-aligned container (`<div className="flex justify-end">`) beneath the stacked buttons and removed the `min-w-[220px]` class from the select.
- Kept existing handlers and disabled logic for `runModel`, `runManual`, `handleCheckSources`, and `handleExportChange` unchanged.
- Adjusted minor Tailwind classes to ensure buttons remain full-width and the export select is responsive (`sm:w-[260px]`).

### Testing
- Ran `npm run dev` in `ui/partner-hub` to start the dev server but it failed because `next` was not found (dev server did not start).
- Attempted `npm install` in `ui/partner-hub`, which produced warnings and the install session was aborted before completion.
- No automated test suites were executed successfully due to the environment not having dependencies installed.
- The UI change is strictly presentational and no runtime code logic was modified beyond markup and classes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69646c2949d883269ee0244415373c1c)