### PR TITLE
Respect basePath for demo account-mapping CSV URLs

### DIFF
--- a/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
+++ b/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
@@ -59,8 +59,9 @@ const DEFAULT_PROGRESS_STEP = 2000;
 const MAX_PREVIEW_ROWS = 20;
 const REVIEW_ROW_HEIGHT = 168;
 const REVIEW_LIST_HEIGHT = 560;
-const DEMO_VENDOR_URL = "/samples/account-mapping/vendor.csv";
-const DEMO_PARTNER_URL = "/samples/account-mapping/partner.csv";
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+const DEMO_VENDOR_URL = `${basePath}/samples/account-mapping/vendor.csv`;
+const DEMO_PARTNER_URL = `${basePath}/samples/account-mapping/partner.csv`;
 const INPUT_BASE_CLASSES =
   "rounded-md border border-foreground/20 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40";
 


### PR DESCRIPTION
### Motivation
- Ensure the "Load demo dataset" action in Account Mapping works when Next.js `basePath` is enabled by making demo CSV URLs basePath-aware.

### Description
- Read `NEXT_PUBLIC_BASE_PATH` into `basePath` (fallback to empty string) and prefix the demo CSV URLs in `ui/partner-hub/components/account-mapping/AccountMappingTool.tsx` so `DEMO_VENDOR_URL` and `DEMO_PARTNER_URL` resolve correctly under a base path.

### Testing
- Ran `npm run build` at the repo root which failed because `package.json` was not present in the root; this is unrelated to the change and build could not proceed there. 
- Ran `npm run build` in `ui/partner-hub` which started the Next.js build but failed with a TypeScript error: missing declaration for module `papaparse` in `lib/account-mapping/workers/csvParse.worker.ts` (suggests adding `@types/papaparse` or a module declaration); the URL change itself compiled before this unrelated type error blocked the full build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69671076f200832693b4323e70d70adc)