### PR TITLE
Case Study: Outcome labels (target / referenced / observed)

### DIFF
--- a/ui/partner-hub/components/case-studies/CaseStudyCard.tsx
+++ b/ui/partner-hub/components/case-studies/CaseStudyCard.tsx
@@ -34,12 +34,12 @@ export function CaseStudyCard({ caseStudy }: CaseStudyCardProps) {
         <p>{caseStudy.heroSummary}</p>
         <ul className="space-y-2">
           {caseStudy.outcomes.slice(0, outcomeLimit).map((outcome) => (
-            <li key={outcome} className="flex items-start gap-3">
+            <li key={outcome.text} className="flex items-start gap-3">
               <span
                 className="mt-1 h-2 w-2 shrink-0 rounded-full bg-primary/70"
                 aria-hidden
               />
-              <span>{outcome}</span>
+              <span>{outcome.text}</span>
             </li>
           ))}
         </ul>

--- a/ui/partner-hub/components/case-studies/CaseStudyRail.tsx
+++ b/ui/partner-hub/components/case-studies/CaseStudyRail.tsx
@@ -6,6 +6,18 @@ import { Button } from "@/components/ui/button";
 const sectionTitleStyles =
   "text-xs font-semibold uppercase tracking-wide text-foreground/60";
 
+const outcomeBadgeStyles = {
+  target: "border-amber-500/30 bg-amber-500/10 text-amber-600",
+  referenced: "border-sky-500/30 bg-sky-500/10 text-sky-600",
+  observed: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600",
+} as const;
+
+const outcomeLabelText = {
+  target: "Target",
+  referenced: "Referenced",
+  observed: "Observed",
+} as const;
+
 type CaseStudyRailProps = {
   caseStudy: CaseStudy;
 };
@@ -61,15 +73,26 @@ export function CaseStudyRail({ caseStudy }: CaseStudyRailProps) {
         <h2 className={sectionTitleStyles}>Outcomes</h2>
         <ul className="space-y-2 text-sm text-foreground/70">
           {caseStudy.outcomes.map((outcome) => (
-            <li key={outcome} className="flex items-start gap-3">
+            <li key={outcome.text} className="flex items-start gap-3">
               <span
                 className="mt-1 h-2 w-2 shrink-0 rounded-full bg-primary/70"
                 aria-hidden
               />
-              <span>{outcome}</span>
+              <div className="space-y-1">
+                <span
+                  className={`inline-flex w-fit items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${outcomeBadgeStyles[outcome.labelType]}`}
+                >
+                  {outcomeLabelText[outcome.labelType]}
+                </span>
+                <p>{outcome.text}</p>
+              </div>
             </li>
           ))}
         </ul>
+        <p className="text-xs text-foreground/50">
+          Legend: Target = planned goal, Referenced = vendor/third-party claim,
+          Observed = measured deployment result.
+        </p>
       </Card>
 
       <Card className="space-y-3 border-border/70 p-4 motion-safe:transition motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-sm motion-reduce:transition-none">

--- a/ui/partner-hub/data/case-studies.ts
+++ b/ui/partner-hub/data/case-studies.ts
@@ -6,6 +6,20 @@ export type CaseStudySection = {
   callouts?: string[];
 };
 
+export type OutcomeLabelType = "target" | "referenced" | "observed";
+
+export type CaseStudyOutcome = {
+  text: string;
+  labelType: OutcomeLabelType;
+  citationIds?: string[];
+};
+
+export type CaseStudyCitation = {
+  id: string;
+  label: string;
+  href: string;
+};
+
 export type CaseStudy = {
   slug: string;
   order?: number;
@@ -20,16 +34,13 @@ export type CaseStudy = {
     before: string;
     after: string;
   };
-  outcomes: string[];
+  outcomes: CaseStudyOutcome[];
   sections: CaseStudySection[];
   assets?: {
     heroTile?: string;
     architecture?: string;
   };
-  citations: {
-    label: string;
-    href: string;
-  }[];
+  citations: CaseStudyCitation[];
 };
 
 export const caseStudies: CaseStudy[] = [
@@ -60,11 +71,26 @@ export const caseStudies: CaseStudy[] = [
       after: "FlashArray + FlashBlade//S + FlashBlade//E + Rubrik",
     },
     outcomes: [
-      "Immutable backups and rapid cyber recovery for Epic and imaging workflows.",
-      "Lower RPO/RTO for clinical systems with policy-based snapshots.",
-      "Tiered archive strategy for long-term imaging retention.",
-      "High-throughput storage for AI imaging pipelines and PACS growth.",
-      "Simplified operations with unified monitoring and automation.",
+      {
+        text: "Immutable backups and rapid cyber recovery for Epic and imaging workflows.",
+        labelType: "referenced",
+      },
+      {
+        text: "Lower RPO/RTO for clinical systems with policy-based snapshots.",
+        labelType: "referenced",
+      },
+      {
+        text: "Tiered archive strategy for long-term imaging retention.",
+        labelType: "referenced",
+      },
+      {
+        text: "High-throughput storage for AI imaging pipelines and PACS growth.",
+        labelType: "referenced",
+      },
+      {
+        text: "Simplified operations with unified monitoring and automation.",
+        labelType: "referenced",
+      },
     ],
     sections: [
       {
@@ -113,10 +139,18 @@ export const caseStudies: CaseStudy[] = [
         "/images/case-studies/healthcare-data-center-refresh-architecture.png",
     },
     citations: [
-      { label: "Epic Systems", href: "https://www.epic.com/" },
-      { label: "Rubrik", href: "https://www.rubrik.com/" },
-      { label: "Pure Storage FlashArray", href: "https://www.purestorage.com/products/flasharray.html" },
-      { label: "Pure Storage FlashBlade", href: "https://www.purestorage.com/products/flashblade.html" },
+      { id: "epic", label: "Epic Systems", href: "https://www.epic.com/" },
+      { id: "rubrik", label: "Rubrik", href: "https://www.rubrik.com/" },
+      {
+        id: "pure-flasharray",
+        label: "Pure Storage FlashArray",
+        href: "https://www.purestorage.com/products/flasharray.html",
+      },
+      {
+        id: "pure-flashblade",
+        label: "Pure Storage FlashBlade",
+        href: "https://www.purestorage.com/products/flashblade.html",
+      },
     ],
   },
 ];


### PR DESCRIPTION
### Motivation
- Clarify that outcomes are classifications rather than guarantees by explicitly tagging each outcome as `target`, `referenced`, or `observed`.
- Enable linking outcomes to source citations so referenced claims can point back to vendor or third-party evidence.
- Surface the classification in the UI so readers can immediately see whether an outcome is planned, cited, or measured.

### Description
- Added types `OutcomeLabelType`, `CaseStudyOutcome`, and `CaseStudyCitation`, and changed `CaseStudy.outcomes` to `CaseStudyOutcome[]` in `data/case-studies.ts`.
- Converted existing outcome strings to structured objects and added citation `id` fields to citations, defaulting existing outcomes to `labelType: "referenced"`.
- Updated `CaseStudyRail` to render a small badge for each outcome (styles for `target`/`referenced`/`observed`) and a one-line legend describing the labels.
- Updated `CaseStudyCard` to consume the new structured outcome objects (`outcome.text`) so cards continue to display outcome summaries.

### Testing
- Ran `npm run lint` which completed successfully but reported existing unrelated warnings in `components/account-mapping/AccountMappingTool.tsx` and `components/energy/energy-tool.tsx`.
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed with no type errors under the updated types.
- Ran `npm run build` (Next.js production build) which compiled and generated static/SSG pages successfully and included the same lint warnings noted above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69699ca868288330addf217d3567138d)