### PR TITLE
Fix TS type predicate error in AccountMappingTool (ReviewRow includes "manual")

### DIFF
--- a/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
+++ b/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
@@ -980,7 +980,7 @@ export default function AccountMappingTool() {
 
   const baseReviewRows = useMemo(() => {
     return matchResults
-      .map((result) => {
+      .map<ReviewRow | null>((result) => {
         const vendor = vendorById.get(result.source.id);
         if (!vendor) {
           return null;
@@ -998,9 +998,9 @@ export default function AccountMappingTool() {
           status: result.status,
           baseStatus: result.status,
           reasons: result.best?.reasons ?? [],
-        } satisfies ReviewRow;
+        } as ReviewRow;
       })
-      .filter((row): row is ReviewRow => Boolean(row));
+      .filter((row): row is ReviewRow => row !== null);
   }, [matchResults, partnerById, vendorById]);
 
   const reviewRows = useMemo(() => {


### PR DESCRIPTION
### Motivation
- Fix a TypeScript type predicate failure when constructing `ReviewRow` entries from `matchResults` so the narrower inferred array type no longer conflicts with `ReviewRow` (the union includes a "manual" status variant). 

### Description
- Change the mapping to explicitly return `ReviewRow | null` via `.map<ReviewRow | null>(...)`, replace the `satisfies ReviewRow` expression with `as ReviewRow`, and use a strict null-check filter `.filter((row): row is ReviewRow => row !== null)` so TypeScript correctly narrows the type without changing runtime logic. 

### Testing
- Ran `npm run build` in this environment and it failed due to a missing `/workspace/accountlist/package.json`, so the build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69670cc891048326b64683e022330146)