### PR TITLE
Add CSS-only hover affordances for architecture diagram

### DIFF
--- a/ui/partner-hub/components/architecture-explorer/architecture-explorer.tsx
+++ b/ui/partner-hub/components/architecture-explorer/architecture-explorer.tsx
@@ -641,7 +641,7 @@ export function ArchitectureExplorer() {
           />
 
           {leftPack ? (
-            <Card className="min-h-[420px]">
+            <Card className="diagram-card min-h-[420px]">
               <CardHeader className="pb-2">
                 <CardTitle className="text-base">
                   {leftPack.vendor} {leftPack.product} {leftPack.model}
@@ -724,7 +724,7 @@ export function ArchitectureExplorer() {
             />
 
             {rightPack ? (
-              <Card className="min-h-[420px]">
+              <Card className="diagram-card min-h-[420px]">
                 <CardHeader className="pb-2">
                   <CardTitle className="text-base">
                     {rightPack.vendor} {rightPack.product} {rightPack.model}

--- a/ui/partner-hub/styles/globals.css
+++ b/ui/partner-hub/styles/globals.css
@@ -32,6 +32,26 @@ body {
   color: var(--foreground);
 }
 
+.diagram-card .react-flow__node {
+  transition: box-shadow 200ms ease, filter 200ms ease;
+}
+
+.diagram-card .react-flow__edge-path,
+.diagram-card .react-flow__edge-marker path {
+  transition: filter 200ms ease, opacity 200ms ease;
+}
+
+.diagram-card:hover .react-flow__node {
+  box-shadow: 0 0 0 1px color-mix(in srgb, hsl(var(--foreground)) 35%, transparent);
+  filter: brightness(1.04);
+}
+
+.diagram-card:hover .react-flow__edge-path,
+.diagram-card:hover .react-flow__edge-marker path {
+  filter: brightness(1.2);
+  opacity: 1;
+}
+
 a {
   @apply text-accent underline-offset-4 hover:underline;
 }


### PR DESCRIPTION
### Motivation

- Provide subtle, purely CSS hover affordances for the architecture diagram so node outlines and arrowheads slightly brighten on group hover without adding JS or SVG animations, and avoid motion for users who prefer reduced motion.

### Description

- Add a `diagram-card` class to the Flow `Card` wrappers in `architecture-explorer.tsx` to enable group-hover targeting of diagram elements.
- Add CSS rules in `ui/partner-hub/styles/globals.css` that apply transitions to `.react-flow__node`, `.react-flow__edge-path`, and edge marker paths and increase `filter`/`opacity` on `.diagram-card:hover` to produce a subtle brighten effect.
- Leverage the existing `@media (prefers-reduced-motion: reduce)` global rule so reduced-motion users see no movement.

### Testing

- Launched the local dev server with `npm --prefix ui/partner-hub run dev -- --hostname 0.0.0.0 --port 3000`, which compiled the `/architecture-explorer` page successfully (200 response). 
- Ran an automated Playwright script that loaded `http://localhost:3000/partner-hub/architecture-explorer/`, hovered the `.diagram-card` element, and produced a screenshot artifact (`artifacts/architecture-explorer-hover.png`), which completed successfully.
- No unit or typecheck test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69699058ca7083269f7262707011f180)