### PR TITLE
Case Studies: Next/Previous navigation on detail pages

### DIFF
--- a/ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx
+++ b/ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx
@@ -1,12 +1,16 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { notFound } from "next/navigation";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 import { CaseStudyHero } from "@/components/case-studies/CaseStudyHero";
 import { CaseStudyRail } from "@/components/case-studies/CaseStudyRail";
 import { CaseStudySection } from "@/components/case-studies/CaseStudySection";
 import { CalloutCard } from "@/components/case-studies/CalloutCard";
 import { ArchitectureDiagramSvg } from "@/components/case-studies/ArchitectureDiagramSvg";
-import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { CaseStudy } from "@/data/case-studies";
 import {
+  getAdjacentCaseStudies,
   getCaseStudyBySlug,
   getCaseStudyOgImage,
   getCaseStudySlugs,
@@ -92,6 +96,48 @@ const migrationPlan = [
   },
 ];
 
+type AdjacentCaseStudyCardProps = {
+  caseStudy: CaseStudy;
+  direction: "Previous" | "Next";
+};
+
+const AdjacentCaseStudyCard = ({
+  caseStudy,
+  direction,
+}: AdjacentCaseStudyCardProps) => {
+  const href = `/case-studies/${caseStudy.slug}`;
+  const isPrevious = direction === "Previous";
+
+  return (
+    <Link
+      href={href}
+      aria-label={`${direction} case study: ${caseStudy.title}`}
+      className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+    >
+      <Card className="flex h-full flex-col border-border/70 bg-muted/40 transition group-hover:-translate-y-0.5 group-hover:shadow-md">
+        <CardHeader className="space-y-3">
+          <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-foreground/60">
+            <span>{direction} case study</span>
+            {isPrevious ? (
+              <ArrowLeft className="h-4 w-4" aria-hidden />
+            ) : (
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            )}
+          </div>
+          <CardTitle className="text-base">{caseStudy.title}</CardTitle>
+          <p className="text-sm text-foreground/70">{caseStudy.heroSummary}</p>
+        </CardHeader>
+        <CardContent className="mt-auto">
+          <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-primary">
+            View case study
+            <span aria-hidden>→</span>
+          </span>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+};
+
 export function generateMetadata({ params }: CaseStudyPageProps): Metadata {
   const caseStudy = getCaseStudyBySlug(params.slug);
 
@@ -138,6 +184,8 @@ export default function CaseStudyPage({ params }: CaseStudyPageProps) {
   if (!caseStudy) {
     notFound();
   }
+
+  const { prev, next } = getAdjacentCaseStudies(caseStudy.slug);
 
   return (
     <div className="space-y-10">
@@ -302,6 +350,19 @@ export default function CaseStudyPage({ params }: CaseStudyPageProps) {
               </ul>
             </Card>
           </CaseStudySection>
+
+          {prev || next ? (
+            <CaseStudySection title="Continue the story" eyebrow="More case studies">
+              <div className="grid gap-4 md:grid-cols-2">
+                {prev ? (
+                  <AdjacentCaseStudyCard caseStudy={prev} direction="Previous" />
+                ) : null}
+                {next ? (
+                  <AdjacentCaseStudyCard caseStudy={next} direction="Next" />
+                ) : null}
+              </div>
+            </CaseStudySection>
+          ) : null}
         </div>
 
         <CaseStudyRail caseStudy={caseStudy} />

--- a/ui/partner-hub/data/case-studies.ts
+++ b/ui/partner-hub/data/case-studies.ts
@@ -8,6 +8,8 @@ export type CaseStudySection = {
 
 export type CaseStudy = {
   slug: string;
+  order?: number;
+  sortOrder?: number;
   title: string;
   heroSummary: string;
   industry: string;

--- a/ui/partner-hub/lib/case-studies.ts
+++ b/ui/partner-hub/lib/case-studies.ts
@@ -10,3 +10,49 @@ export const getCaseStudyOgImage = (caseStudy: CaseStudy): string =>
 
 export const getCaseStudySlugs = (): { slug: string }[] =>
   caseStudies.map((study) => ({ slug: study.slug }));
+
+const getSortedCaseStudies = (): CaseStudy[] => {
+  const hasExplicitSort = caseStudies.some(
+    (study) =>
+      typeof study.sortOrder === "number" ||
+      typeof (study as { order?: number }).order === "number"
+  );
+
+  if (!hasExplicitSort) {
+    return caseStudies;
+  }
+
+  const indexMap = new Map(caseStudies.map((study, index) => [study.slug, index]));
+
+  return [...caseStudies].sort((a, b) => {
+    const aIndex = indexMap.get(a.slug) ?? 0;
+    const bIndex = indexMap.get(b.slug) ?? 0;
+    const aSort = a.sortOrder ?? (a as { order?: number }).order ?? aIndex;
+    const bSort = b.sortOrder ?? (b as { order?: number }).order ?? bIndex;
+
+    if (aSort === bSort) {
+      return aIndex - bIndex;
+    }
+
+    return aSort - bSort;
+  });
+};
+
+export const getAdjacentCaseStudies = (
+  slug: string
+): { prev?: CaseStudy; next?: CaseStudy } => {
+  const sortedCaseStudies = getSortedCaseStudies();
+  const currentIndex = sortedCaseStudies.findIndex((study) => study.slug === slug);
+
+  if (currentIndex === -1) {
+    return {};
+  }
+
+  return {
+    prev: currentIndex > 0 ? sortedCaseStudies[currentIndex - 1] : undefined,
+    next:
+      currentIndex < sortedCaseStudies.length - 1
+        ? sortedCaseStudies[currentIndex + 1]
+        : undefined,
+  };
+};


### PR DESCRIPTION
### Motivation
- Provide Next/Previous navigation on case study detail pages following the registry order or an explicit sort field to improve portfolio browsing and polish.

### Description
- Added optional ordering fields `order?` and `sortOrder?` to the `CaseStudy` type in `data/case-studies.ts`.
- Implemented a helper `getAdjacentCaseStudies(slug)` in `lib/case-studies.ts` that returns `{ prev?, next? }` using explicit sort fields when present and falling back to registry order.
- Rendered accessible premium-styled adjacent navigation cards on the detail page by adding `AdjacentCaseStudyCard` and invoking `getAdjacentCaseStudies` in `app/(routes)/case-studies/[slug]/page.tsx`, hiding the previous/next side when missing.
- Reused existing card styles and focus-visible utilities to ensure keyboard/focus states match site patterns without adding new dependencies.

### Testing
- Ran `npm run lint` which completed successfully with existing codebase warnings in unrelated files (warnings only). 
- Ran `npm run typecheck` which completed successfully with no errors. 
- Ran `npm run build` which compiled successfully and prerendered pages (build warnings are from existing files only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969948179208330ac3ba49848c07ad3)