### PR TITLE
Replace Estimator with Account Mapping scaffold

### DIFF
--- a/ui/partner-hub/app/(routes)/estimator/page.tsx
+++ b/ui/partner-hub/app/(routes)/estimator/page.tsx
@@ -1,39 +1,76 @@
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-const estimateSteps = [
+const wizardSteps = [
   {
-    title: "Capture workload inputs",
-    detail: "Collect capacity, performance, and resiliency requirements.",
+    title: "Upload",
+    detail: "Bring in account lists, CRM exports, or CSV drops in seconds.",
   },
   {
-    title: "Map to platform tiers",
-    detail: "Align workloads to the right storage and data services mix.",
+    title: "Map Fields",
+    detail: "Align source columns to standard account attributes and owners.",
   },
   {
-    title: "Review cost bands",
-    detail: "Generate budgetary ranges with assumptions clearly documented.",
+    title: "Match",
+    detail: "Review suggested matches, resolve exceptions, and confirm coverage.",
+  },
+  {
+    title: "Export",
+    detail: "Download the mapped list or send clean matches back to your tools.",
   },
 ];
 
 export default function EstimatorPage() {
   return (
-    <section className="space-y-6">
+    <section className="space-y-8">
       <header className="space-y-2">
-        <h1 className="text-2xl font-semibold">Estimator</h1>
+        <h1 className="text-2xl font-semibold">Account Mapping</h1>
         <p className="text-sm text-foreground/70">
-          Build a rapid sizing model for data center infrastructure proposals.
+          Normalize, match, and export account data so partner teams stay aligned.
         </p>
       </header>
-      <div className="grid gap-4 md:grid-cols-3">
-        {estimateSteps.map((step) => (
-          <Card key={step.title}>
-            <CardHeader>
-              <CardTitle className="text-base">{step.title}</CardTitle>
-            </CardHeader>
-            <CardContent className="text-sm text-foreground/70">{step.detail}</CardContent>
-          </Card>
-        ))}
-      </div>
+
+      <Card className="space-y-6">
+        <CardHeader className="gap-3">
+          <CardTitle className="text-xl">Account Mapping workspace</CardTitle>
+          <p className="text-sm text-foreground/70">
+            Launch a new mapping run to consolidate account lists, validate overlaps, and
+            deliver a clean handoff to sales operations.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap gap-3">
+            <Button>Start new mapping</Button>
+            <Button variant="secondary">Demo dataset</Button>
+          </div>
+          <p className="text-xs text-foreground/60">
+            Privacy note: Processing stays client-side so account data never leaves your
+            browser.
+          </p>
+        </CardContent>
+      </Card>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">4-step wizard</h2>
+          <span className="text-xs uppercase tracking-wide text-foreground/50">
+            workflow scaffold
+          </span>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {wizardSteps.map((step, index) => (
+            <Card key={step.title} className="space-y-3">
+              <CardHeader className="gap-2">
+                <span className="text-xs font-semibold uppercase tracking-wide text-primary">
+                  Step {index + 1}
+                </span>
+                <CardTitle className="text-base">{step.title}</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-foreground/70">{step.detail}</CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
     </section>
   );
 }

--- a/ui/partner-hub/app/page.tsx
+++ b/ui/partner-hub/app/page.tsx
@@ -9,8 +9,8 @@ const featureCards = [
     href: "/tools/architecture-explorer",
   },
   {
-    title: "Estimator",
-    description: "Size infrastructure footprints and budgetary ranges quickly.",
+    title: "Account Mapping",
+    description: "Normalize and match account lists to streamline partner alignment.",
     href: "/estimator",
   },
   {

--- a/ui/partner-hub/components/left-nav.tsx
+++ b/ui/partner-hub/components/left-nav.tsx
@@ -10,7 +10,7 @@ const links = [
   { name: "Home", href: "/" },
   { name: "Case Studies", href: "/case-studies" },
   { name: "Presales Studio", href: "/tools/architecture-explorer" },
-  { name: "Estimator", href: "/estimator" },
+  { name: "Account Mapping", href: "/estimator" },
   { name: "Energy Tool", href: "/tools/energy" },
   { name: "About / Contact", href: "/about" },
 ];

--- a/ui/partner-hub/data/links.json
+++ b/ui/partner-hub/data/links.json
@@ -13,7 +13,7 @@
   ],
   "Tools": [
     {
-      "label": "Estimator",
+      "label": "Account Mapping",
       "href": "/estimator",
       "type": "internal"
     },


### PR DESCRIPTION
### Motivation

- Replace the placeholder Estimator page with an intentional Account Mapping scaffold while preserving the existing `/estimator` route and navigation targets.
- Surface the new workflow in the app navigation, home featured card, and tools link data so users see the updated name everywhere.

### Description

- Replace `ui/partner-hub/app/(routes)/estimator/page.tsx` content with an Account Mapping hero, CTAs (`Start new mapping`, `Demo dataset`), a client-side privacy note, and a 4-step wizard skeleton (Upload → Map Fields → Match → Export). 
- Add and use the `Button` component and keep the route path as `/estimator` while renaming the displayed heading to `Account Mapping` in the page. 
- Update left navigation label in `ui/partner-hub/components/left-nav.tsx` from `Estimator` to `Account Mapping` while keeping `href: "/estimator"` unchanged. 
- Update the home featured card in `ui/partner-hub/app/page.tsx` and the Tools label in `ui/partner-hub/data/links.json` to `Account Mapping` (links still point to `/estimator`).

### Testing

- Ran `npm test` in `ui/partner-hub`, which executed the TypeScript tests and Node tests and reported 6 passing and 2 failing tests. 
- The failing automated tests are the presales export route tests: `returns a PDF buffer` and `returns a PPTX buffer` (tests expected HTTP 200 but received 500).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6966f58b6dd483269ab77d3aa78391b9)