### PR TITLE
Modern visual refresh for Partner Hub (design system polish + consistent layout)

### DIFF
--- a/ui/partner-hub/app/(routes)/about/page.tsx
+++ b/ui/partner-hub/app/(routes)/about/page.tsx
@@ -1,49 +1,68 @@
 import Link from "next/link";
+import { Mail, MapPin, ArrowUpRight } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function AboutPage() {
   return (
-    <section className="space-y-6">
-      <header className="space-y-2">
-        <h1 className="text-2xl font-semibold">About / Contact</h1>
-        <p className="text-sm text-foreground/70">
+    <section className="space-y-8 md:space-y-10">
+      <header className="space-y-3">
+        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">About / Contact</h1>
+        <p className="max-w-2xl text-base text-foreground/70">
           Portfolio context for presales solution architecture engagements.
         </p>
       </header>
-      <div className="rounded-2xl border border-border bg-background p-6 text-sm text-foreground/70 shadow-sm">
-        <p>
-          Focused on data center modernization, hybrid cloud integrations, and energy-aware infrastructure
-          planning. Available for technical discovery sessions, architecture validation, and solution
-          roadmap alignment.
-        </p>
-        <div className="mt-4 space-y-2">
-          <p>
-            <span className="font-semibold text-foreground">Contact:</span>{" "}
-            <Link href="mailto:jwsiejk@gmail.com" className="text-primary hover:underline">
-              jwsiejk@gmail.com
-            </Link>
+      <Card>
+        <CardHeader className="space-y-2">
+          <CardTitle className="text-lg">Engagement focus</CardTitle>
+          <p className="max-w-2xl text-sm text-foreground/70">
+            Focused on data center modernization, hybrid cloud integrations, and energy-aware infrastructure
+            planning. Available for technical discovery sessions, architecture validation, and solution
+            roadmap alignment.
           </p>
-          <p>
-            <span className="font-semibold text-foreground">Location:</span> Boyertown, PA
-          </p>
-          <p>
-            <span className="font-semibold text-foreground">LinkedIn:</span>{" "}
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm text-foreground/70">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="flex items-center gap-2 rounded-lg border border-border/70 bg-muted/40 px-3 py-2">
+              <Mail className="h-4 w-4 text-primary" aria-hidden />
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
+                  Contact
+                </p>
+                <Link href="mailto:jwsiejk@gmail.com" className="text-sm font-semibold text-foreground">
+                  jwsiejk@gmail.com
+                </Link>
+              </div>
+            </div>
+            <div className="flex items-center gap-2 rounded-lg border border-border/70 bg-muted/40 px-3 py-2">
+              <MapPin className="h-4 w-4 text-primary" aria-hidden />
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
+                  Location
+                </p>
+                <p className="text-sm font-semibold text-foreground">Boyertown, PA</p>
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
             <Link
               href="https://www.linkedin.com/in/james-siejk-b93a2481/"
               target="_blank"
               rel="noreferrer"
-              className="text-primary hover:underline"
+              className="inline-flex items-center gap-2 rounded-md border border-border/70 bg-background px-3 py-2 text-xs font-semibold uppercase tracking-wide text-primary transition hover:bg-muted/40"
             >
-              View profile
+              View LinkedIn
+              <ArrowUpRight className="h-4 w-4" aria-hidden />
             </Link>
-          </p>
-          <Link
-            href="/resume/James_Siejk_Resume.pdf"
-            className="inline-flex items-center text-xs font-semibold uppercase tracking-wide text-primary hover:underline"
-          >
-            Download resume
-          </Link>
-        </div>
-      </div>
+            <Link
+              href="/resume/James_Siejk_Resume.pdf"
+              className="inline-flex items-center gap-2 rounded-md border border-border/70 bg-background px-3 py-2 text-xs font-semibold uppercase tracking-wide text-primary transition hover:bg-muted/40"
+            >
+              Download resume
+              <ArrowUpRight className="h-4 w-4" aria-hidden />
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
     </section>
   );
 }

