### PR TITLE
Case Studies: Download PDF placeholder (Coming soon)

### DIFF
--- a/ui/partner-hub/components/case-studies/CaseStudyRail.tsx
+++ b/ui/partner-hub/components/case-studies/CaseStudyRail.tsx
@@ -1,20 +1,10 @@
 import { Card } from "@/components/ui/card";
 import type { CaseStudy } from "@/data/case-studies";
 import { CopyLinkButton } from "@/components/case-studies/CopyLinkButton";
+import { Button } from "@/components/ui/button";
 
 const sectionTitleStyles =
   "text-xs font-semibold uppercase tracking-wide text-foreground/60";
-
-const downloadLinks = [
-  {
-    label: "Download executive summary (PDF)",
-    href: "#/downloads/executive-summary",
-  },
-  {
-    label: "Download architecture brief (PDF)",
-    href: "#/downloads/architecture-brief",
-  },
-];
 
 type CaseStudyRailProps = {
   caseStudy: CaseStudy;
@@ -102,18 +92,19 @@ export function CaseStudyRail({ caseStudy }: CaseStudyRailProps) {
 
       <Card className="space-y-3 border-border/70 p-4 motion-safe:transition motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-sm motion-reduce:transition-none">
         <h2 className={sectionTitleStyles}>Downloads</h2>
-        <ul className="space-y-2 text-sm">
-          {downloadLinks.map((link) => (
-            <li key={link.label}>
-              <a
-                href={link.href}
-                className="font-semibold text-primary transition hover:underline motion-safe:hover:translate-x-0.5 motion-reduce:transition-none"
-              >
-                {link.label}
-              </a>
-            </li>
-          ))}
-        </ul>
+        <div className="space-y-2">
+          <Button
+            type="button"
+            size="sm"
+            className="w-full"
+            disabled
+            aria-disabled="true"
+            title="Coming soon"
+          >
+            Download PDF
+          </Button>
+          <p className="text-xs text-foreground/50">Coming soon</p>
+        </div>
       </Card>
 
       <Card className="space-y-3 border-border/70 p-4 motion-safe:transition motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-sm motion-reduce:transition-none">


### PR DESCRIPTION
### Motivation
- Provide a clear, accessible placeholder in the case study rail for PDF downloads while the real download functionality is not yet available.
- Prevent broken links or navigation from the downloads area by replacing anchors with a disabled control that communicates status.
- Reuse the existing shared `Button` styling and accessible semantics for a consistent UI.

### Description
- Replaced the Downloads anchor list with a disabled `Button` and helper text in `ui/partner-hub/components/case-studies/CaseStudyRail.tsx`.
- Imported the shared `Button` component and removed the previous `downloadLinks` list and anchors.
- The button is non-interactive (`disabled`, `aria-disabled="true"`) and includes `title="Coming soon"` and a small `Coming soon` helper label.

### Testing
- Ran `npm run lint` which completed successfully with non-blocking warnings about unrelated files.
- Ran `npm run typecheck` (`tsc --noEmit`) which completed successfully.
- Ran `npm run build` (Next.js production build) which completed successfully and produced the optimized build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969990ca0708330868f8d0cc4717a28)