### PR TITLE
Add registry-driven case study detail route and not-found UI

### DIFF
--- a/ui/partner-hub/app/(routes)/case-studies/[slug]/not-found.tsx
+++ b/ui/partner-hub/app/(routes)/case-studies/[slug]/not-found.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function CaseStudyNotFound() {
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center">
+      <Card className="w-full max-w-md border-border/70">
+        <CardHeader className="space-y-2">
+          <CardTitle>Case study not found</CardTitle>
+          <p className="text-sm text-foreground/70">
+            We couldn&apos;t find that case study. Try another from the registry.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <Link
+            href="/case-studies"
+            className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary transition hover:bg-primary/10"
+          >
+            Back to case studies
+          </Link>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx
+++ b/ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx
@@ -1,0 +1,166 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { caseStudies } from "@/data/case-studies";
+
+type CaseStudyPageProps = {
+  params: {
+    slug: string;
+  };
+};
+
+export default function CaseStudyPage({ params }: CaseStudyPageProps) {
+  const caseStudy = caseStudies.find((study) => study.slug === params.slug);
+
+  if (!caseStudy) {
+    notFound();
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-4">
+        <Link
+          href="/case-studies"
+          className="text-xs font-semibold uppercase tracking-wide text-primary transition hover:text-primary/80"
+        >
+          ← Back to case studies
+        </Link>
+        <div className="space-y-3">
+          <h1 className="text-3xl font-semibold tracking-tight">
+            {caseStudy.title}
+          </h1>
+          <p className="text-base text-foreground/70">{caseStudy.heroSummary}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <span className="inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+            {caseStudy.industry}
+          </span>
+          {caseStudy.tags.map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center rounded-full border border-border/70 bg-muted/40 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-foreground/60"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <Card className="border-border/70">
+          <CardHeader>
+            <CardTitle className="text-sm font-semibold uppercase tracking-wide text-foreground/60">
+              Workloads
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-foreground/70">
+            <ul className="list-disc space-y-1 pl-5">
+              {caseStudy.workloads.map((workload) => (
+                <li key={workload}>{workload}</li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+        <Card className="border-border/70">
+          <CardHeader>
+            <CardTitle className="text-sm font-semibold uppercase tracking-wide text-foreground/60">
+              Stack shift
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-foreground/70">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
+                Before
+              </p>
+              <p>{caseStudy.stack.before}</p>
+            </div>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
+                After
+              </p>
+              <p>{caseStudy.stack.after}</p>
+            </div>
+          </CardContent>
+        </Card>
+        <Card className="border-border/70">
+          <CardHeader>
+            <CardTitle className="text-sm font-semibold uppercase tracking-wide text-foreground/60">
+              Outcomes
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-foreground/70">
+            <ul className="space-y-2">
+              {caseStudy.outcomes.map((outcome) => (
+                <li key={outcome} className="flex items-start gap-3">
+                  <span
+                    className="mt-1 h-2 w-2 shrink-0 rounded-full bg-primary/70"
+                    aria-hidden
+                  />
+                  <span>{outcome}</span>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {caseStudy.sections.map((section) => (
+          <Card key={section.id} className="border-border/70">
+            <CardHeader>
+              <CardTitle className="text-base">{section.title}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-foreground/70">
+              {section.body ? <p>{section.body}</p> : null}
+              {section.bullets ? (
+                <ul className="list-disc space-y-1 pl-5">
+                  {section.bullets.map((bullet) => (
+                    <li key={bullet}>{bullet}</li>
+                  ))}
+                </ul>
+              ) : null}
+              {section.callouts ? (
+                <div className="space-y-2">
+                  {section.callouts.map((callout) => (
+                    <div
+                      key={callout}
+                      className="rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-primary/80"
+                    >
+                      {callout}
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {caseStudy.citations.length ? (
+        <Card className="border-border/70">
+          <CardHeader>
+            <CardTitle className="text-sm font-semibold uppercase tracking-wide text-foreground/60">
+              Sources
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-foreground/70">
+            <ul className="space-y-2">
+              {caseStudy.citations.map((citation) => (
+                <li key={citation.href}>
+                  <a
+                    href={citation.href}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-primary hover:underline"
+                  >
+                    {citation.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/partner-hub/package-lock.json
+++ b/ui/partner-hub/package-lock.json
@@ -969,7 +969,6 @@
             "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -1030,7 +1029,6 @@
             "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.52.0",
                 "@typescript-eslint/types": "8.52.0",
@@ -1569,7 +1567,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1999,7 +1996,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -2326,7 +2322,6 @@
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -2777,7 +2772,6 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -2947,7 +2941,6 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -4325,7 +4318,6 @@
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -5138,7 +5130,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -5382,7 +5373,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -5395,7 +5385,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -6321,7 +6310,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -6491,7 +6479,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"


### PR DESCRIPTION
### Motivation
- Provide per-case-study detail pages driven from the centralized `caseStudies` registry so each study can be addressed at `/case-studies/{slug}`.
- Show a friendly UI when a slug is unknown by returning `notFound()` and rendering a small card-based not-found page.

### Description
- Added `ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx` which pulls `params.slug`, looks up the matching entry in `caseStudies`, calls `notFound()` if missing, and renders details (title, hero summary, industry/tags, workloads, stack shift, outcomes, sections, and citations).
- Added `ui/partner-hub/app/(routes)/case-studies/[slug]/not-found.tsx` which displays a `Card` with a message and a link back to `/case-studies`.
- Left the case study card links as-is since `CaseStudyCard` already points to `/case-studies/${caseStudy.slug}`.
- Updated `ui/partner-hub/package-lock.json` after running `npm install`.

### Testing
- Ran `npm install` in `ui/partner-hub` which completed successfully.
- Started the dev server with `npm run dev` and the server reported ready.
- Executed a Playwright script to visit `http://127.0.0.1:3000/case-studies/healthcare-data-center-refresh` and captured a screenshot (artifact produced), but the dev server logged a `GET /case-studies/healthcare-data-center-refresh` as `404` during that run indicating the route returned `notFound()` in that session.
- No full production `build` or unit test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696981e233808326a8b92839d964467e)