### PR TITLE
Case Study: Citations appendix (vendor vs third-party)

### DIFF
--- a/ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx
+++ b/ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { CalloutCard } from "@/components/case-studies/CalloutCard";
 import { ArchitectureDiagramSvg } from "@/components/case-studies/ArchitectureDiagramSvg";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { CaseStudy } from "@/data/case-studies";
+import { getSourceDomain } from "@/lib/case-study-sources";
 import {
   getAdjacentCaseStudies,
   getCaseStudyBySlug,
@@ -186,6 +187,15 @@ export default function CaseStudyPage({ params }: CaseStudyPageProps) {
   }
 
   const { prev, next } = getAdjacentCaseStudies(caseStudy.slug);
+  const sources = caseStudy.sources.map((source, index) => ({
+    ...source,
+    index: index + 1,
+    domain: getSourceDomain(source.url),
+  }));
+  const vendorSources = sources.filter((source) => source.category === "vendor");
+  const thirdPartySources = sources.filter(
+    (source) => source.category === "third-party"
+  );
 
   return (
     <div className="space-y-10">
@@ -333,22 +343,146 @@ export default function CaseStudyPage({ params }: CaseStudyPageProps) {
           ))}
 
           <CaseStudySection title="Sources / Evidence" eyebrow="Citations">
