### PR TITLE
Upgrade case studies to registry-backed premium Card layout

### DIFF
--- a/ui/partner-hub/app/(routes)/case-studies/page.tsx
+++ b/ui/partner-hub/app/(routes)/case-studies/page.tsx
@@ -1,25 +1,55 @@
-import Link from "next/link";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+"use client";
 
-const caseStudies = [
-  {
-    title: "Tier-3 Colocation Modernization",
-    summary: "Consolidated legacy storage estates into a unified, resilient fabric with faster provisioning.",
-    href: "#",
-  },
-  {
-    title: "Healthcare Data Center Refresh",
-    summary: "Improved clinical application uptime while cutting backup windows by 40%.",
-    href: "#",
-  },
-  {
-    title: "Global SaaS Expansion",
-    summary: "Scaled multi-region capacity planning with predictable performance guardrails.",
-    href: "#",
-  },
+import { useMemo, useState } from "react";
+import { caseStudies } from "@/data/case-studies";
+import { CaseStudyCard } from "@/components/case-studies/CaseStudyCard";
+
+const filters = [
+  { label: "All", value: "all" },
+  { label: "Healthcare", value: "healthcare" },
+  { label: "Cyber Recovery", value: "cyber recovery" },
+  { label: "AI / Imaging", value: "ai / imaging" },
+  { label: "Storage Refresh", value: "storage refresh" },
 ];
 
+const normalize = (value: string) => value.toLowerCase();
+
+const matchesFilter = (filter: string, caseStudy: (typeof caseStudies)[number]) => {
+  if (filter === "all") {
+    return true;
+  }
+
+  const industry = normalize(caseStudy.industry);
+  const workloads = caseStudy.workloads.map(normalize);
+  const tags = caseStudy.tags.map(normalize);
+
+  switch (filter) {
+    case "healthcare":
+      return industry.includes("healthcare");
+    case "cyber recovery":
+      return tags.includes("cyber recovery");
+    case "ai / imaging":
+      return (
+        tags.some((tag) => tag.includes("ai") || tag.includes("imaging")) ||
+        workloads.some((workload) => workload.includes("imaging"))
+      );
+    case "storage refresh":
+      return tags.some(
+        (tag) => tag.includes("refresh") || tag.includes("storage refresh")
+      );
+    default:
+      return true;
+  }
+};
+
 export default function CaseStudiesPage() {
+  const [activeFilter, setActiveFilter] = useState(filters[0].value);
+
+  const filteredCaseStudies = useMemo(
+    () => caseStudies.filter((caseStudy) => matchesFilter(activeFilter, caseStudy)),
+    [activeFilter]
+  );
+
   return (
     <section className="space-y-6">
       <header className="space-y-2">
@@ -28,22 +58,28 @@ export default function CaseStudiesPage() {
           Proof points and outcomes from recent data center infrastructure engagements.
         </p>
       </header>
-      <div className="grid gap-4 md:grid-cols-2">
-        {caseStudies.map((study) => (
-          <Card key={study.title}>
-            <CardHeader>
-              <CardTitle className="text-base">{study.title}</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-foreground/70">
-              <p>{study.summary}</p>
-              <Link
-                href={study.href}
-                className="text-xs font-semibold uppercase tracking-wide text-primary hover:underline"
-              >
-                View summary
-              </Link>
-            </CardContent>
-          </Card>
+      <div className="flex flex-wrap gap-2">
+        {filters.map((filter) => {
+          const isActive = filter.value === activeFilter;
+          return (
+            <button
+              key={filter.value}
+              type="button"
+              onClick={() => setActiveFilter(filter.value)}
+              className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
+                isActive
+                  ? "border-primary/40 bg-primary/10 text-primary"
+                  : "border-border/70 text-foreground/60 hover:border-primary/40 hover:text-primary"
+              }`}
+            >
+              {filter.label}
+            </button>
+          );
+        })}
+      </div>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {filteredCaseStudies.map((study) => (
+          <CaseStudyCard key={study.slug} caseStudy={study} />
         ))}
       </div>
     </section>

--- a/ui/partner-hub/components/case-studies/CaseStudyCard.tsx
+++ b/ui/partner-hub/components/case-studies/CaseStudyCard.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { CaseStudy } from "@/data/case-studies";
+
+type CaseStudyCardProps = {
+  caseStudy: CaseStudy;
+};
+
+const outcomeLimit = 3;
+
+export function CaseStudyCard({ caseStudy }: CaseStudyCardProps) {
+  const href = `/case-studies/${caseStudy.slug}`;
+
+  return (
+    <Card className="border-border/70 transition hover:-translate-y-0.5 hover:shadow-md">
+      <CardHeader className="space-y-3">
+        <div className="flex flex-wrap gap-2">
+          <span className="inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+            {caseStudy.industry}
+          </span>
+          {caseStudy.workloads.map((workload) => (
+            <span
+              key={workload}
+              className="inline-flex items-center rounded-full border border-border/70 bg-muted/40 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-foreground/60"
+            >
+              {workload}
+            </span>
+          ))}
+        </div>
+        <CardTitle className="text-base">{caseStudy.title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm text-foreground/70">
+        <p>{caseStudy.heroSummary}</p>
+        <ul className="space-y-2">
+          {caseStudy.outcomes.slice(0, outcomeLimit).map((outcome) => (
+            <li key={outcome} className="flex items-start gap-3">
+              <span
+                className="mt-1 h-2 w-2 shrink-0 rounded-full bg-primary/70"
+                aria-hidden
+              />
+              <span>{outcome}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="rounded-md border border-border/70 bg-muted/40 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-foreground/60">
+          <span className="text-foreground/50">Before</span>
+          <span className="mx-2 text-foreground/40">→</span>
+          <span className="text-foreground/80">After</span>
+          <div className="mt-1 flex flex-wrap gap-x-2 gap-y-1 text-[11px] font-medium normal-case text-foreground/70">
+            <span>{caseStudy.stack.before}</span>
+            <span className="text-foreground/40">→</span>
+            <span>{caseStudy.stack.after}</span>
+          </div>
+        </div>
+        <Link
+          href={href}
+          className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary transition hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        >
+          Read case study
+          <ArrowUpRight className="h-4 w-4" aria-hidden />
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
### Motivation
- Replace the inline/static case studies list with the canonical registry and present entries using the existing premium Card design language for a consistent, higher-quality library view.
- Provide lightweight client-side filtering and a responsive grid so visitors can discover relevant case studies across devices.

### Description
- Replace the hardcoded array in the page with `caseStudies` imported from `@/data/case-studies` and convert the page to a client component (`app/(routes)/case-studies/page.tsx`).
- Add a new `CaseStudyCard` component at `ui/partner-hub/components/case-studies/CaseStudyCard.tsx` that uses `Card`, `CardHeader`, `CardContent`, and `CardTitle` and includes industry/workload badges, the `heroSummary`, an outcomes list (3 items), a "Before → After" strip, and a CTA styled like the home "Read case study" button.
- Implement client-side tag chips (`All`, `Healthcare`, `Cyber Recovery`, `AI / Imaging`, `Storage Refresh`) which filter `caseStudies` by `industry`, `workloads`, and `tags`.
- Ensure responsive layout with a grid of 1 column on mobile, 2 columns at `md`, and 3 columns at `xl`, and mirror the Featured Work hover lift via `transition hover:-translate-y-0.5 hover:shadow-md`.
- Address accessibility by providing a clear CTA with a visible `focus-visible:ring` and avoiding nested interactive conflicts by keeping the primary link as the card action.

### Testing
- Started the dev server with `npm run dev`, the `/case-studies` page compiled successfully and served (Next dev compilation completed).
- Captured a visual smoke test using Playwright which opened `/partner-hub/case-studies` and produced a screenshot artifact, confirming the page renders and the grid/cards appear.
- No automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6969809aa5e88326927bc82fa973ce46)