--- a/ui/partner-hub/app/page.tsx
+++ b/ui/partner-hub/app/page.tsx
@@ -95,18 +95,18 @@ const toolCards = [
 
 export default function HomePage() {
   return (
-    <div className="space-y-12">
-      <section className="relative overflow-hidden rounded-3xl border border-border bg-gradient-to-br from-primary/10 via-white to-secondary/10 p-10 shadow-sm dark:via-slate-900">
+    <div className="space-y-10 md:space-y-14">
+      <section className="relative overflow-hidden rounded-3xl border border-border/70 bg-gradient-to-br from-primary/10 via-white to-secondary/10 p-10 shadow-sm dark:via-slate-900 md:p-12">
         <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(15,23,42,0.12)_1px,_transparent_1px)] [background-size:20px_20px] opacity-40" />
         <div className="relative grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
           <div className="space-y-6">
             <p className="text-sm font-medium text-primary">
               Senior Solutions Architect / Presales Engineer
             </p>
-            <h1 className="text-4xl font-bold tracking-tight leading-tight sm:text-5xl">
+            <h1 className="text-4xl font-semibold tracking-tight leading-tight sm:text-5xl lg:text-6xl">
               James Siejk — Senior Solutions Architect / Presales Engineer
             </h1>
-            <p className="max-w-3xl text-base text-foreground/70">
+            <p className="max-w-2xl text-base leading-relaxed text-foreground/70">
               30+ years in enterprise infrastructure. I own the technical side of sales campaigns:
               discovery, architecture, validation, demos, and technical decision support across data
               center and cloud.
@@ -114,7 +114,7 @@ export default function HomePage() {
             <div className="flex flex-wrap items-center gap-3">
               <Link
                 href="/resume/James_Siejk_Resume.pdf"
-                className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-foreground shadow transition hover:bg-primary/90"
+                className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-semibold text-foreground shadow-sm transition hover:bg-primary/90"
               >
                 <Download className="h-4 w-4" aria-hidden />
                 Download Resume
@@ -123,14 +123,14 @@ export default function HomePage() {
                 href="https://www.linkedin.com/in/james-siejk-b93a2481/"
                 target="_blank"
                 rel="noreferrer"
-                className="inline-flex items-center gap-2 rounded-md border border-border bg-background/80 px-4 py-2 text-sm font-semibold text-foreground transition hover:bg-muted"
+                className="inline-flex h-10 items-center gap-2 rounded-md border border-border/70 bg-background/80 px-4 text-sm font-semibold text-foreground transition hover:bg-muted"
               >
                 <Linkedin className="h-4 w-4" aria-hidden />
                 View LinkedIn
               </Link>
               <Link
                 href="/about"
-                className="inline-flex items-center gap-2 rounded-md border border-border bg-background/80 px-4 py-2 text-sm font-semibold text-foreground transition hover:bg-muted"
+                className="inline-flex h-10 items-center gap-2 rounded-md border border-border/70 bg-background/80 px-4 text-sm font-semibold text-foreground transition hover:bg-muted"
               >
                 <Mail className="h-4 w-4" aria-hidden />
                 Contact
@@ -187,13 +187,15 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="space-y-5">
+      <section className="space-y-6">
         <div className="space-y-2">
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground/50">
             How I Work
           </p>
-          <h2 className="text-2xl font-semibold">A focused operating model for presales delivery</h2>
-          <p className="max-w-3xl text-sm text-foreground/70">
+          <h2 className="text-2xl font-semibold tracking-tight md:text-3xl">
+            A focused operating model for presales delivery
+          </h2>
+          <p className="max-w-2xl text-base text-foreground/70">
             I move from discovery to enablement with clear artifacts that build confidence, shorten
             sales cycles, and reduce technical risk for partners and customers.
           </p>
@@ -220,12 +222,14 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="space-y-5">
+      <section className="space-y-6">
         <div className="space-y-2">
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground/50">
             Selected Impact
           </p>
-          <h2 className="text-2xl font-semibold">Recent outcomes that build credibility</h2>
+          <h2 className="text-2xl font-semibold tracking-tight md:text-3xl">
+            Recent outcomes that build credibility
+          </h2>
         </div>
         <div className="grid gap-4 md:grid-cols-2">
           {impactHighlights.map((item) => (
@@ -244,11 +248,16 @@ export default function HomePage() {
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground/50">
             Featured Work
           </p>
-          <h2 className="text-2xl font-semibold">Case studies and supporting artifacts</h2>
+          <h2 className="text-2xl font-semibold tracking-tight md:text-3xl">
+            Case studies and supporting artifacts
+          </h2>
         </div>
         <div className="grid gap-4 lg:grid-cols-3">
           {caseStudies.map((study) => (
-            <Card key={study.title} className="border-border/70">
+            <Card
+              key={study.title}
+              className="border-border/70 transition hover:-translate-y-0.5 hover:shadow-md"
+            >
               <CardHeader>
                 <div className="flex items-center justify-between">
                   <CardTitle className="text-base">{study.title}</CardTitle>
@@ -292,7 +301,7 @@ export default function HomePage() {
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
               <h3 className="text-lg font-semibold">Operational accelerators</h3>
-              <p className="text-sm text-foreground/70">
+              <p className="max-w-2xl text-base text-foreground/70">
                 Tools I build to reduce friction, standardize execution, and speed up technical
                 decisions.
               </p>
@@ -303,7 +312,10 @@ export default function HomePage() {
           </div>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {toolCards.map((card) => (
-              <Card key={card.title}>
+              <Card
+                key={card.title}
+                className="transition hover:-translate-y-0.5 hover:shadow-md"
+              >
                 <CardHeader>
                   <CardTitle className="flex items-center justify-between text-base">
                     <span>{card.title}</span>

--- a/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
+++ b/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
@@ -82,7 +82,7 @@ const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
 const DEMO_VENDOR_URL = `${basePath}/samples/account-mapping/vendor.csv`;
 const DEMO_PARTNER_URL = `${basePath}/samples/account-mapping/partner.csv`;
 const INPUT_BASE_CLASSES =
-  "rounded-md border border-foreground/20 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40";
+  "h-10 rounded-lg border border-border/70 bg-background px-3 text-sm text-foreground shadow-sm transition placeholder:text-foreground/40 focus-visible:outline-none focus-visible:border-primary/60 focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 const SIMPLE_SEARCH_COLUMNS = [
   "vendor_account_name",
   "partner_account_name",
@@ -2307,12 +2307,12 @@ export default function AccountMappingTool() {
   }, [handlePartnerFile, handleVendorFile, resetRunTracking]);
 
   return (
-    <section className="space-y-8">
+    <section className="space-y-8 md:space-y-10">
       <header className="space-y-4">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="space-y-2">
-            <h1 className="text-2xl font-semibold">Account Mapping</h1>
-            <p className="text-sm text-foreground/70">
+            <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Account Mapping</h1>
+            <p className="max-w-2xl text-base text-foreground/70">
               Match partner + vendor accounts, reduce review queues, and generate target lists in minutes.
             </p>
           </div>
@@ -2344,9 +2344,9 @@ export default function AccountMappingTool() {
           {["Upload", "Map", "Match", "Review", "Export"].map((step, index) => (
             <div
               key={step}
-              className={`rounded-full px-3 py-1 ${
+              className={`rounded-full px-3 py-1 shadow-sm ${
                 index <= currentStep
-                  ? "bg-primary text-primary-foreground"
+                  ? "bg-primary text-foreground"
                   : "bg-muted text-foreground/60"
               }`}
             >

--- a/ui/partner-hub/components/app-header.tsx
+++ b/ui/partner-hub/components/app-header.tsx
@@ -29,8 +29,8 @@ export function AppHeader() {
   };
 
   return (
-    <header className="sticky top-0 z-20 border-b border-border bg-background/95 backdrop-blur">
-      <div className="mx-auto flex h-16 max-w-6xl items-center gap-4 px-6">
+    <header className="sticky top-0 z-20 border-b border-border bg-background/90 backdrop-blur">
+      <div className="mx-auto flex h-16 max-w-7xl items-center gap-4 px-6 lg:px-10">
         <Link
           href="/"
           aria-label="Portfolio Hub Home"
@@ -57,7 +57,7 @@ export function AppHeader() {
         <div className="relative mx-auto flex w-full max-w-xl items-center">
           <Search className="absolute left-3 h-4 w-4 text-foreground/40" aria-hidden />
           <input
-            className="h-10 w-full rounded-lg border border-border bg-background/60 pl-9 pr-3 text-sm shadow-inner outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/40 focus:ring-offset-2 focus:ring-offset-background"
+            className="h-10 w-full rounded-lg border border-border/70 bg-background/80 pl-9 pr-3 text-sm text-foreground shadow-inner outline-none transition focus-visible:border-primary/60 focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
             placeholder="Search portfolio resources"
             type="search"
             aria-label="Search"

--- a/ui/partner-hub/components/app-shell.tsx
+++ b/ui/partner-hub/components/app-shell.tsx
@@ -4,11 +4,13 @@ import { LeftNav } from "./left-nav";
 
 export function AppShell({ children }: { children: ReactNode }) {
   return (
-    <div className="flex min-h-screen flex-col bg-background">
+    <div className="relative flex min-h-screen flex-col bg-background">
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_left,_rgba(239,74,0,0.08),_transparent_50%),radial-gradient(circle_at_top_right,_rgba(0,174,239,0.08),_transparent_45%)]" />
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(to_bottom,_rgba(15,23,42,0.04),_transparent_40%)]" />
       <AppHeader />
-      <div className="mx-auto flex w-full max-w-6xl flex-1 gap-6 px-6 py-8">
+      <div className="mx-auto flex w-full max-w-7xl flex-1 gap-8 px-6 py-10 lg:px-10">
         <LeftNav />
-        <main className="flex-1 space-y-6">{children}</main>
+        <main className="flex-1 space-y-10 md:space-y-14">{children}</main>
       </div>
     </div>
   );

--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -31,6 +31,9 @@ const fmt1 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
 const fmt2 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 });
 const formatRackUnits = (value: number | null | undefined) => (value == null ? "—" : fmt0.format(value));
 const DEFAULT_GRID_KGCO2E_PER_KWH = 0.4;
+const INPUT_BASE_CLASSES =
+  "h-10 w-full rounded-lg border border-border/70 bg-background px-3 text-sm text-foreground shadow-sm transition placeholder:text-foreground/40 focus-visible:outline-none focus-visible:border-primary/60 focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+const LABEL_CLASSES = "text-xs font-semibold uppercase tracking-wide text-foreground/60";
 
 type EnergyMeta = {
   lastSyncedISO?: string;
@@ -956,17 +959,17 @@ export function EnergyTool() {
   const exportDisabled = loading || exportLoading != null || !fb || !selectedCandidate;
   const toggleButtonClass = (isActive: boolean) =>
     [
-      "inline-flex h-10 items-center justify-center rounded-md border px-4 text-sm font-semibold transition-colors",
+      "inline-flex h-10 items-center justify-center rounded-lg border px-4 text-sm font-semibold transition-colors",
       isActive
-        ? "border-primary bg-primary text-primary-foreground hover:bg-primary/90 ring-1 ring-primary/30"
+        ? "border-primary bg-primary text-foreground hover:bg-primary/90 ring-1 ring-primary/30"
         : "border-border bg-background text-foreground hover:bg-muted/50",
     ].join(" ");
 
   return (
-    <div className="space-y-6">
-      <header className="space-y-2">
-        <h1 className="text-2xl font-semibold">Energy Tool</h1>
-        <p className="text-sm text-foreground/70">
+    <div className="space-y-8 md:space-y-10">
+      <header className="space-y-3">
+        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Energy Tool</h1>
+        <p className="max-w-2xl text-base text-foreground/70">
           Compare annual energy consumption and cost between a FlashBlade//E configuration and a NetApp E-Series baseline.
         </p>
       </header>
@@ -988,11 +991,9 @@ export function EnergyTool() {
           <CardContent className="space-y-4">
             <div className="grid gap-3 sm:grid-cols-2">
               <div className="space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
-                  DFM size (TB)
-                </label>
+                <label className={LABEL_CLASSES}>DFM size (TB)</label>
                 <select
-                  className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm"
+                  className={INPUT_BASE_CLASSES}
                   value={inputs.dfmTb}
                   onChange={(e) => {
                     const dfmTb = Number(e.target.value);
@@ -1014,11 +1015,9 @@ export function EnergyTool() {
               </div>
 
               <div className="space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
-                  Capacity (Usable PB)
-                </label>
+                <label className={LABEL_CLASSES}>Capacity (Usable PB)</label>
                 <select
-                  className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm"
+                  className={INPUT_BASE_CLASSES}
                   value={inputs.capacityPb}
                   onChange={(e) => setInputs((prev) => ({ ...prev, capacityPb: Number(e.target.value) }))}
                   disabled={loading || capacities.length === 0}
@@ -1047,7 +1046,7 @@ export function EnergyTool() {
             <CardTitle className="text-base">NetApp baseline inputs</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="flex w-full rounded-md border border-border bg-background p-1 text-xs font-semibold uppercase tracking-wide text-foreground/70">
+            <div className="flex w-full rounded-lg border border-border/70 bg-background p-1 text-xs font-semibold uppercase tracking-wide text-foreground/70">
               <button
                 type="button"
                 className={
@@ -1077,11 +1076,9 @@ export function EnergyTool() {
               <NumberInput label="Overhead (raw→usable)" value={inputs.naOverhead} step={0.01} onChange={(v) => setInputs((p) => ({ ...p, naOverhead: v }))} />
               <NumberInput label="DRR" value={inputs.naDrr} step={0.1} onChange={(v) => setInputs((p) => ({ ...p, naDrr: v }))} />
               <div className="space-y-1">
-                <label className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
-                  Drive size (TB)
-                </label>
+                <label className={LABEL_CLASSES}>Drive size (TB)</label>
                 <select
-                  className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm"
+                  className={INPUT_BASE_CLASSES}
                   value={inputs.naDriveSizeTb}
                   onChange={(e) => setInputs((p) => ({ ...p, naDriveSizeTb: Number(e.target.value) }))}
                   disabled={loading || driveSizeOptions.length === 0}
@@ -1099,17 +1096,15 @@ export function EnergyTool() {
             </div>
 
             {mode === "manual" ? (
-              <div className="rounded-md border border-border bg-muted/30 p-3">
+              <div className="rounded-lg border border-border/70 bg-muted/30 p-4">
                 <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-foreground/60">
                   Manual configuration
                 </div>
                 <div className="grid gap-3 sm:grid-cols-2">
                   <div className="space-y-1">
-                    <label className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
-                      Controller model
-                    </label>
+                    <label className={LABEL_CLASSES}>Controller model</label>
                     <select
-                      className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm"
+                      className={INPUT_BASE_CLASSES}
                       value={manualInputs.controllerModel}
                       onChange={(e) => {
                         const controllerModel = e.target.value;
@@ -1137,11 +1132,9 @@ export function EnergyTool() {
                     </select>
                   </div>
                   <div className="space-y-1">
-                    <label className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
-                      Expansion shelf model
-                    </label>
+                    <label className={LABEL_CLASSES}>Expansion shelf model</label>
                     <select
-                      className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm"
+                      className={INPUT_BASE_CLASSES}
                       value={manualInputs.expansionModel}
                       onChange={(e) => {
                         const expansionModel = e.target.value;
@@ -1200,7 +1193,7 @@ export function EnergyTool() {
               {mode === "auto" ? (
                 <button
                   type="button"
-                  className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+                  className="inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-foreground transition hover:opacity-90 disabled:opacity-50"
                   onClick={runModel}
                   disabled={loading || pureRows.length === 0 || netappRows.length === 0}
                 >
@@ -1209,7 +1202,7 @@ export function EnergyTool() {
               ) : (
                 <button
                   type="button"
-                  className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+                  className="inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-foreground transition hover:opacity-90 disabled:opacity-50"
                   onClick={runManual}
                   disabled={manualApplyDisabled}
                 >
@@ -1250,7 +1243,7 @@ export function EnergyTool() {
               View control on the left, Export dropdown on the right */}
           <div className="flex flex-wrap items-center gap-3">
             <div className="text-xs font-semibold uppercase tracking-wide text-foreground/60">View</div>
-            <div className="flex rounded-md border border-border bg-background p-1 text-xs font-semibold uppercase tracking-wide text-foreground/70">
+            <div className="flex rounded-lg border border-border/70 bg-background p-1 text-xs font-semibold uppercase tracking-wide text-foreground/70">
               <button
                 type="button"
                 className={
@@ -1287,7 +1280,7 @@ export function EnergyTool() {
                 and the NetApp candidates card below (even when View is visible). */}
             <div className="ml-auto flex w-full justify-end sm:w-auto">
               <select
-                className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm font-semibold text-foreground transition hover:bg-muted/50 disabled:opacity-50 sm:w-[260px]"
+                className={`${INPUT_BASE_CLASSES} font-semibold text-foreground transition hover:bg-muted/50 disabled:opacity-50 sm:w-[260px]`}
                 aria-label="Export"
                 value={exportChoice}
                 onChange={handleExportChange}
@@ -1692,13 +1685,13 @@ function NumberInput({
 }) {
   return (
     <div className="space-y-1">
-      <label className="text-xs font-semibold uppercase tracking-wide text-foreground/60">{label}</label>
+      <label className={LABEL_CLASSES}>{label}</label>
       <input
         type="number"
         step={step ?? 1}
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}
-        className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm"
+        className={INPUT_BASE_CLASSES}
       />
     </div>
   );

--- a/ui/partner-hub/components/left-nav.tsx
+++ b/ui/partner-hub/components/left-nav.tsx
@@ -22,12 +22,12 @@ export function LeftNav() {
   return (
     <aside
       className={clsx(
-        "flex h-full flex-col border-r border-border bg-white/70 backdrop-blur transition-all dark:bg-slate-900/70",
+        "flex h-full flex-col border-r border-border/60 bg-white/70 backdrop-blur transition-all dark:bg-slate-900/70",
         collapsed ? "w-16" : "w-64",
       )}
     >
       <button
-        className="flex items-center justify-between px-4 py-3 text-xs font-semibold uppercase tracking-wider text-foreground/60"
+        className="flex items-center justify-between px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.2em] text-foreground/50"
         onClick={() => setCollapsed((prev) => !prev)}
         aria-label={collapsed ? "Expand navigation" : "Collapse navigation"}
       >
@@ -38,9 +38,11 @@ export function LeftNav() {
         {links.map((link) => {
           const active = link.href === "/" ? pathname === "/" : pathname.startsWith(link.href);
           const baseClasses = clsx(
-            "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition hover:bg-muted",
-            active ? "bg-primary/10 text-primary" : "text-foreground/70",
-            collapsed && "justify-center px-0",
+            "flex items-center gap-3 rounded-lg border-l-2 border-transparent px-3 py-2 text-sm font-medium transition hover:border-primary/40 hover:bg-muted/60",
+            active
+              ? "border-primary bg-primary/10 text-foreground shadow-sm"
+              : "text-foreground/70",
+            collapsed && "justify-center border-l-0 px-0",
           );
 
           return (

--- a/ui/partner-hub/components/ui/button.tsx
+++ b/ui/partner-hub/components/ui/button.tsx
@@ -2,18 +2,18 @@ import * as React from "react";
 import { clsx } from "clsx";
 
 const baseStyles =
-  "inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50";
+  "inline-flex items-center justify-center gap-2 rounded-md font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50";
 
 const variants: Record<string, string> = {
-  primary: "bg-primary text-foreground shadow hover:bg-primary/90",
-  secondary: "bg-muted text-foreground hover:bg-muted/80",
-  ghost: "bg-transparent text-foreground hover:bg-muted",
+  primary: "bg-primary text-foreground shadow-sm hover:bg-primary/90",
+  secondary: "border border-border bg-muted/80 text-foreground hover:bg-muted",
+  ghost: "bg-transparent text-foreground/80 hover:bg-muted/60",
 };
 
 const sizes: Record<string, string> = {
-  sm: "px-3 py-1.5 text-xs",
-  md: "px-4 py-2 text-sm",
-  lg: "px-5 py-2.5 text-base",
+  sm: "h-8 px-3 text-xs",
+  md: "h-10 px-4 text-sm",
+  lg: "h-12 px-5 text-base",
 };
 
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {

--- a/ui/partner-hub/components/ui/card.tsx
+++ b/ui/partner-hub/components/ui/card.tsx
@@ -14,7 +14,7 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>(
     <div
       ref={ref}
       className={clsx(
-        "rounded-xl border border-border bg-white/80 p-6 shadow-sm backdrop-blur dark:bg-slate-900/80",
+        "rounded-xl border border-border/60 bg-white/80 p-6 shadow-sm backdrop-blur transition-shadow duration-200 dark:bg-slate-900/80",
         className,
       )}
       {...props}

--- a/ui/partner-hub/components/ui/combobox.tsx
+++ b/ui/partner-hub/components/ui/combobox.tsx
@@ -10,7 +10,7 @@ import {
 } from "./comboboxUtils";
 
 const INPUT_BASE_CLASSES =
-  "rounded-md border border-foreground/20 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40";
+  "h-10 rounded-lg border border-border/70 bg-background px-3 text-sm text-foreground shadow-sm transition placeholder:text-foreground/40 focus-visible:outline-none focus-visible:border-primary/60 focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
 type ComboboxProps = {
   value: string;

--- a/ui/partner-hub/components/ui/multiCombobox.tsx
+++ b/ui/partner-hub/components/ui/multiCombobox.tsx
@@ -10,7 +10,7 @@ import {
 } from "./comboboxUtils";
 
 const INPUT_BASE_CLASSES =
-  "rounded-md border border-foreground/20 bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40";
+  "h-10 rounded-lg border border-border/70 bg-background px-3 text-sm text-foreground shadow-sm transition placeholder:text-foreground/40 focus-visible:outline-none focus-visible:border-primary/60 focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 const DEFAULT_MAX_VISIBLE_OPTIONS = 300;
 
 type MultiComboboxProps = {


### PR DESCRIPTION
### Motivation
- Create a cohesive, portfolio-grade visual polish across the Partner Hub without changing routes or adding dependencies. 
- Apply a consistent spacing/typography system so pages read as a unified product rather than disparate internal pages. 
- Improve affordances and subtle depth (nav selected state, cards, inputs, focus rings) to increase clarity and perceived quality.

### Description
- Global layout and shell: tightened container, increased max-width to `max-w-7xl`, adjusted horizontal/vertical padding and spacing, and added subtle radial/linear background washes to add depth (`ui/partner-hub/components/app-shell.tsx`, `app-header.tsx`).
- Navigation: refined left-nav selected/hover state to use a subtle left border and background highlight, tightened nav typography and collapsed behavior (`components/left-nav.tsx`).
- Core UI primitives: updated `Button`, `Card`, and combobox input styles for consistent sizing, padding, focus rings, hover states, and shadow/transition behavior (`components/ui/button.tsx`, `components/ui/card.tsx`, `components/ui/combobox.tsx`, `components/ui/multiCombobox.tsx`).
- Page-level polish: aligned typographic scale, section spacing, and card treatments on Home, About, Account Mapping, and Energy tool pages; standardized inputs and labels for form controls and search panels; added light hover lift for clickable cards (`app/page.tsx`, `app/(routes)/about/page.tsx`, `components/account-mapping/AccountMappingTool.tsx`, `components/energy/energy-tool.tsx`).

### Testing
- Ran the production build with `npm run build` and the Next.js build completed successfully and produced a static export.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69685ed60258832690363561d2fc6c28)