-            <Card className="border-border/70 p-4 motion-safe:transition motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-sm motion-reduce:transition-none">
-              <ul className="space-y-2 text-sm">
-                {caseStudy.citations.map((citation) => (
-                  <li key={citation.href}>
-                    <a
-                      href={citation.href}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="font-semibold text-primary transition hover:underline motion-safe:hover:translate-x-0.5 motion-reduce:transition-none"
-                    >
-                      {citation.label}
-                    </a>
-                  </li>
-                ))}
-              </ul>
+            <Card className="space-y-4 border-border/70 p-4 motion-safe:transition motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-sm motion-reduce:transition-none">
+              <p className="text-xs text-foreground/50">
+                Compact references are shown here. The full appendix is listed
+                below in numbered order.{" "}
+                <a
+                  href="#citations-appendix"
+                  className="font-semibold text-primary hover:underline"
+                >
+                  Jump to appendix
+                </a>
+                .
+              </p>
+              <div className="space-y-4 text-xs text-foreground/70">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-wide text-foreground/50">
+                    Vendor references
+                  </p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {vendorSources.length ? (
+                      vendorSources.map((source) => (
+                        <a
+                          key={source.id}
+                          href={source.url}
+                          target="_blank"
+                          rel="noreferrer noopener"
+                          className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-muted/40 px-2 py-1 text-[11px] font-semibold text-foreground/80 transition hover:underline"
+                        >
+                          <span className="text-foreground/50">
+                            [{source.index}]
+                          </span>
+                          <span>{source.title}</span>
+                          <span className="text-foreground/50">
+                            ({source.domain})
+                          </span>
+                        </a>
+                      ))
+                    ) : (
+                      <span className="text-foreground/50">
+                        No vendor references listed.
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-wide text-foreground/50">
+                    Third-party references
+                  </p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {thirdPartySources.length ? (
+                      thirdPartySources.map((source) => (
+                        <a
+                          key={source.id}
+                          href={source.url}
+                          target="_blank"
+                          rel="noreferrer noopener"
+                          className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-muted/40 px-2 py-1 text-[11px] font-semibold text-foreground/80 transition hover:underline"
+                        >
+                          <span className="text-foreground/50">
+                            [{source.index}]
+                          </span>
+                          <span>{source.title}</span>
+                          <span className="text-foreground/50">
+                            ({source.domain})
+                          </span>
+                        </a>
+                      ))
+                    ) : (
+                      <span className="text-foreground/50">
+                        No third-party references listed.
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
             </Card>
+          </CaseStudySection>
+
+          <CaseStudySection
+            id="citations-appendix"
+            title="Citations appendix"
+            eyebrow="Appendix"
+          >
+            <div className="grid gap-6 md:grid-cols-2">
+              <div className="space-y-3">
+                <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
+                  Vendor references
+                </p>
+                {vendorSources.length ? (
+                  <ol className="space-y-2 text-sm text-foreground/70">
+                    {vendorSources.map((source) => (
+                      <li key={source.id} value={source.index}>
+                        <a
+                          href={source.url}
+                          target="_blank"
+                          rel="noreferrer noopener"
+                          className="font-semibold text-primary hover:underline"
+                        >
+                          {source.title}
+                        </a>{" "}
+                        <span className="text-foreground/50">
+                          ({source.domain})
+                        </span>
+                      </li>
+                    ))}
+                  </ol>
+                ) : (
+                  <p className="text-sm text-foreground/50">
+                    No vendor references listed.
+                  </p>
+                )}
+              </div>
+              <div className="space-y-3">
+                <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
+                  Third-party references
+                </p>
+                {thirdPartySources.length ? (
+                  <ol className="space-y-2 text-sm text-foreground/70">
+                    {thirdPartySources.map((source) => (
+                      <li key={source.id} value={source.index}>
+                        <a
+                          href={source.url}
+                          target="_blank"
+                          rel="noreferrer noopener"
+                          className="font-semibold text-primary hover:underline"
+                        >
+                          {source.title}
+                        </a>{" "}
+                        <span className="text-foreground/50">
+                          ({source.domain})
+                        </span>
+                      </li>
+                    ))}
+                  </ol>
+                ) : (
+                  <p className="text-sm text-foreground/50">
+                    No third-party references listed.
+                  </p>
+                )}
+              </div>
+            </div>
           </CaseStudySection>
 
           {prev || next ? (

--- a/ui/partner-hub/components/case-studies/CaseStudyRail.tsx
+++ b/ui/partner-hub/components/case-studies/CaseStudyRail.tsx
@@ -2,6 +2,7 @@ import { Card } from "@/components/ui/card";
 import type { CaseStudy } from "@/data/case-studies";
 import { CopyLinkButton } from "@/components/case-studies/CopyLinkButton";
 import { Button } from "@/components/ui/button";
+import { getSourceDomain } from "@/lib/case-study-sources";
 
 const sectionTitleStyles =
   "text-xs font-semibold uppercase tracking-wide text-foreground/60";
@@ -23,6 +24,16 @@ type CaseStudyRailProps = {
 };
 
 export function CaseStudyRail({ caseStudy }: CaseStudyRailProps) {
+  const sources = caseStudy.sources.map((source, index) => ({
+    ...source,
+    index: index + 1,
+    domain: getSourceDomain(source.url),
+  }));
+  const vendorSources = sources.filter((source) => source.category === "vendor");
+  const thirdPartySources = sources.filter(
+    (source) => source.category === "third-party"
+  );
+
   return (
     <aside className="space-y-4 lg:sticky lg:top-24">
       <Card className="space-y-3 border-border/70 p-4 motion-safe:transition motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-sm motion-reduce:transition-none">
@@ -132,20 +143,68 @@ export function CaseStudyRail({ caseStudy }: CaseStudyRailProps) {
 
       <Card className="space-y-3 border-border/70 p-4 motion-safe:transition motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-sm motion-reduce:transition-none">
         <h2 className={sectionTitleStyles}>Sources</h2>
-        <ul className="space-y-2 text-sm">
-          {caseStudy.citations.map((citation) => (
-            <li key={citation.href}>
-              <a
-                href={citation.href}
-                target="_blank"
-                rel="noreferrer"
-                className="font-semibold text-primary transition hover:underline motion-safe:hover:translate-x-0.5 motion-reduce:transition-none"
-              >
-                {citation.label}
-              </a>
-            </li>
-          ))}
-        </ul>
+        <div className="space-y-3 text-xs text-foreground/70">
+          <p>
+            Inline references are numbered.{" "}
+            <a
+              href="#citations-appendix"
+              className="font-semibold text-primary hover:underline"
+            >
+              View appendix
+            </a>
+            .
+          </p>
+          <div className="space-y-3">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-foreground/50">
+                Vendor references
+              </p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {vendorSources.length ? (
+                  vendorSources.map((source) => (
+                    <a
+                      key={source.id}
+                      href={source.url}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-muted/40 px-2 py-1 text-[11px] font-semibold text-foreground/80 transition hover:underline"
+                    >
+                      <span className="text-foreground/50">[{source.index}]</span>
+                      <span>{source.title}</span>
+                      <span className="text-foreground/50">({source.domain})</span>
+                    </a>
+                  ))
+                ) : (
+                  <span className="text-foreground/50">None listed.</span>
+                )}
+              </div>
+            </div>
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-foreground/50">
+                Third-party references
+              </p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {thirdPartySources.length ? (
+                  thirdPartySources.map((source) => (
+                    <a
+                      key={source.id}
+                      href={source.url}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-muted/40 px-2 py-1 text-[11px] font-semibold text-foreground/80 transition hover:underline"
+                    >
+                      <span className="text-foreground/50">[{source.index}]</span>
+                      <span>{source.title}</span>
+                      <span className="text-foreground/50">({source.domain})</span>
+                    </a>
+                  ))
+                ) : (
+                  <span className="text-foreground/50">None listed.</span>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
       </Card>
     </aside>
   );

--- a/ui/partner-hub/components/case-studies/CaseStudySection.tsx
+++ b/ui/partner-hub/components/case-studies/CaseStudySection.tsx
@@ -4,11 +4,17 @@ type CaseStudySectionProps = {
   title: string;
   eyebrow?: string;
   children: ReactNode;
+  id?: string;
 };
 
-export function CaseStudySection({ title, eyebrow, children }: CaseStudySectionProps) {
+export function CaseStudySection({
+  title,
+  eyebrow,
+  children,
+  id,
+}: CaseStudySectionProps) {
   return (
-    <section className="space-y-4">
+    <section id={id} className="space-y-4">
       <div className="space-y-2">
         {eyebrow ? (
           <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">

--- a/ui/partner-hub/data/case-studies.ts
+++ b/ui/partner-hub/data/case-studies.ts
@@ -14,10 +14,13 @@ export type CaseStudyOutcome = {
   citationIds?: string[];
 };
 
-export type CaseStudyCitation = {
+export type CaseStudySourceCategory = "vendor" | "third-party";
+
+export type CaseStudySource = {
   id: string;
-  label: string;
-  href: string;
+  title: string;
+  url: string;
+  category: CaseStudySourceCategory;
 };
 
 export type CaseStudy = {
@@ -40,7 +43,7 @@ export type CaseStudy = {
     heroTile?: string;
     architecture?: string;
   };
-  citations: CaseStudyCitation[];
+  sources: CaseStudySource[];
 };
 
 export const caseStudies: CaseStudy[] = [
@@ -138,18 +141,36 @@ export const caseStudies: CaseStudy[] = [
       architecture:
         "/images/case-studies/healthcare-data-center-refresh-architecture.png",
     },
-    citations: [
-      { id: "epic", label: "Epic Systems", href: "https://www.epic.com/" },
-      { id: "rubrik", label: "Rubrik", href: "https://www.rubrik.com/" },
+    sources: [
+      {
+        id: "epic",
+        title: "Epic Systems",
+        url: "https://www.epic.com/",
+        category: "vendor",
+      },
+      {
+        id: "rubrik",
+        title: "Rubrik",
+        url: "https://www.rubrik.com/",
+        category: "vendor",
+      },
       {
         id: "pure-flasharray",
-        label: "Pure Storage FlashArray",
-        href: "https://www.purestorage.com/products/flasharray.html",
+        title: "Pure Storage FlashArray",
+        url: "https://www.purestorage.com/products/flasharray.html",
+        category: "vendor",
       },
       {
         id: "pure-flashblade",
-        label: "Pure Storage FlashBlade",
-        href: "https://www.purestorage.com/products/flashblade.html",
+        title: "Pure Storage FlashBlade",
+        url: "https://www.purestorage.com/products/flashblade.html",
+        category: "vendor",
+      },
+      {
+        id: "hipaa-security-rule",
+        title: "HIPAA Security Rule (HHS)",
+        url: "https://www.hhs.gov/hipaa/for-professionals/security/index.html",
+        category: "third-party",
       },
     ],
   },

--- a/ui/partner-hub/lib/case-study-sources.ts
+++ b/ui/partner-hub/lib/case-study-sources.ts
@@ -1,0 +1,7 @@
+export const getSourceDomain = (url: string): string => {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+};


### PR DESCRIPTION
### Motivation
- Provide a clean, scannable citations appendix on case study pages that separates vendor vs third-party references and avoids raw URL dumps.
- Make inline references compact and numbered, and ensure external links are safe (`rel="noreferrer noopener"`).

### Description
- Extend the case study data model to `sources[]` with `CaseStudySource` (`id`, `title`, `url`, `category: 'vendor' | 'third-party'`) and add a sample third-party entry in the healthcare case study (`ui/partner-hub/data/case-studies.ts`).
- Add a small helper `getSourceDomain` to extract and render source domains (`ui/partner-hub/lib/case-study-sources.ts`).
- Expose an `id` prop on `CaseStudySection` so the appendix can be anchorable (`ui/partner-hub/components/case-studies/CaseStudySection.tsx`).
- Render compact, numbered inline references in the rail and the page, grouped by category, and add a dedicated "Citations appendix" section with ordered lists and safe outgoing links (`rel="noreferrer noopener"`) (`ui/partner-hub/components/case-studies/CaseStudyRail.tsx`, `ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx`).

### Testing
- Ran `npm --prefix ui/partner-hub run lint` which completed with existing project warnings but no new errors reported.
- Ran `npm --prefix ui/partner-hub run typecheck` which completed successfully (no type errors).
- Ran `npm --prefix ui/partner-hub run build` which compiled successfully with the same warnings observed during lint.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69699e1f66248330bd91f23ac4e88b47)