### PR TITLE
Case Studies: Copy link button in sticky rail

### DIFF
--- a/ui/partner-hub/components/case-studies/CaseStudyRail.tsx
+++ b/ui/partner-hub/components/case-studies/CaseStudyRail.tsx
@@ -1,5 +1,6 @@
 import { Card } from "@/components/ui/card";
 import type { CaseStudy } from "@/data/case-studies";
+import { CopyLinkButton } from "@/components/case-studies/CopyLinkButton";
 
 const sectionTitleStyles =
   "text-xs font-semibold uppercase tracking-wide text-foreground/60";
@@ -22,6 +23,11 @@ type CaseStudyRailProps = {
 export function CaseStudyRail({ caseStudy }: CaseStudyRailProps) {
   return (
     <aside className="space-y-4 lg:sticky lg:top-24">
+      <Card className="space-y-3 border-border/70 p-4">
+        <h2 className={sectionTitleStyles}>Share</h2>
+        <CopyLinkButton />
+      </Card>
+
       <Card className="space-y-3 border-border/70 p-4">
         <h2 className={sectionTitleStyles}>Quick Facts</h2>
         <dl className="space-y-3 text-sm text-foreground/70">

--- a/ui/partner-hub/components/case-studies/CopyLinkButton.tsx
+++ b/ui/partner-hub/components/case-studies/CopyLinkButton.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+
+const copiedResetDelayMs = 1500;
+
+export function CopyLinkButton() {
+  const pathname = usePathname();
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+
+  const handleCopy = useCallback(async () => {
+    if (typeof window === "undefined") return;
+    if (!navigator?.clipboard?.writeText) return;
+
+    const origin = window.location.origin;
+    const url = `${origin}${pathname ?? ""}`;
+
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = window.setTimeout(() => {
+        setCopied(false);
+      }, copiedResetDelayMs);
+    } catch {
+      // Fail silently if clipboard access is denied.
+    }
+  }, [pathname]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      size="sm"
+      onClick={handleCopy}
+      className="w-full justify-center"
+      aria-label={copied ? "Link copied" : "Copy link"}
+    >
+      {copied ? "Copied" : "Copy link"}
+    </Button>
+  );
+}


### PR DESCRIPTION
### Motivation
- Add a simple, accessible way for users to copy the current case study URL from the sticky rail on detail pages.
- Clipboard access must be implemented in a client component to avoid hydration warnings in Next.js server components.
- Provide subtle visual feedback when a link is copied and fail gracefully if clipboard is unavailable.

### Description
- Add a new client component `ui/partner-hub/components/case-studies/CopyLinkButton.tsx` that uses `usePathname()` to build the full URL (`window.location.origin + pathname`), calls `navigator.clipboard.writeText(url)`, and shows a temporary "Copied" state that resets after ~1.5s with cleanup on unmount.
- Wire the new component into the sticky rail by inserting a `Share` card in `CaseStudyRail` (`ui/partner-hub/components/case-studies/CaseStudyRail.tsx`) which renders `CopyLinkButton`.
- Use the existing `Button` UI for keyboard focus and activation and include `aria-label` text to ensure accessibility.
- Guard against missing `window`/`navigator.clipboard` to fail silently on unsupported environments and avoid hydration issues.

### Testing
- Ran `npm run lint`, which completed but reported existing warnings (`react-hooks/exhaustive-deps` and `jsx-a11y/role-supports-aria-props`) that are unrelated to the new component.
- Ran `npm run typecheck` (`tsc --noEmit`) which passed with no errors.
- Ran `npm run build` (`next build`) which completed successfully with the same lint warnings reported.
- Performed a dev smoke render and captured a screenshot of the case study page via an automated Playwright script, confirming the new Share card renders on the case study detail page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969961530a48330925c8bfde5a988f4)