### PR TITLE
Energy comparison cards — align rows + split Cost % into its own line

### DIFF
--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -562,17 +562,26 @@ export function EnergyTool() {
     | "weightedW"
     | "kwhPerYear"
     | "annualCost"
+    | "costPct"
     | "btuPerHour"
     | "rackUnits"
     | "co2eYear"
     | "co2ePerTbYear";
 
-  const energyRowKeys = ["effectiveTb", "weightedW", "kwhPerYear", "annualCost", "rackUnits"] as const satisfies readonly RowKey[];
+  const energyRowKeys = [
+    "effectiveTb",
+    "weightedW",
+    "kwhPerYear",
+    "annualCost",
+    "costPct",
+    "rackUnits",
+  ] as const satisfies readonly RowKey[];
   const energyTotalsRowKeys = [
     "effectiveTb",
     "weightedW",
     "kwhPerYear",
     "annualCost",
+    "costPct",
     "btuPerHour",
     "rackUnits",
   ] as const satisfies readonly RowKey[];
@@ -607,6 +616,7 @@ export function EnergyTool() {
     weightedW: "Weighted IT load (W)",
     kwhPerYear: "kWh / year (with PUE)",
     annualCost: "Annual energy cost",
+    costPct: "Cost %",
     btuPerHour: "BTU / hour",
     rackUnits: "Total rack units",
     co2eYear: "CO₂e / year",
@@ -617,6 +627,7 @@ export function EnergyTool() {
     weightedW: "W",
     kwhPerYear: "kWh/year",
     annualCost: "USD/year",
+    costPct: null,
     btuPerHour: "BTU/hour",
     rackUnits: "RU",
     co2eYear: "tCO₂e/year",
@@ -629,6 +640,7 @@ export function EnergyTool() {
         weightedW: fmt0.format(fb.weightedW),
         kwhPerYear: fmt0.format(fb.kwhWithPue),
         annualCost: `$${fmt0.format(fb.annualCost)}`,
+        costPct: "—",
         btuPerHour: fmt0.format(fb.btuPerHour),
         rackUnits: formatRackUnits(fb.rackUnits),
         co2eYear: formatCo2eYear(fbCo2eKgPerYear),
@@ -642,23 +654,20 @@ export function EnergyTool() {
         weightedW: fmt0.format(selectedCandidate.weightedW),
         kwhPerYear: fmt0.format(selectedCandidate.kwhYearWithPue),
         annualCost: `$${fmt0.format(selectedCandidate.annualEnergyCost)}`,
+        costPct: "—",
         rackUnits: formatRackUnits(selectedCandidate.rackUnits),
         co2eYear: formatCo2eYear(netappCo2eKgPerYear),
         co2ePerTbYear: formatCo2ePerTbYear(netappCo2ePerTbYear),
       }
     : null;
 
-  const deltaCostWithPct =
-    savings?.deltaCost == null
-      ? "—"
-      : `$${fmt0.format(savings.deltaCost)}${
-          view !== "sustainability" && savings?.pctCost != null ? ` (${fmt1.format(savings.pctCost)}%)` : ""
-        }`;
   const deltaRowValues: Partial<Record<RowKey, string>> = {
     effectiveTb: savings?.deltaEffectiveTb == null ? "—" : fmt0.format(savings.deltaEffectiveTb),
     weightedW: savings?.deltaW == null ? "—" : fmt0.format(savings.deltaW),
     kwhPerYear: savings?.deltaKwh == null ? "—" : fmt0.format(savings.deltaKwh),
-    annualCost: deltaCostWithPct,
+    annualCost: savings?.deltaCost == null ? "—" : `$${fmt0.format(savings.deltaCost)}`,
+    costPct:
+      view !== "sustainability" && savings?.pctCost != null ? `${fmt1.format(savings.pctCost)}%` : "—",
     rackUnits: savings?.deltaRackUnits == null ? "—" : fmt0.format(savings.deltaRackUnits),
     co2eYear: formatCo2eYear(deltaCo2eKgPerYear),
     co2ePerTbYear: formatCo2ePerTbYear(deltaCo2ePerTbYear),


### PR DESCRIPTION
### Motivation
- Prevent the delta card from wrapping values like `$-5,447 (-91.8%)` so rows line up across the three comparison cards.
- Add a dedicated Cost % row so numeric rows (including `Total rack units`) share the same vertical position in every card.
- Ensure the delta percent appears on its own line and uses the same right-aligned numeric styling as other values.

### Description
- Added a new `RowKey` value `costPct` and registered it in `energyRowKeys` and `energyTotalsRowKeys` so it appears after `annualCost` and before `rackUnits`.
- Added `rowLabels.costPct = "Cost %"` and `rowUnits.costPct = null` to expose the new row and avoid unit rendering.
- Populated `fbRowValues.costPct` and `netappRowValues.costPct` with a placeholder `"—"` so all three cards have identical row counts.
- Split the embedded percent from the delta cost output by replacing the combined string with `deltaRowValues.annualCost = \`$${fmt0.format(savings.deltaCost)}\`` and `deltaRowValues.costPct = \`${fmt1.format(savings.pctCost)}%\` (or `"—"` when unavailable), using the same value styling as other numeric cells.

### Testing
- Ran `npm run build` in `ui/partner-hub` (which runs the Next build pipeline); the build completed successfully and static pages were generated.
- An attempt to run `npm run build` at the repository root failed due to a missing `package.json` at `/workspace/accountlist`, which is unrelated to the component change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69682733be2c8326a92f7fe1b689c2d0)