### PR TITLE
Account Mapping search UX — 3-line layout (Account + Vendor filters + Partner filters) + modern visual refresh

### DIFF
--- a/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
+++ b/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
@@ -71,6 +71,7 @@ import {
   type StoredCsvSnapshot,
 } from "@/lib/account-mapping/runHistory";
 import { Combobox, type ComboboxOption } from "@/components/ui/combobox";
+import { MultiCombobox } from "@/components/ui/multiCombobox";
 
 const DEFAULT_PROGRESS_STEP = 2000;
 const MAX_PREVIEW_ROWS = 20;
@@ -392,18 +393,21 @@ const MergedDatasetSearchPanelSimple = ({
   uploadState: CsvParseState;
   onUploadFile: (file: File) => void;
 }) => {
+  const [accountNamesFilter, setAccountNamesFilter] = useState<string[]>([]);
   const [vendorOwnerFilter, setVendorOwnerFilter] = useState("");
+  const [vendorRegionFilter, setVendorRegionFilter] = useState("");
+  const [vendorOrganizationFilter, setVendorOrganizationFilter] = useState("");
+  const [vendorStatusFilter, setVendorStatusFilter] = useState("");
   const [partnerOwnerFilter, setPartnerOwnerFilter] = useState("");
-  const [regionFilter, setRegionFilter] = useState("");
-  const [organizationFilter, setOrganizationFilter] = useState("");
-  const [customerProspectFilter, setCustomerProspectFilter] = useState("");
+  const [partnerRegionFilter, setPartnerRegionFilter] = useState("");
+  const [partnerOrganizationFilter, setPartnerOrganizationFilter] = useState("");
+  const [partnerStatusFilter, setPartnerStatusFilter] = useState("");
   const [overlapOnly, setOverlapOnly] = useState(false);
   const [firstFilterKey, setFirstFilterKey] = useState<FilterKey | null>(null);
   const previousOwnersRef = useRef({ hasVendor: false, hasPartner: false });
 
   const hasVendorOwner = Boolean(vendorOwnerFilter);
   const hasPartnerOwner = Boolean(partnerOwnerFilter);
-  const hasAnyOwner = hasVendorOwner || hasPartnerOwner;
 
   useEffect(() => {
     const hasBothOwners = hasVendorOwner && hasPartnerOwner;
@@ -421,7 +425,8 @@ const MergedDatasetSearchPanelSimple = ({
     () => SIMPLE_SEARCH_COLUMNS.filter((column) => headers.includes(column)),
     [headers],
   );
-  const hasAnyStatus = headers.includes("vendor_status") || headers.includes("partner_status");
+  const hasVendorStatus = headers.includes("vendor_status");
+  const hasPartnerStatus = headers.includes("partner_status");
 
   const missingUploadColumns = useMemo(() => {
     if (dataset !== "upload") {
@@ -432,109 +437,58 @@ const MergedDatasetSearchPanelSimple = ({
     );
   }, [dataset, headers]);
 
-  const normalizeFilter = (value: string) => value.trim().toLowerCase();
-  const matchesExact = (value: string | undefined, filter: string) => {
-    if (!filter) {
-      return true;
-    }
-    return normalizeFilter(value ?? "") === normalizeFilter(filter);
-  };
-  const matchesEither = (row: MergedSearchRow, filter: string, keys: string[]) => {
-    if (!filter) {
-      return true;
-    }
-    return keys.some((key) => matchesExact(row[key], filter));
-  };
-
   const hasVendorAccount = (row: MergedSearchRow) =>
     Boolean(row.vendor_account_name?.trim());
   const hasPartnerAccount = (row: MergedSearchRow) =>
     Boolean(row.partner_account_name?.trim());
 
-  const matchesSideFilters = useCallback(
-    (row: MergedSearchRow, side: "vendor" | "partner" | "both") => {
-      if (side === "vendor" || side === "both") {
-        if (hasVendorOwner && !matchesExact(row.vendor_owner, vendorOwnerFilter)) {
-          return false;
-        }
-      }
-
-      if (side === "partner" || side === "both") {
-        if (hasPartnerOwner && !matchesExact(row.partner_owner, partnerOwnerFilter)) {
-          return false;
-        }
-      }
-
-      if (
-        regionFilter &&
-        !matchesEither(row, regionFilter, ["vendor_region", "partner_region"])
-      ) {
-        return false;
-      }
-
-      if (
-        organizationFilter &&
-        !matchesEither(row, organizationFilter, [
-          "vendor_organization",
-          "partner_organization",
-        ])
-      ) {
-        return false;
-      }
-
-      if (
-        customerProspectFilter &&
-        hasAnyStatus &&
-        !matchesEither(row, customerProspectFilter, ["vendor_status", "partner_status"])
-      ) {
-        return false;
-      }
-
-      return true;
-    },
-    [
-      customerProspectFilter,
-      hasAnyStatus,
-      hasPartnerOwner,
-      hasVendorOwner,
-      organizationFilter,
-      partnerOwnerFilter,
-      regionFilter,
-      vendorOwnerFilter,
-    ],
-  );
-
   const filterState = useMemo<MergedSearchFilterState>(
     () => ({
+      accountNames: accountNamesFilter,
       vendorOwner: vendorOwnerFilter,
+      vendorRegion: vendorRegionFilter,
+      vendorOrganization: vendorOrganizationFilter,
+      vendorStatus: vendorStatusFilter,
       partnerOwner: partnerOwnerFilter,
-      region: regionFilter,
-      organization: organizationFilter,
-      custProspect: customerProspectFilter,
+      partnerRegion: partnerRegionFilter,
+      partnerOrganization: partnerOrganizationFilter,
+      partnerStatus: partnerStatusFilter,
     }),
     [
-      customerProspectFilter,
-      organizationFilter,
+      accountNamesFilter,
+      partnerOrganizationFilter,
       partnerOwnerFilter,
-      regionFilter,
+      partnerRegionFilter,
+      partnerStatusFilter,
+      vendorOrganizationFilter,
       vendorOwnerFilter,
+      vendorRegionFilter,
+      vendorStatusFilter,
     ],
   );
 
   const activeFilterKeys = useMemo<FilterKey[]>(
     () => [
+      accountNamesFilter.length > 0 ? "accountNames" : null,
       vendorOwnerFilter ? "vendorOwner" : null,
+      vendorRegionFilter ? "vendorRegion" : null,
+      vendorOrganizationFilter ? "vendorOrganization" : null,
+      vendorStatusFilter ? "vendorStatus" : null,
       partnerOwnerFilter ? "partnerOwner" : null,
-      regionFilter ? "region" : null,
-      organizationFilter ? "organization" : null,
-      customerProspectFilter ? "custProspect" : null,
+      partnerRegionFilter ? "partnerRegion" : null,
+      partnerOrganizationFilter ? "partnerOrganization" : null,
+      partnerStatusFilter ? "partnerStatus" : null,
     ].filter((value): value is FilterKey => value !== null),
     [
-      customerProspectFilter,
-      organizationFilter,
+      accountNamesFilter.length,
+      partnerOrganizationFilter,
       partnerOwnerFilter,
-      regionFilter,
+      partnerRegionFilter,
+      partnerStatusFilter,
+      vendorOrganizationFilter,
       vendorOwnerFilter,
+      vendorRegionFilter,
+      vendorStatusFilter,
     ],
   );
 
@@ -580,48 +534,74 @@ const MergedDatasetSearchPanelSimple = ({
 
   useEffect(() => {
     const cleanedFilters = clearInvalidFilters(filterState, optionsFor);
+    const hasAccountChanges =
+      cleanedFilters.accountNames.length !== accountNamesFilter.length ||
+      cleanedFilters.accountNames.some(
+        (value, index) => value !== accountNamesFilter[index],
+      );
+    if (hasAccountChanges) {
+      setAccountNamesFilter(cleanedFilters.accountNames);
+    }
     if (cleanedFilters.vendorOwner !== vendorOwnerFilter) {
       setVendorOwnerFilter(cleanedFilters.vendorOwner);
+    }
+    if (cleanedFilters.vendorRegion !== vendorRegionFilter) {
+      setVendorRegionFilter(cleanedFilters.vendorRegion);
+    }
+    if (cleanedFilters.vendorOrganization !== vendorOrganizationFilter) {
+      setVendorOrganizationFilter(cleanedFilters.vendorOrganization);
+    }
+    if (cleanedFilters.vendorStatus !== vendorStatusFilter) {
+      setVendorStatusFilter(cleanedFilters.vendorStatus);
     }
     if (cleanedFilters.partnerOwner !== partnerOwnerFilter) {
       setPartnerOwnerFilter(cleanedFilters.partnerOwner);
     }
-    if (cleanedFilters.region !== regionFilter) {
-      setRegionFilter(cleanedFilters.region);
+    if (cleanedFilters.partnerRegion !== partnerRegionFilter) {
+      setPartnerRegionFilter(cleanedFilters.partnerRegion);
     }
-    if (cleanedFilters.organization !== organizationFilter) {
-      setOrganizationFilter(cleanedFilters.organization);
+    if (cleanedFilters.partnerOrganization !== partnerOrganizationFilter) {
+      setPartnerOrganizationFilter(cleanedFilters.partnerOrganization);
     }
-    if (cleanedFilters.custProspect !== customerProspectFilter) {
-      setCustomerProspectFilter(cleanedFilters.custProspect);
+    if (cleanedFilters.partnerStatus !== partnerStatusFilter) {
+      setPartnerStatusFilter(cleanedFilters.partnerStatus);
     }
   }, [
-    customerProspectFilter,
+    accountNamesFilter,
     filterState,
     optionsFor,
-    organizationFilter,
+    partnerOrganizationFilter,
     partnerOwnerFilter,
-    regionFilter,
+    partnerRegionFilter,
+    partnerStatusFilter,
+    vendorOrganizationFilter,
     vendorOwnerFilter,
+    vendorRegionFilter,
+    vendorStatusFilter,
   ]);
 
   const isClearDisabled = useMemo(
     () => isFilterStateEmpty(filterState),
     [filterState],
   );
+  const hasAnyFilters = useMemo(() => !isFilterStateEmpty(filterState), [filterState]);
 
   const handleClearAll = () => {
     const emptyFilters = createEmptyFilterState();
+    setAccountNamesFilter(emptyFilters.accountNames);
     setVendorOwnerFilter(emptyFilters.vendorOwner);
+    setVendorRegionFilter(emptyFilters.vendorRegion);
+    setVendorOrganizationFilter(emptyFilters.vendorOrganization);
+    setVendorStatusFilter(emptyFilters.vendorStatus);
     setPartnerOwnerFilter(emptyFilters.partnerOwner);
-    setRegionFilter(emptyFilters.region);
-    setOrganizationFilter(emptyFilters.organization);
-    setCustomerProspectFilter(emptyFilters.custProspect);
+    setPartnerRegionFilter(emptyFilters.partnerRegion);
+    setPartnerOrganizationFilter(emptyFilters.partnerOrganization);
+    setPartnerStatusFilter(emptyFilters.partnerStatus);
     setFirstFilterKey(null);
   };
 
   const sections = useMemo(() => {
-    if (!hasAnyOwner) {
+    if (!hasAnyFilters) {
       return [];
     }
     if (rows.length === 0 || missingUploadColumns.length > 0) {
@@ -633,29 +613,33 @@ const MergedDatasetSearchPanelSimple = ({
       hasVendorAccount(row) && !hasPartnerAccount(row);
     const isPartnerOnly = (row: MergedSearchRow) =>
       hasPartnerAccount(row) && !hasVendorAccount(row);
+    const overlapRows = rows.filter(isOverlap);
 
     if (hasVendorOwner && hasPartnerOwner) {
-      const overlapRows = rows.filter(isOverlap);
-      const shared = getEligibleRows({ rows: overlapRows, filters: filterState }).filter(
-        (row) => matchesSideFilters(row, "both"),
-      );
+      const shared = getEligibleRows({ rows: overlapRows, filters: filterState });
       if (overlapOnly) {
         return [{ id: "shared", title: "Shared accounts", rows: shared }];
       }
       const vendorOnly = getEligibleRows({
         rows,
-        filters: filterState,
-        excludeKey: "partnerOwner",
-      })
-        .filter(isVendorOnly)
-        .filter((row) => matchesSideFilters(row, "vendor"));
+        filters: {
+          ...filterState,
+          partnerOwner: "",
+          partnerRegion: "",
+          partnerOrganization: "",
+          partnerStatus: "",
+        },
+      }).filter(isVendorOnly);
       const partnerOnly = getEligibleRows({
         rows,
-        filters: filterState,
-        excludeKey: "vendorOwner",
-      })
-        .filter(isPartnerOnly)
-        .filter((row) => matchesSideFilters(row, "partner"));
+        filters: {
+          ...filterState,
+          vendorOwner: "",
+          vendorRegion: "",
+          vendorOrganization: "",
+          vendorStatus: "",
+        },
+      }).filter(isPartnerOnly);
       return [
         { id: "shared", title: "Shared accounts", rows: shared },
         { id: "vendor-only", title: "Vendor-only accounts", rows: vendorOnly },
@@ -663,28 +647,32 @@ const MergedDatasetSearchPanelSimple = ({
       ];
     }
 
-    const side: "vendor" | "partner" = hasVendorOwner ? "vendor" : "partner";
-    const results = getEligibleRows({
-      rows: baseRows,
-      filters: filterState,
-      excludeKey: side === "vendor" ? "partnerOwner" : "vendorOwner",
-    }).filter((row) => {
-      if (side === "vendor" && !hasVendorAccount(row)) {
-        return false;
-      }
-      if (side === "partner" && !hasPartnerAccount(row)) {
-        return false;
-      }
-      return matchesSideFilters(row, side);
-    });
+    if (hasVendorOwner || hasPartnerOwner) {
+      const side: "vendor" | "partner" = hasVendorOwner ? "vendor" : "partner";
+      const results = getEligibleRows({
+        rows: baseRows,
+        filters: filterState,
+        excludeKey: side === "vendor" ? "partnerOwner" : "vendorOwner",
+      }).filter((row) => {
+        if (side === "vendor" && !hasVendorAccount(row)) {
+          return false;
+        }
+        if (side === "partner" && !hasPartnerAccount(row)) {
+          return false;
+        }
+        return true;
+      });
+      return [{ id: "results", title: "Results", rows: results }];
+    }
+
+    const results = getEligibleRows({ rows: baseRows, filters: filterState });
     return [{ id: "results", title: "Results", rows: results }];
   }, [
     baseRows,
     filterState,
-    hasAnyOwner,
+    hasAnyFilters,
     hasPartnerOwner,
     hasVendorOwner,
-    matchesSideFilters,
     missingUploadColumns.length,
     overlapOnly,
     rows,
@@ -709,7 +697,9 @@ const MergedDatasetSearchPanelSimple = ({
     disabled = false,
   ) => (
     <div className="min-w-[180px] flex-1 space-y-2">
-      <label className="text-sm font-medium">{label}</label>
+      <label className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
+        {label}
+      </label>
       <Combobox
         value={value}
         onChange={onChange}
@@ -727,9 +717,6 @@ const MergedDatasetSearchPanelSimple = ({
         <CardTitle className="text-lg">Search merged dataset</CardTitle>
         <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-foreground/60">
           <span>Dataset: {datasetLabel}</span>
-          <span>
-            Showing {totalResults.toLocaleString()} of {rows.length.toLocaleString()}
-          </span>
         </div>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -775,45 +762,98 @@ const MergedDatasetSearchPanelSimple = ({
           </div>
         ) : (
           <>
-            <div className="grid gap-3 lg:grid-cols-[repeat(5,minmax(180px,1fr))]">
-              {renderFilterCombobox(
-                "Vendor owner",
-                vendorOwnerFilter,
-                setVendorOwnerFilter,
-                optionsWithCounts.vendorOwner,
-                "All vendor owners",
-              )}
-              {renderFilterCombobox(
-                "Partner owner",
-                partnerOwnerFilter,
-                setPartnerOwnerFilter,
-                optionsWithCounts.partnerOwner,
-                "All partner owners",
-              )}
-              {renderFilterCombobox(
-                "Region",
-                regionFilter,
-                setRegionFilter,
-                optionsWithCounts.region,
-                "All regions",
-              )}
-              {renderFilterCombobox(
-                "Organization",
-                organizationFilter,
-                setOrganizationFilter,
-                optionsWithCounts.organization,
-                "All organizations",
-              )}
-              {renderFilterCombobox(
-                "Customer / Prospect",
-                customerProspectFilter,
-                setCustomerProspectFilter,
-                optionsWithCounts.custProspect,
-                hasAnyStatus ? "All statuses" : "Status unavailable",
-                !hasAnyStatus,
-              )}
+            <div className="space-y-4 rounded-xl border border-foreground/10 bg-foreground/[0.03] p-4">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
+                  Account
+                </p>
+                <MultiCombobox
+                  values={accountNamesFilter}
+                  onChange={setAccountNamesFilter}
+                  options={optionsWithCounts.accountNames}
+                  placeholder="Search accounts..."
+                  emptyLabel="No matching accounts"
+                  maxVisibleOptions={300}
+                />
+              </div>
+
+              <div className="space-y-4">
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-start">
+                  <div className="min-w-[80px] pt-1 text-xs font-semibold uppercase tracking-wide text-foreground/50">
+                    Vendor
+                  </div>
+                  <div className="grid flex-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                    {renderFilterCombobox(
+                      "Owner",
+                      vendorOwnerFilter,
+                      setVendorOwnerFilter,
+                      optionsWithCounts.vendorOwner,
+                      "All vendor owners",
+                    )}
+                    {renderFilterCombobox(
+                      "Region",
+                      vendorRegionFilter,
+                      setVendorRegionFilter,
+                      optionsWithCounts.vendorRegion,
+                      "All regions",
+                    )}
+                    {renderFilterCombobox(
+                      "Organization",
+                      vendorOrganizationFilter,
+                      setVendorOrganizationFilter,
+                      optionsWithCounts.vendorOrganization,
+                      "All organizations",
+                    )}
+                    {renderFilterCombobox(
+                      "Customer / Prospect",
+                      vendorStatusFilter,
+                      setVendorStatusFilter,
+                      optionsWithCounts.vendorStatus,
+                      hasVendorStatus ? "All statuses" : "Status unavailable",
+                      !hasVendorStatus,
+                    )}
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-start">
+                  <div className="min-w-[80px] pt-1 text-xs font-semibold uppercase tracking-wide text-foreground/50">
+                    Partner
+                  </div>
+                  <div className="grid flex-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                    {renderFilterCombobox(
+                      "Owner",
+                      partnerOwnerFilter,
+                      setPartnerOwnerFilter,
+                      optionsWithCounts.partnerOwner,
+                      "All partner owners",
+                    )}
+                    {renderFilterCombobox(
+                      "Region",
+                      partnerRegionFilter,
+                      setPartnerRegionFilter,
+                      optionsWithCounts.partnerRegion,
+                      "All regions",
+                    )}
+                    {renderFilterCombobox(
+                      "Organization",
+                      partnerOrganizationFilter,
+                      setPartnerOrganizationFilter,
+                      optionsWithCounts.partnerOrganization,
+                      "All organizations",
+                    )}
+                    {renderFilterCombobox(
+                      "Customer / Prospect",
+                      partnerStatusFilter,
+                      setPartnerStatusFilter,
+                      optionsWithCounts.partnerStatus,
+                      hasPartnerStatus ? "All statuses" : "Status unavailable",
+                      !hasPartnerStatus,
+                    )}
+                  </div>
+                </div>
+              </div>
             </div>
-            <div className="flex flex-wrap items-center justify-between gap-3 text-sm font-medium">
+            <div className="flex flex-wrap items-center justify-end gap-3 text-sm font-medium">
               <label className="flex items-center gap-2">
                 <input
                   type="checkbox"
@@ -834,16 +874,9 @@ const MergedDatasetSearchPanelSimple = ({
               </Button>
             </div>
 
-            <p className="text-xs text-foreground/50">
-              Filters apply to owners by side, while region, organization, and status match
-              either side.
-            </p>
-
             <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-foreground/60">
               <span>
-                {hasAnyOwner
-                  ? `Filtered results: ${totalResults.toLocaleString()}`
-                  : "Choose a vendor or partner owner to begin."}
+                Showing {totalResults.toLocaleString()} of {rows.length.toLocaleString()}
               </span>
               <Button
                 size="sm"
@@ -854,9 +887,9 @@ const MergedDatasetSearchPanelSimple = ({
               </Button>
             </div>
 
-            {!hasAnyOwner ? (
+            {!hasAnyFilters ? (
               <p className="text-sm text-foreground/60">
-                Select a vendor or partner owner to see results.
+                Select an account, vendor filters, or partner filters to begin.
               </p>
             ) : sections.length === 0 ? (
               <p className="text-sm text-foreground/60">No rows match these filters.</p>

--- a/ui/partner-hub/components/ui/multiCombobox.tsx
+++ b/ui/partner-hub/components/ui/multiCombobox.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+
+import {
+  formatComboboxOptionLabel,
+  toComboboxOption,
+  type ComboboxOption,
+  type ComboboxOptionInput,
+} from "./comboboxUtils";
+
+const INPUT_BASE_CLASSES =
+  "rounded-md border border-foreground/20 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40";
+const DEFAULT_MAX_VISIBLE_OPTIONS = 300;
+
+type MultiComboboxProps = {
+  values: string[];
+  onChange: (values: string[]) => void;
+  options: ComboboxOptionInput[];
+  placeholder?: string;
+  emptyLabel?: string;
+  disabled?: boolean;
+  maxVisibleOptions?: number;
+};
+
+const normalizeValue = (value: string) => value.trim().toLowerCase();
+
+export const MultiCombobox = ({
+  values,
+  onChange,
+  options,
+  placeholder,
+  emptyLabel = "No matches",
+  disabled = false,
+  maxVisibleOptions = DEFAULT_MAX_VISIBLE_OPTIONS,
+}: MultiComboboxProps) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState<number | null>(null);
+
+  const normalizedOptions = useMemo(
+    () => options.map((option) => toComboboxOption(option)),
+    [options],
+  );
+
+  const selectedSet = useMemo(() => {
+    return new Set(values.map((value) => normalizeValue(value)));
+  }, [values]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setInputValue("");
+      setHighlightedIndex(null);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [isOpen]);
+
+  const filteredOptions = useMemo(() => {
+    const normalizedInput = normalizeValue(inputValue);
+    const baseOptions = normalizedInput
+      ? normalizedOptions.filter((option) => {
+          const normalizedValue = normalizeValue(option.value);
+          if (normalizedValue.includes(normalizedInput)) {
+            return true;
+          }
+          if (option.label) {
+            return normalizeValue(option.label).includes(normalizedInput);
+          }
+          return false;
+        })
+      : normalizedOptions;
+
+    if (!normalizedInput && baseOptions.length > maxVisibleOptions) {
+      return baseOptions.slice(0, maxVisibleOptions);
+    }
+    return baseOptions;
+  }, [inputValue, maxVisibleOptions, normalizedOptions]);
+
+  const handleSelect = (nextValue: string) => {
+    if (selectedSet.has(normalizeValue(nextValue))) {
+      return;
+    }
+    onChange([...values, nextValue]);
+    setInputValue("");
+    setHighlightedIndex(null);
+    setIsOpen(true);
+  };
+
+  const handleRemove = (valueToRemove: string) => {
+    onChange(values.filter((value) => normalizeValue(value) !== normalizeValue(valueToRemove)));
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (disabled) {
+      return;
+    }
+    if (!isOpen && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
+      event.preventDefault();
+      setIsOpen(true);
+      setHighlightedIndex(0);
+      return;
+    }
+
+    if (!isOpen) {
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setIsOpen(false);
+      return;
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (highlightedIndex !== null) {
+        const option = filteredOptions[highlightedIndex];
+        if (option) {
+          handleSelect(option.value);
+        }
+      }
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setHighlightedIndex((current) => {
+        const nextIndex = current === null ? 0 : current + 1;
+        return Math.min(nextIndex, filteredOptions.length - 1);
+      });
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setHighlightedIndex((current) => {
+        const nextIndex = current === null ? filteredOptions.length - 1 : current - 1;
+        return Math.max(nextIndex, 0);
+      });
+    }
+  };
+
+  const showLimitHint =
+    !inputValue && normalizedOptions.length > maxVisibleOptions && filteredOptions.length > 0;
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <div className="space-y-2">
+        {values.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {values.map((value) => (
+              <span
+                key={value}
+                className="inline-flex items-center gap-1 rounded-full bg-foreground/5 px-2 py-1 text-xs text-foreground/80"
+              >
+                <span className="max-w-[220px] truncate">{value}</span>
+                {!disabled ? (
+                  <button
+                    type="button"
+                    className="text-foreground/60 hover:text-foreground"
+                    onClick={() => handleRemove(value)}
+                    aria-label={`Remove ${value}`}
+                  >
+                    ×
+                  </button>
+                ) : null}
+              </span>
+            ))}
+          </div>
+        ) : null}
+        <div className="flex items-center gap-2">
+          <input
+            className={`w-full ${INPUT_BASE_CLASSES}`}
+            placeholder={placeholder}
+            value={inputValue}
+            disabled={disabled}
+            onChange={(event) => {
+              setInputValue(event.target.value);
+              setIsOpen(true);
+            }}
+            onFocus={() => {
+              if (!disabled) {
+                setIsOpen(true);
+              }
+            }}
+            onKeyDown={handleKeyDown}
+          />
+          {values.length > 0 && !disabled ? (
+            <button
+              type="button"
+              className="text-xs font-semibold text-foreground/60 hover:text-foreground"
+              onClick={() => {
+                setInputValue("");
+                onChange([]);
+                setIsOpen(false);
+              }}
+            >
+              Clear all
+            </button>
+          ) : null}
+        </div>
+      </div>
+      {isOpen && !disabled ? (
+        <div className="absolute z-20 mt-1 w-full rounded-md border border-foreground/10 bg-background shadow-lg">
+          <ul className="max-h-56 overflow-auto py-1 text-sm">
+            {filteredOptions.length === 0 ? (
+              <li className="px-3 py-2 text-xs text-foreground/50">{emptyLabel}</li>
+            ) : (
+              filteredOptions.map((option, index) => {
+                const isHighlighted = highlightedIndex === index;
+                const isSelected = selectedSet.has(normalizeValue(option.value));
+                return (
+                  <li key={option.value}>
+                    <button
+                      type="button"
+                      className={`flex w-full items-center justify-between px-3 py-2 text-left ${
+                        isHighlighted ? "bg-primary/10 text-primary" : ""
+                      } ${isSelected ? "text-foreground/50" : ""}`}
+                      onMouseEnter={() => setHighlightedIndex(index)}
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                        handleSelect(option.value);
+                      }}
+                      disabled={isSelected}
+                    >
+                      <span>{formatComboboxOptionLabel(option)}</span>
+                      {isSelected ? <span className="text-xs">Selected</span> : null}
+                    </button>
+                  </li>
+                );
+              })
+            )}
+          </ul>
+          {showLimitHint ? (
+            <div className="border-t border-foreground/10 px-3 py-2 text-xs text-foreground/50">
+              Showing first {maxVisibleOptions} accounts. Type to refine.
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export type { ComboboxOption } from "./comboboxUtils";

--- a/ui/partner-hub/lib/account-mapping/mergedSearchFilters.test.ts
+++ b/ui/partner-hub/lib/account-mapping/mergedSearchFilters.test.ts
@@ -54,21 +54,52 @@ describe("merged search cascading filters", () => {
   ];
 
   const baseFilters: MergedSearchFilterState = {
+    accountNames: [],
     vendorOwner: "Alice",
+    vendorRegion: "",
+    vendorOrganization: "",
+    vendorStatus: "",
     partnerOwner: "",
-    region: "South",
-    organization: "",
-    custProspect: "",
+    partnerRegion: "South",
+    partnerOrganization: "",
+    partnerStatus: "",
   };
 
   it("filters eligible rows while excluding one key", () => {
     const eligibleRows = getEligibleRows({
       rows,
       filters: baseFilters,
-      excludeKey: "region",
+      excludeKey: "partnerRegion",
     });
     assert.equal(eligibleRows.length, 2);
     assert.equal(eligibleRows[0].vendor_owner, "Alice");
+  });
+
+  it("matches account names on either side", () => {
+    const eligibleRows = getEligibleRows({
+      rows,
+      filters: {
+        ...baseFilters,
+        accountNames: ["partner two"],
+        vendorOwner: "",
+        partnerRegion: "",
+      },
+    });
+    assert.equal(eligibleRows.length, 1);
+    assert.equal(eligibleRows[0].partner_account_name, "Partner Two");
+  });
+
+  it("does not match partner values for vendor-only filters", () => {
+    const eligibleRows = getEligibleRows({
+      rows,
+      filters: {
+        ...baseFilters,
+        vendorOwner: "",
+        partnerRegion: "",
+        vendorRegion: "East",
+      },
+    });
+    assert.equal(eligibleRows.length, 0);
   });
 
   it("builds cascading options with a first filter key", () => {
@@ -79,66 +110,78 @@ describe("merged search cascading filters", () => {
       firstFilterKey: "vendorOwner",
     });
     assert.deepEqual(options.vendorOwner, ["Alice"]);
-    assert.deepEqual(options.region, ["East", "South", "West"]);
+    assert.deepEqual(options.partnerRegion, ["East", "South"]);
   });
 
   it("clears invalid selections based on options", () => {
     const options = {
+      accountNames: ["Vendor One", "Partner Two"],
       vendorOwner: ["Alice"],
+      vendorRegion: ["West"],
+      vendorOrganization: ["OrgA"],
+      vendorStatus: ["Customer"],
       partnerOwner: ["Bob"],
-      region: ["West"],
-      organization: ["OrgA"],
-      custProspect: ["Customer"],
+      partnerRegion: ["East"],
+      partnerOrganization: ["OrgB"],
+      partnerStatus: ["Prospect"],
     };
     const cleaned = clearInvalidFilters(
       {
+        accountNames: ["Vendor One", "Missing"],
         vendorOwner: "Dan",
+        vendorRegion: "East",
+        vendorOrganization: "OrgA",
+        vendorStatus: "Prospect",
         partnerOwner: "Bob",
-        region: "East",
-        organization: "OrgA",
-        custProspect: "Prospect",
+        partnerRegion: "East",
+        partnerOrganization: "OrgX",
+        partnerStatus: "Prospect",
       },
       options,
     );
+    assert.deepEqual(cleaned.accountNames, ["Vendor One"]);
     assert.equal(cleaned.vendorOwner, "");
-    assert.equal(cleaned.region, "");
-    assert.equal(cleaned.custProspect, "");
+    assert.equal(cleaned.vendorRegion, "");
+    assert.equal(cleaned.vendorStatus, "");
+    assert.equal(cleaned.partnerOrganization, "");
   });
 
   it("counts options per key using eligible rows", () => {
     const baseRows = buildBaseRows(rows, true);
     const options = buildOptionsWithCounts({
       rows: baseRows,
-      filters: {
-        vendorOwner: "",
-        partnerOwner: "",
-        region: "",
-        organization: "",
-        custProspect: "",
-      },
+      filters: createEmptyFilterState(),
       firstFilterKey: null,
     });
 
-    assert.deepEqual(options.vendorOwner, [
-      { value: "Alice", count: 2 },
+    assert.deepEqual(options.accountNames, [
+      { value: "Partner One", count: 1 },
+      { value: "Partner Two", count: 1 },
+      { value: "Vendor One", count: 1 },
+      { value: "Vendor Two", count: 1 },
     ]);
+    assert.deepEqual(options.vendorOwner, [{ value: "Alice", count: 2 }]);
     assert.deepEqual(options.partnerOwner, [
       { value: "Bob", count: 1 },
       { value: "Cara", count: 1 },
     ]);
-    assert.deepEqual(options.region, [
-      { value: "West", count: 2 },
+    assert.deepEqual(options.vendorRegion, [{ value: "West", count: 2 }]);
+    assert.deepEqual(options.partnerRegion, [
       { value: "East", count: 1 },
       { value: "South", count: 1 },
     ]);
-    assert.deepEqual(options.organization, [
-      { value: "OrgA", count: 2 },
+    assert.deepEqual(options.vendorOrganization, [{ value: "OrgA", count: 2 }]);
+    assert.deepEqual(options.partnerOrganization, [
       { value: "OrgB", count: 1 },
       { value: "OrgC", count: 1 },
     ]);
-    assert.deepEqual(options.custProspect, [
-      { value: "Customer", count: 2 },
-      { value: "Prospect", count: 2 },
+    assert.deepEqual(options.vendorStatus, [
+      { value: "Customer", count: 1 },
+      { value: "Prospect", count: 1 },
+    ]);
+    assert.deepEqual(options.partnerStatus, [
+      { value: "Customer", count: 1 },
+      { value: "Prospect", count: 1 },
     ]);
   });
 
@@ -148,7 +191,7 @@ describe("merged search cascading filters", () => {
     assert.equal(
       isFilterStateEmpty({
         ...emptyState,
-        region: "West",
+        partnerRegion: "West",
       }),
       false,
     );

--- a/ui/partner-hub/lib/account-mapping/mergedSearchFilters.ts
+++ b/ui/partner-hub/lib/account-mapping/mergedSearchFilters.ts
@@ -1,18 +1,26 @@
 import type { MergedSearchRow } from "./mergedSearch";
 
 export type FilterKey =
+  | "accountNames"
   | "vendorOwner"
+  | "vendorRegion"
+  | "vendorOrganization"
+  | "vendorStatus"
   | "partnerOwner"
-  | "region"
-  | "organization"
-  | "custProspect";
+  | "partnerRegion"
+  | "partnerOrganization"
+  | "partnerStatus";
 
 export type MergedSearchFilterState = {
+  accountNames: string[];
   vendorOwner: string;
+  vendorRegion: string;
+  vendorOrganization: string;
+  vendorStatus: string;
   partnerOwner: string;
-  region: string;
-  organization: string;
-  custProspect: string;
+  partnerRegion: string;
+  partnerOrganization: string;
+  partnerStatus: string;
 };
 
 export type FilterOptions = Record<FilterKey, string[]>;
@@ -27,8 +35,17 @@ const normalizeValue = (value: string) => value.trim().toLowerCase();
 const matchesExact = (value: string | undefined, filter: string) =>
   normalizeValue(value ?? "") === normalizeValue(filter);
 
-const matchesEitherField = (row: MergedSearchRow, filter: string, keys: string[]) =>
-  keys.some((key) => matchesExact(row[key], filter));
+const matchesAccountNames = (row: MergedSearchRow, accountNames: string[]) => {
+  if (accountNames.length === 0) {
+    return true;
+  }
+  const vendorName = normalizeValue(row.vendor_account_name ?? "");
+  const partnerName = normalizeValue(row.partner_account_name ?? "");
+  return accountNames.some((name) => {
+    const normalized = normalizeValue(name);
+    return normalized === vendorName || normalized === partnerName;
+  });
+};
 
 export const buildBaseRows = (rows: MergedSearchRow[], overlapOnly: boolean) => {
   if (!overlapOnly) {
@@ -51,8 +68,28 @@ export const getEligibleRows = ({
   excludeKey?: FilterKey;
 }) =>
   rows.filter((row) => {
+    if (excludeKey !== "accountNames" && filters.accountNames.length > 0) {
+      if (!matchesAccountNames(row, filters.accountNames)) {
+        return false;
+      }
+    }
     if (excludeKey !== "vendorOwner" && filters.vendorOwner) {
       if (!matchesExact(row.vendor_owner, filters.vendorOwner)) {
+        return false;
+      }
+    }
+    if (excludeKey !== "vendorRegion" && filters.vendorRegion) {
+      if (!matchesExact(row.vendor_region, filters.vendorRegion)) {
+        return false;
+      }
+    }
+    if (excludeKey !== "vendorOrganization" && filters.vendorOrganization) {
+      if (!matchesExact(row.vendor_organization, filters.vendorOrganization)) {
+        return false;
+      }
+    }
+    if (excludeKey !== "vendorStatus" && filters.vendorStatus) {
+      if (!matchesExact(row.vendor_status, filters.vendorStatus)) {
         return false;
       }
     }
@@ -61,33 +98,18 @@ export const getEligibleRows = ({
         return false;
       }
     }
-    if (excludeKey !== "region" && filters.region) {
-      if (
-        !matchesEitherField(row, filters.region, [
-          "vendor_region",
-          "partner_region",
-        ])
-      ) {
+    if (excludeKey !== "partnerRegion" && filters.partnerRegion) {
+      if (!matchesExact(row.partner_region, filters.partnerRegion)) {
         return false;
       }
     }
-    if (excludeKey !== "organization" && filters.organization) {
-      if (
-        !matchesEitherField(row, filters.organization, [
-          "vendor_organization",
-          "partner_organization",
-        ])
-      ) {
+    if (excludeKey !== "partnerOrganization" && filters.partnerOrganization) {
+      if (!matchesExact(row.partner_organization, filters.partnerOrganization)) {
         return false;
       }
     }
-    if (excludeKey !== "custProspect" && filters.custProspect) {
-      if (
-        !matchesEitherField(row, filters.custProspect, [
-          "vendor_status",
-          "partner_status",
-        ])
-      ) {
+    if (excludeKey !== "partnerStatus" && filters.partnerStatus) {
+      if (!matchesExact(row.partner_status, filters.partnerStatus)) {
         return false;
       }
     }
@@ -140,11 +162,15 @@ export const buildOptionsFor = ({
   firstFilterKey: FilterKey | null;
 }): FilterOptions => {
   const keys: FilterKey[] = [
+    "accountNames",
     "vendorOwner",
+    "vendorRegion",
+    "vendorOrganization",
+    "vendorStatus",
     "partnerOwner",
-    "region",
-    "organization",
-    "custProspect",
+    "partnerRegion",
+    "partnerOrganization",
+    "partnerStatus",
   ];
 
   return keys.reduce<FilterOptions>((acc, key) => {
@@ -153,26 +179,42 @@ export const buildOptionsFor = ({
         ? rows
         : getEligibleRows({ rows, filters, excludeKey: key });
 
+    if (key === "accountNames") {
+      acc[key] = collectOptions(eligibleRows, [
+        "vendor_account_name",
+        "partner_account_name",
+      ]);
+      return acc;
+    }
     if (key === "vendorOwner") {
       acc[key] = collectOptions(eligibleRows, ["vendor_owner"]);
+      return acc;
+    }
+    if (key === "vendorRegion") {
+      acc[key] = collectOptions(eligibleRows, ["vendor_region"]);
+      return acc;
+    }
+    if (key === "vendorOrganization") {
+      acc[key] = collectOptions(eligibleRows, ["vendor_organization"]);
+      return acc;
+    }
+    if (key === "vendorStatus") {
+      acc[key] = collectOptions(eligibleRows, ["vendor_status"]);
       return acc;
     }
     if (key === "partnerOwner") {
       acc[key] = collectOptions(eligibleRows, ["partner_owner"]);
       return acc;
     }
-    if (key === "region") {
-      acc[key] = collectOptions(eligibleRows, ["vendor_region", "partner_region"]);
+    if (key === "partnerRegion") {
+      acc[key] = collectOptions(eligibleRows, ["partner_region"]);
       return acc;
     }
-    if (key === "organization") {
-      acc[key] = collectOptions(eligibleRows, [
-        "vendor_organization",
-        "partner_organization",
-      ]);
+    if (key === "partnerOrganization") {
+      acc[key] = collectOptions(eligibleRows, ["partner_organization"]);
       return acc;
     }
-    acc[key] = collectOptions(eligibleRows, ["vendor_status", "partner_status"]);
+    acc[key] = collectOptions(eligibleRows, ["partner_status"]);
     return acc;
   }, {} as FilterOptions);
 };
@@ -187,11 +229,15 @@ export const buildOptionsWithCounts = ({
   firstFilterKey: FilterKey | null;
 }): FilterOptionsWithCounts => {
   const keys: FilterKey[] = [
+    "accountNames",
     "vendorOwner",
+    "vendorRegion",
+    "vendorOrganization",
+    "vendorStatus",
     "partnerOwner",
-    "region",
-    "organization",
-    "custProspect",
+    "partnerRegion",
+    "partnerOrganization",
+    "partnerStatus",
   ];
 
   return keys.reduce<FilterOptionsWithCounts>((acc, key) => {
@@ -200,29 +246,42 @@ export const buildOptionsWithCounts = ({
         ? rows
         : getEligibleRows({ rows, filters, excludeKey: key });
 
+    if (key === "accountNames") {
+      acc[key] = collectOptionCounts(eligibleRows, [
+        "vendor_account_name",
+        "partner_account_name",
+      ]);
+      return acc;
+    }
     if (key === "vendorOwner") {
       acc[key] = collectOptionCounts(eligibleRows, ["vendor_owner"]);
+      return acc;
+    }
+    if (key === "vendorRegion") {
+      acc[key] = collectOptionCounts(eligibleRows, ["vendor_region"]);
+      return acc;
+    }
+    if (key === "vendorOrganization") {
+      acc[key] = collectOptionCounts(eligibleRows, ["vendor_organization"]);
+      return acc;
+    }
+    if (key === "vendorStatus") {
+      acc[key] = collectOptionCounts(eligibleRows, ["vendor_status"]);
       return acc;
     }
     if (key === "partnerOwner") {
       acc[key] = collectOptionCounts(eligibleRows, ["partner_owner"]);
       return acc;
     }
-    if (key === "region") {
-      acc[key] = collectOptionCounts(eligibleRows, [
-        "vendor_region",
-        "partner_region",
-      ]);
+    if (key === "partnerRegion") {
+      acc[key] = collectOptionCounts(eligibleRows, ["partner_region"]);
       return acc;
     }
-    if (key === "organization") {
-      acc[key] = collectOptionCounts(eligibleRows, [
-        "vendor_organization",
-        "partner_organization",
-      ]);
+    if (key === "partnerOrganization") {
+      acc[key] = collectOptionCounts(eligibleRows, ["partner_organization"]);
       return acc;
     }
-    acc[key] = collectOptionCounts(eligibleRows, ["vendor_status", "partner_status"]);
+    acc[key] = collectOptionCounts(eligibleRows, ["partner_status"]);
     return acc;
   }, {} as FilterOptionsWithCounts);
 };
@@ -235,38 +294,66 @@ const isValidSelection = (value: string, options: string[]) => {
   return options.some((option) => normalizeValue(option) === normalizedValue);
 };
 
+const filterValidSelections = (values: string[], options: string[]) => {
+  if (values.length === 0) {
+    return values;
+  }
+  const optionByValue = new Map<string, string>();
+  options.forEach((option) => {
+    optionByValue.set(normalizeValue(option), option);
+  });
+  return values
+    .map((value) => optionByValue.get(normalizeValue(value)))
+    .filter((value): value is string => Boolean(value));
+};
+
 export const clearInvalidFilters = (
   filters: MergedSearchFilterState,
   optionsFor: FilterOptions,
 ): MergedSearchFilterState => {
   const next = { ...filters };
 
+  next.accountNames = filterValidSelections(filters.accountNames, optionsFor.accountNames);
   if (!isValidSelection(filters.vendorOwner, optionsFor.vendorOwner)) {
     next.vendorOwner = "";
+  }
+  if (!isValidSelection(filters.vendorRegion, optionsFor.vendorRegion)) {
+    next.vendorRegion = "";
+  }
+  if (!isValidSelection(filters.vendorOrganization, optionsFor.vendorOrganization)) {
+    next.vendorOrganization = "";
+  }
+  if (!isValidSelection(filters.vendorStatus, optionsFor.vendorStatus)) {
+    next.vendorStatus = "";
   }
   if (!isValidSelection(filters.partnerOwner, optionsFor.partnerOwner)) {
     next.partnerOwner = "";
   }
-  if (!isValidSelection(filters.region, optionsFor.region)) {
-    next.region = "";
+  if (!isValidSelection(filters.partnerRegion, optionsFor.partnerRegion)) {
+    next.partnerRegion = "";
   }
-  if (!isValidSelection(filters.organization, optionsFor.organization)) {
-    next.organization = "";
+  if (!isValidSelection(filters.partnerOrganization, optionsFor.partnerOrganization)) {
+    next.partnerOrganization = "";
   }
-  if (!isValidSelection(filters.custProspect, optionsFor.custProspect)) {
-    next.custProspect = "";
+  if (!isValidSelection(filters.partnerStatus, optionsFor.partnerStatus)) {
+    next.partnerStatus = "";
   }
 
   return next;
 };
 
 export const createEmptyFilterState = (): MergedSearchFilterState => ({
+  accountNames: [],
   vendorOwner: "",
+  vendorRegion: "",
+  vendorOrganization: "",
+  vendorStatus: "",
   partnerOwner: "",
-  region: "",
-  organization: "",
-  custProspect: "",
+  partnerRegion: "",
+  partnerOrganization: "",
+  partnerStatus: "",
 });
 
 export const isFilterStateEmpty = (filters: MergedSearchFilterState) =>
-  Object.values(filters).every((value) => !value);
+  filters.accountNames.length === 0 &&
+  Object.values(filters).every((value) => (Array.isArray(value) ? true : !value));


### PR DESCRIPTION
### Motivation
- Improve usability of the merged-dataset search by exposing a clear three-row filter hierarchy: Account, Vendor, Partner, and make filters feel modern and space-efficient while preserving existing filtering semantics and scale.
- Allow users to select one or more accounts as a top-level filter concept and make region/organization/status filters operate per-side (vendor vs partner) instead of as an "either side" shared control.
- Maintain cascading option building and large-dataset performance characteristics while enabling the requested UI layout and behavior.

### Description
- Added a new `MultiCombobox` component at `ui/partner-hub/components/ui/multiCombobox.tsx` providing multi-select chips, typeahead filtering, and option limiting for large option sets.
- Reworked filter state and keys in `ui/partner-hub/lib/account-mapping/mergedSearchFilters.ts` to include `accountNames: string[]` and per-side keys `vendorRegion`, `vendorOrganization`, `vendorStatus`, `partnerRegion`, `partnerOrganization`, and `partnerStatus`; updated `getEligibleRows`, `buildOptionsFor`, `buildOptionsWithCounts`, `clearInvalidFilters`, `createEmptyFilterState`, and `isFilterStateEmpty` accordingly.
- Updated `MergedDatasetSearchPanelSimple` in `ui/partner-hub/components/account-mapping/AccountMappingTool.tsx` to implement the 3-line layout (Account row with `MultiCombobox`, Vendor row, Partner row), modernized labels/styling, relocated controls (overlap toggle / Clear all / Download), and adjusted section logic to show results when any filter is active.
- Reworked cascading option logic and filtering usage so account options are built from both `vendor_account_name` and `partner_account_name` (deduped), and vendor/partner filters only match their respective side fields.
- Updated unit tests in `ui/partner-hub/lib/account-mapping/mergedSearchFilters.test.ts` to cover account multi-select matching, vendor-only vs partner-only matching, cascading options, counts, and empty-state detection.

### Testing
- Unit tests were updated in `ui/partner-hub/lib/account-mapping/mergedSearchFilters.test.ts` to exercise the new `accountNames` and per-side filter behavior; these tests were added/modified but not executed in this rollout.
- No automated test suite (e.g. `npm test` or `npm run build`) was run as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6968591510fc8326ba31e195fb174af3)