### PR TITLE
Case Study: Add disclaimers (anonymized / results vary / cited outcomes)

### DIFF
--- a/ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx
+++ b/ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { CaseStudyHero } from "@/components/case-studies/CaseStudyHero";
 import { CaseStudyRail } from "@/components/case-studies/CaseStudyRail";
 import { CaseStudySection } from "@/components/case-studies/CaseStudySection";
 import { CalloutCard } from "@/components/case-studies/CalloutCard";
+import { DisclaimerCallout } from "@/components/case-studies/DisclaimerCallout";
 import { ArchitectureDiagramSvg } from "@/components/case-studies/ArchitectureDiagramSvg";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { CaseStudy } from "@/data/case-studies";
@@ -341,6 +342,8 @@ export default function CaseStudyPage({ params }: CaseStudyPageProps) {
               ) : null}
             </CaseStudySection>
           ))}
+
+          <DisclaimerCallout />
 
           <CaseStudySection title="Sources / Evidence" eyebrow="Citations">
             <Card className="space-y-4 border-border/70 p-4 motion-safe:transition motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-sm motion-reduce:transition-none">

--- a/ui/partner-hub/components/case-studies/DisclaimerCallout.tsx
+++ b/ui/partner-hub/components/case-studies/DisclaimerCallout.tsx
@@ -1,0 +1,13 @@
+import { Card } from "@/components/ui/card";
+
+export function DisclaimerCallout() {
+  return (
+    <Card className="border-border/70 bg-muted/30 p-4 text-xs text-foreground/70">
+      <div className="space-y-1">
+        <p>Anonymized scenario; results vary.</p>
+        <p>Referenced outcomes are cited.</p>
+        <p>No customer endorsement is implied.</p>
+      </div>
+    </Card>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a small, reusable disclaimer near citations to clarify anonymization, variability of results, and that referenced outcomes are cited without implying customer endorsement.

### Description
- Add a new `DisclaimerCallout` component at `ui/partner-hub/components/case-studies/DisclaimerCallout.tsx` that renders a calm 2–3 line card with the required language.
- Import and insert the `DisclaimerCallout` into the case study detail template at `ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx` placed immediately before the "Sources / Evidence" section for consistent placement.
- Keep styling minimal and consistent with existing callout/card components to avoid visual regressions.

### Testing
- Ran `npm run lint`, which completed but surfaced pre-existing React hook and a11y warnings unrelated to this change.
- Ran `npm run typecheck`, which completed with no type errors.
- Ran `npm run build`, which compiled successfully and prerendered static pages (including the healthcare case study), with the same lint warnings observed during development.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69699ffceac88330b96ba40bb84748c5)