### PR TITLE
Case Studies: Per-case SEO metadata (generateMetadata)

### DIFF
--- a/ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx
+++ b/ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { CaseStudyHero } from "@/components/case-studies/CaseStudyHero";
 import { CaseStudyRail } from "@/components/case-studies/CaseStudyRail";
@@ -5,7 +6,11 @@ import { CaseStudySection } from "@/components/case-studies/CaseStudySection";
 import { CalloutCard } from "@/components/case-studies/CalloutCard";
 import { ArchitectureDiagramSvg } from "@/components/case-studies/ArchitectureDiagramSvg";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
-import { caseStudies } from "@/data/case-studies";
+import {
+  getCaseStudyBySlug,
+  getCaseStudyOgImage,
+  getCaseStudySlugs,
+} from "@/lib/case-studies";
 
 type CaseStudyPageProps = {
   params: {
@@ -87,8 +92,48 @@ const migrationPlan = [
   },
 ];
 
+export function generateMetadata({ params }: CaseStudyPageProps): Metadata {
+  const caseStudy = getCaseStudyBySlug(params.slug);
+
+  if (!caseStudy) {
+    notFound();
+  }
+
+  const title = `${caseStudy.title} Case Study`;
+  const description = caseStudy.heroSummary;
+  const ogImage = getCaseStudyOgImage(caseStudy);
+  const url = `/partner-hub/case-studies/${caseStudy.slug}`;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: url,
+    },
+    keywords: [caseStudy.industry, ...caseStudy.tags],
+    openGraph: {
+      title,
+      description,
+      type: "article",
+      url,
+      images: [
+        {
+          url: ogImage,
+          alt: `${caseStudy.title} preview`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [ogImage],
+    },
+  };
+}
+
 export default function CaseStudyPage({ params }: CaseStudyPageProps) {
-  const caseStudy = caseStudies.find((study) => study.slug === params.slug);
+  const caseStudy = getCaseStudyBySlug(params.slug);
 
   if (!caseStudy) {
     notFound();
@@ -266,5 +311,5 @@ export default function CaseStudyPage({ params }: CaseStudyPageProps) {
 }
 
 export function generateStaticParams() {
-  return caseStudies.map((study) => ({ slug: study.slug }));
+  return getCaseStudySlugs();
 }

--- a/ui/partner-hub/data/case-studies.ts
+++ b/ui/partner-hub/data/case-studies.ts
@@ -13,6 +13,7 @@ export type CaseStudy = {
   industry: string;
   workloads: string[];
   tags: string[];
+  ogImage?: string;
   stack: {
     before: string;
     after: string;
@@ -51,6 +52,7 @@ export const caseStudies: CaseStudy[] = [
       "data center refresh",
       "resilience",
     ],
+    ogImage: "/images/case-studies/healthcare-data-center-refresh-hero.png",
     stack: {
       before: "PowerMax + Commvault",
       after: "FlashArray + FlashBlade//S + FlashBlade//E + Rubrik",

--- a/ui/partner-hub/lib/case-studies.ts
+++ b/ui/partner-hub/lib/case-studies.ts
@@ -1,0 +1,12 @@
+import { caseStudies, type CaseStudy } from "@/data/case-studies";
+
+const defaultOgImage = "/partner-hub/opengraph-image.png";
+
+export const getCaseStudyBySlug = (slug: string): CaseStudy | undefined =>
+  caseStudies.find((study) => study.slug === slug);
+
+export const getCaseStudyOgImage = (caseStudy: CaseStudy): string =>
+  caseStudy.ogImage ?? caseStudy.assets?.heroTile ?? defaultOgImage;
+
+export const getCaseStudySlugs = (): { slug: string }[] =>
+  caseStudies.map((study) => ({ slug: study.slug }));


### PR DESCRIPTION
### Motivation
- Provide per-case SEO metadata for case study detail pages so each study has its own title, description, OpenGraph/Twitter metadata, and canonical URL resolved via the app-level `metadataBase`.
- Use registry-driven data for metadata and support optional per-case OG images with a sensible site-wide fallback.

### Description
- Add an optional `ogImage` field to the `CaseStudy` type and set it for the `healthcare-data-center-refresh` entry in `ui/partner-hub/data/case-studies.ts`.
- Introduce server-safe helpers in `ui/partner-hub/lib/case-studies.ts`: `getCaseStudyBySlug`, `getCaseStudyOgImage`, and `getCaseStudySlugs` which encapsulate lookup and OG image fallback logic.
- Implement `generateMetadata` in `ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx` to return per-case `Metadata` containing `title`, `description`, `alternates.canonical`, `openGraph`, `twitter`, and `keywords`, and switch the page to use `getCaseStudyBySlug` and `getCaseStudySlugs`.
- Ensure unknown slugs call `notFound()` (matching existing behavior) and avoid client-only APIs inside `generateMetadata`.

### Testing
- Ran `npm run lint` in `ui/partner-hub` and it completed successfully with existing project warnings about hook dependencies and an `aria-selected` attribute (warnings only).
- Ran `npm run typecheck` (`tsc --noEmit`) and it succeeded with no type errors.
- Ran `npm run build` (`next build`) and the production build completed successfully (compiled successfully) with the same non-blocking warnings reported by lint.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696991aa3ad083269fcd0af9051d97d1)