### PR TITLE
Redesign case study detail layout

### DIFF
--- a/ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx
+++ b/ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx
@@ -1,6 +1,9 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CaseStudyHero } from "@/components/case-studies/CaseStudyHero";
+import { CaseStudyRail } from "@/components/case-studies/CaseStudyRail";
+import { CaseStudySection } from "@/components/case-studies/CaseStudySection";
+import { CalloutCard } from "@/components/case-studies/CalloutCard";
+import { Card } from "@/components/ui/card";
 import { caseStudies } from "@/data/case-studies";
 
 type CaseStudyPageProps = {
@@ -8,6 +11,80 @@ type CaseStudyPageProps = {
     slug: string;
   };
 };
+
+const beforeAfterCards = [
+  {
+    title: "Before",
+    description: "PowerMax + Commvault",
+    accent: "from-rose-500/10 via-rose-500/5 to-transparent",
+  },
+  {
+    title: "After",
+    description: "FlashArray + FlashBlade//S + FlashBlade//E + Rubrik",
+    accent: "from-emerald-500/15 via-emerald-500/5 to-transparent",
+  },
+];
+
+const cyberResilienceTiles = [
+  {
+    title: "Immutable backups",
+    description: "Policy-driven snapshots with locked retention windows.",
+  },
+  {
+    title: "Credential isolation",
+    description: "Separation of duties with cyber vault access controls.",
+  },
+  {
+    title: "Anomaly detection",
+    description: "Signal-based alerting across backup and storage layers.",
+  },
+  {
+    title: "Rapid recovery",
+    description: "Tiered recovery plans tested against clinical RTOs.",
+  },
+];
+
+const pacsTieringTiles = [
+  {
+    title: "FlashBlade//S",
+    description: "AI + performance tier for real-time imaging workflows.",
+  },
+  {
+    title: "FlashBlade//E",
+    description: "Archive tier optimized for long-term PACS retention.",
+  },
+];
+
+const migrationPlan = [
+  {
+    phase: "Discovery",
+    deliverables: [
+      "App dependency mapping",
+      "Cyber recovery risk assessment",
+    ],
+  },
+  {
+    phase: "Build",
+    deliverables: [
+      "FlashArray + FlashBlade landing zones",
+      "Rubrik policies and recovery lanes",
+    ],
+  },
+  {
+    phase: "Migration",
+    deliverables: [
+      "Epic and PACS workload cutover waves",
+      "Archive tiering automation",
+    ],
+  },
+  {
+    phase: "Prove Recovery",
+    deliverables: [
+      "Tabletop and failover drills",
+      "Operational runbook sign-off",
+    ],
+  },
+];
 
 export default function CaseStudyPage({ params }: CaseStudyPageProps) {
   const caseStudy = caseStudies.find((study) => study.slug === params.slug);
@@ -17,100 +94,114 @@ export default function CaseStudyPage({ params }: CaseStudyPageProps) {
   }
 
   return (
-    <div className="space-y-8">
-      <div className="space-y-4">
-        <Link
-          href="/case-studies"
-          className="text-xs font-semibold uppercase tracking-wide text-primary transition hover:text-primary/80"
-        >
-          ← Back to case studies
-        </Link>
-        <div className="space-y-3">
-          <h1 className="text-3xl font-semibold tracking-tight">
-            {caseStudy.title}
-          </h1>
-          <p className="text-base text-foreground/70">{caseStudy.heroSummary}</p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <span className="inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
-            {caseStudy.industry}
-          </span>
-          {caseStudy.tags.map((tag) => (
-            <span
-              key={tag}
-              className="inline-flex items-center rounded-full border border-border/70 bg-muted/40 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-foreground/60"
-            >
-              {tag}
-            </span>
-          ))}
-        </div>
-      </div>
+    <div className="space-y-10">
+      <CaseStudyHero caseStudy={caseStudy} />
 
-      <div className="grid gap-4 lg:grid-cols-3">
-        <Card className="border-border/70">
-          <CardHeader>
-            <CardTitle className="text-sm font-semibold uppercase tracking-wide text-foreground/60">
-              Workloads
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-sm text-foreground/70">
-            <ul className="list-disc space-y-1 pl-5">
-              {caseStudy.workloads.map((workload) => (
-                <li key={workload}>{workload}</li>
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
-        <Card className="border-border/70">
-          <CardHeader>
-            <CardTitle className="text-sm font-semibold uppercase tracking-wide text-foreground/60">
-              Stack shift
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3 text-sm text-foreground/70">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
-                Before
-              </p>
-              <p>{caseStudy.stack.before}</p>
-            </div>
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
-                After
-              </p>
-              <p>{caseStudy.stack.after}</p>
-            </div>
-          </CardContent>
-        </Card>
-        <Card className="border-border/70">
-          <CardHeader>
-            <CardTitle className="text-sm font-semibold uppercase tracking-wide text-foreground/60">
-              Outcomes
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-sm text-foreground/70">
-            <ul className="space-y-2">
-              {caseStudy.outcomes.map((outcome) => (
-                <li key={outcome} className="flex items-start gap-3">
-                  <span
-                    className="mt-1 h-2 w-2 shrink-0 rounded-full bg-primary/70"
-                    aria-hidden
-                  />
-                  <span>{outcome}</span>
-                </li>
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
-      </div>
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="space-y-10">
+          <CaseStudySection title="Executive overview" eyebrow="Engagement summary">
+            {caseStudy.sections.slice(0, 1).map((section) => (
+              <p key={section.id}>{section.body}</p>
+            ))}
+          </CaseStudySection>
 
-      <div className="grid gap-4 lg:grid-cols-2">
-        {caseStudy.sections.map((section) => (
-          <Card key={section.id} className="border-border/70">
-            <CardHeader>
-              <CardTitle className="text-base">{section.title}</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-foreground/70">
+          <CaseStudySection title="Architecture at a glance" eyebrow="Storage blueprint">
+            <p>
+              A tiered storage and backup architecture anchors Epic and PACS
+              workloads while isolating recovery lanes for cyber resilience.
+            </p>
+            <div className="rounded-2xl border border-border/70 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800 p-6">
+              <div className="grid gap-4 md:grid-cols-3">
+                <div className="rounded-xl border border-white/10 bg-white/5 p-4 text-xs text-white/70">
+                  Epic + Clinical Apps
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/5 p-4 text-xs text-white/70">
+                  FlashArray (Tier-0)
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/5 p-4 text-xs text-white/70">
+                  Rubrik Cyber Vault
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/5 p-4 text-xs text-white/70">
+                  PACS + Imaging AI
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/5 p-4 text-xs text-white/70">
+                  FlashBlade//S
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/5 p-4 text-xs text-white/70">
+                  FlashBlade//E Archive
+                </div>
+              </div>
+              <p className="mt-4 text-xs text-white/50">
+                Secure lanes separate clinical operations from immutable recovery
+                stores.
+              </p>
+            </div>
+          </CaseStudySection>
+
+          <CaseStudySection title="Before → After" eyebrow="Transformation">
+            <div className="grid gap-4 md:grid-cols-2">
+              {beforeAfterCards.map((card) => (
+                <CalloutCard
+                  key={card.title}
+                  title={card.title}
+                  description={card.description}
+                  accent={card.accent}
+                />
+              ))}
+            </div>
+          </CaseStudySection>
+
+          <CaseStudySection
+            title="Cyber Resilience Posture"
+            eyebrow="Security outcomes"
+          >
+            <div className="grid gap-4 md:grid-cols-2">
+              {cyberResilienceTiles.map((tile) => (
+                <CalloutCard
+                  key={tile.title}
+                  title={tile.title}
+                  description={tile.description}
+                />
+              ))}
+            </div>
+          </CaseStudySection>
+
+          <CaseStudySection title="PACS tiering" eyebrow="Imaging strategy">
+            <div className="grid gap-4 md:grid-cols-2">
+              {pacsTieringTiles.map((tile) => (
+                <CalloutCard
+                  key={tile.title}
+                  title={tile.title}
+                  description={tile.description}
+                  accent="from-sky-500/15 via-sky-500/5 to-transparent"
+                />
+              ))}
+            </div>
+          </CaseStudySection>
+
+          <CaseStudySection title="Migration plan" eyebrow="Timeline">
+            <div className="space-y-6">
+              {migrationPlan.map((step, index) => (
+                <div key={step.phase} className="relative pl-6">
+                  <div className="absolute left-0 top-1 h-full w-px bg-border/70" />
+                  <div className="absolute left-[-5px] top-1 h-3 w-3 rounded-full bg-primary" />
+                  <div className="space-y-2">
+                    <p className="text-sm font-semibold text-foreground">
+                      Phase {index + 1}: {step.phase}
+                    </p>
+                    <ul className="list-disc space-y-1 pl-5">
+                      {step.deliverables.map((deliverable) => (
+                        <li key={deliverable}>{deliverable}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CaseStudySection>
+
+          {caseStudy.sections.slice(1).map((section) => (
+            <CaseStudySection key={section.id} title={section.title}>
               {section.body ? <p>{section.body}</p> : null}
               {section.bullets ? (
                 <ul className="list-disc space-y-1 pl-5">
@@ -120,47 +211,45 @@ export default function CaseStudyPage({ params }: CaseStudyPageProps) {
                 </ul>
               ) : null}
               {section.callouts ? (
-                <div className="space-y-2">
+                <div className="grid gap-3 md:grid-cols-2">
                   {section.callouts.map((callout) => (
-                    <div
+                    <CalloutCard
                       key={callout}
-                      className="rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-primary/80"
-                    >
-                      {callout}
-                    </div>
+                      title="Highlight"
+                      description={callout}
+                    />
                   ))}
                 </div>
               ) : null}
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+            </CaseStudySection>
+          ))}
 
-      {caseStudy.citations.length ? (
-        <Card className="border-border/70">
-          <CardHeader>
-            <CardTitle className="text-sm font-semibold uppercase tracking-wide text-foreground/60">
-              Sources
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-sm text-foreground/70">
-            <ul className="space-y-2">
-              {caseStudy.citations.map((citation) => (
-                <li key={citation.href}>
-                  <a
-                    href={citation.href}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-primary hover:underline"
-                  >
-                    {citation.label}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
-      ) : null}
+          <CaseStudySection title="Sources / Evidence" eyebrow="Citations">
+            <Card className="border-border/70 p-4">
+              <ul className="space-y-2 text-sm">
+                {caseStudy.citations.map((citation) => (
+                  <li key={citation.href}>
+                    <a
+                      href={citation.href}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="font-semibold text-primary hover:underline"
+                    >
+                      {citation.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          </CaseStudySection>
+        </div>
+
+        <CaseStudyRail caseStudy={caseStudy} />
+      </div>
     </div>
   );
+}
+
+export function generateStaticParams() {
+  return caseStudies.map((study) => ({ slug: study.slug }));
 }

--- a/ui/partner-hub/components/case-studies/CalloutCard.tsx
+++ b/ui/partner-hub/components/case-studies/CalloutCard.tsx
@@ -1,0 +1,28 @@
+import { Card } from "@/components/ui/card";
+
+type CalloutCardProps = {
+  title: string;
+  description: string;
+  accent?: string;
+};
+
+export function CalloutCard({
+  title,
+  description,
+  accent = "from-primary/15 via-primary/5 to-transparent",
+}: CalloutCardProps) {
+  return (
+    <Card className="relative overflow-hidden border-border/70 bg-background/80 p-4">
+      <div
+        className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${accent}`}
+        aria-hidden
+      />
+      <div className="relative space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+          {title}
+        </p>
+        <p className="text-sm font-medium text-foreground/80">{description}</p>
+      </div>
+    </Card>
+  );
+}

--- a/ui/partner-hub/components/case-studies/CaseStudyHero.tsx
+++ b/ui/partner-hub/components/case-studies/CaseStudyHero.tsx
@@ -1,0 +1,129 @@
+import Link from "next/link";
+import type { CaseStudy } from "@/data/case-studies";
+
+const badgeStyles =
+  "inline-flex items-center rounded-full border border-border/70 bg-muted/40 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-foreground/60";
+
+const industryBadgeStyles =
+  "inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary";
+
+type CaseStudyHeroProps = {
+  caseStudy: CaseStudy;
+};
+
+export function CaseStudyHero({ caseStudy }: CaseStudyHeroProps) {
+  return (
+    <section className="space-y-6">
+      <Link
+        href="/case-studies"
+        className="text-xs font-semibold uppercase tracking-wide text-primary transition hover:text-primary/80"
+      >
+        ← Back to case studies
+      </Link>
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_240px] lg:items-center">
+        <div className="space-y-5">
+          <div className="flex flex-wrap gap-2">
+            <span className={industryBadgeStyles}>{caseStudy.industry}</span>
+            {caseStudy.tags.map((tag) => (
+              <span key={tag} className={badgeStyles}>
+                {tag}
+              </span>
+            ))}
+          </div>
+          <div className="space-y-3">
+            <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+              {caseStudy.title}
+            </h1>
+            <p className="text-base text-foreground/70">
+              {caseStudy.heroSummary}
+            </p>
+            <p className="rounded-md border border-border/70 bg-muted/30 px-4 py-3 text-sm font-semibold text-foreground/80">
+              <span className="text-foreground/50">Transformation:</span>{" "}
+              <span>{caseStudy.stack.before}</span>
+              <span className="mx-2 text-foreground/40">→</span>
+              <span>{caseStudy.stack.after}</span>
+            </p>
+          </div>
+        </div>
+        <div className="relative overflow-hidden rounded-2xl border border-border/70 bg-gradient-to-br from-primary/20 via-background to-muted/60 p-4">
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
+              Visual tile
+            </p>
+            <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+              <svg
+                viewBox="0 0 180 120"
+                role="img"
+                aria-label="Case study architecture visual"
+                className="h-24 w-full"
+              >
+                <defs>
+                  <linearGradient id="heroGradient" x1="0" y1="0" x2="1" y2="1">
+                    <stop offset="0%" stopColor="#2563eb" stopOpacity="0.8" />
+                    <stop offset="100%" stopColor="#22d3ee" stopOpacity="0.8" />
+                  </linearGradient>
+                </defs>
+                <rect x="0" y="0" width="180" height="120" rx="16" fill="#0f172a" />
+                <rect
+                  x="12"
+                  y="18"
+                  width="64"
+                  height="32"
+                  rx="10"
+                  fill="url(#heroGradient)"
+                />
+                <rect
+                  x="92"
+                  y="18"
+                  width="76"
+                  height="32"
+                  rx="10"
+                  fill="#1e293b"
+                  stroke="#38bdf8"
+                  strokeWidth="1.5"
+                />
+                <rect
+                  x="12"
+                  y="64"
+                  width="76"
+                  height="36"
+                  rx="10"
+                  fill="#1e293b"
+                  stroke="#60a5fa"
+                  strokeWidth="1.5"
+                />
+                <rect
+                  x="98"
+                  y="64"
+                  width="70"
+                  height="36"
+                  rx="10"
+                  fill="url(#heroGradient)"
+                  opacity="0.7"
+                />
+                <path
+                  d="M46 50 L46 64"
+                  stroke="#94a3b8"
+                  strokeWidth="2"
+                />
+                <path
+                  d="M130 50 L130 64"
+                  stroke="#38bdf8"
+                  strokeWidth="2"
+                />
+                <path
+                  d="M76 34 L92 34"
+                  stroke="#94a3b8"
+                  strokeWidth="2"
+                />
+              </svg>
+            </div>
+            <p className="text-xs text-foreground/60">
+              Secure, tiered storage with cyber recovery lanes.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/ui/partner-hub/components/case-studies/CaseStudyRail.tsx
+++ b/ui/partner-hub/components/case-studies/CaseStudyRail.tsx
@@ -1,0 +1,132 @@
+import { Card } from "@/components/ui/card";
+import type { CaseStudy } from "@/data/case-studies";
+
+const sectionTitleStyles =
+  "text-xs font-semibold uppercase tracking-wide text-foreground/60";
+
+const downloadLinks = [
+  {
+    label: "Download executive summary (PDF)",
+    href: "#/downloads/executive-summary",
+  },
+  {
+    label: "Download architecture brief (PDF)",
+    href: "#/downloads/architecture-brief",
+  },
+];
+
+type CaseStudyRailProps = {
+  caseStudy: CaseStudy;
+};
+
+export function CaseStudyRail({ caseStudy }: CaseStudyRailProps) {
+  return (
+    <aside className="space-y-4 lg:sticky lg:top-24">
+      <Card className="space-y-3 border-border/70 p-4">
+        <h2 className={sectionTitleStyles}>Quick Facts</h2>
+        <dl className="space-y-3 text-sm text-foreground/70">
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
+              Industry
+            </dt>
+            <dd>{caseStudy.industry}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
+              Workloads
+            </dt>
+            <dd>
+              <ul className="mt-1 space-y-1">
+                {caseStudy.workloads.map((workload) => (
+                  <li key={workload}>{workload}</li>
+                ))}
+              </ul>
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
+              Tags
+            </dt>
+            <dd className="mt-1 flex flex-wrap gap-2">
+              {caseStudy.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-full border border-border/70 bg-muted/40 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-foreground/60"
+                >
+                  {tag}
+                </span>
+              ))}
+            </dd>
+          </div>
+        </dl>
+      </Card>
+
+      <Card className="space-y-3 border-border/70 p-4">
+        <h2 className={sectionTitleStyles}>Outcomes</h2>
+        <ul className="space-y-2 text-sm text-foreground/70">
+          {caseStudy.outcomes.map((outcome) => (
+            <li key={outcome} className="flex items-start gap-3">
+              <span
+                className="mt-1 h-2 w-2 shrink-0 rounded-full bg-primary/70"
+                aria-hidden
+              />
+              <span>{outcome}</span>
+            </li>
+          ))}
+        </ul>
+      </Card>
+
+      <Card className="space-y-3 border-border/70 p-4">
+        <h2 className={sectionTitleStyles}>Stack</h2>
+        <div className="space-y-3 text-sm text-foreground/70">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
+              Before
+            </p>
+            <p>{caseStudy.stack.before}</p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
+              After
+            </p>
+            <p>{caseStudy.stack.after}</p>
+          </div>
+        </div>
+      </Card>
+
+      <Card className="space-y-3 border-border/70 p-4">
+        <h2 className={sectionTitleStyles}>Downloads</h2>
+        <ul className="space-y-2 text-sm">
+          {downloadLinks.map((link) => (
+            <li key={link.label}>
+              <a
+                href={link.href}
+                className="font-semibold text-primary hover:underline"
+              >
+                {link.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </Card>
+
+      <Card className="space-y-3 border-border/70 p-4">
+        <h2 className={sectionTitleStyles}>Sources</h2>
+        <ul className="space-y-2 text-sm">
+          {caseStudy.citations.map((citation) => (
+            <li key={citation.href}>
+              <a
+                href={citation.href}
+                target="_blank"
+                rel="noreferrer"
+                className="font-semibold text-primary hover:underline"
+              >
+                {citation.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </Card>
+    </aside>
+  );
+}

--- a/ui/partner-hub/components/case-studies/CaseStudySection.tsx
+++ b/ui/partner-hub/components/case-studies/CaseStudySection.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+type CaseStudySectionProps = {
+  title: string;
+  eyebrow?: string;
+  children: ReactNode;
+};
+
+export function CaseStudySection({ title, eyebrow, children }: CaseStudySectionProps) {
+  return (
+    <section className="space-y-4">
+      <div className="space-y-2">
+        {eyebrow ? (
+          <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
+            {eyebrow}
+          </p>
+        ) : null}
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">
+          {title}
+        </h2>
+      </div>
+      <div className="space-y-4 text-sm text-foreground/70">{children}</div>
+    </section>
+  );
+}

--- a/ui/partner-hub/data/case-studies.ts
+++ b/ui/partner-hub/data/case-studies.ts
@@ -53,7 +53,7 @@ export const caseStudies: CaseStudy[] = [
     ],
     stack: {
       before: "PowerMax + Commvault",
-      after: "FlashArray/FlashBlade + Rubrik",
+      after: "FlashArray + FlashBlade//S + FlashBlade//E + Rubrik",
     },
     outcomes: [
       "Immutable backups and rapid cyber recovery for Epic and imaging workflows.",


### PR DESCRIPTION
### Motivation
- Present case study details as a premium consulting deliverable with a hero, two-column layout and a sticky right rail to surface quick facts, outcomes, stack and downloads.

### Description
- Add reusable components for the detail layout: `ui/partner-hub/components/case-studies/CaseStudyHero.tsx`, `CaseStudyRail.tsx`, `CaseStudySection.tsx`, and `CalloutCard.tsx` to encapsulate hero, sticky rail, section headers and callout tiles.
- Rebuild the case study detail page at `ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx` to use the new components and render: an SVG visual tile, a “Before → After” comparison, a 4-tile Cyber Resilience posture block, PACS tiering tiles, and a 4-phase migration timeline.
- Update the healthcare case study data in `ui/partner-hub/data/case-studies.ts` to reflect the expanded "after" stack: `FlashArray + FlashBlade//S + FlashBlade//E + Rubrik`.
- Add `generateStaticParams()` to the detail page to support `output: 'export'` builds and ensure static routing for the case studies.

### Testing
- Started the dev server with `npm run dev` and confirmed the app compiled and the case study route compiled without errors after adding `generateStaticParams()`.
- Automated page render verification via Playwright: visited `/partner-hub/case-studies/healthcare-data-center-refresh/` and captured a full-page screenshot confirming the new layout rendered (page returned 200).
- Observed non-blocking missing brand asset 404s during rendering, but core layout and components rendered successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696986b840a08326a27ffc9845cca2ef)