### PR TITLE
Fix ESLint warnings from `npm run build` (hooks deps + aria props)

### DIFF
--- a/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
+++ b/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
@@ -1620,17 +1620,14 @@ export default function AccountMappingTool() {
     [partnerMapping],
   );
 
-  const vendorRows = vendorState.result?.rows ?? [];
-  const partnerRows = partnerState.result?.rows ?? [];
-
-  const vendorRecords = useMemo(
-    () => buildAccountRecords(vendorRows, normalizedVendorMapping, "vendor"),
-    [buildAccountRecords, vendorRows, normalizedVendorMapping],
-  );
-  const partnerRecords = useMemo(
-    () => buildAccountRecords(partnerRows, normalizedPartnerMapping, "partner"),
-    [buildAccountRecords, partnerRows, normalizedPartnerMapping],
-  );
+  const vendorRecords = useMemo(() => {
+    const vendorRows = vendorState.result?.rows ?? [];
+    return buildAccountRecords(vendorRows, normalizedVendorMapping, "vendor");
+  }, [buildAccountRecords, normalizedVendorMapping, vendorState.result?.rows]);
+  const partnerRecords = useMemo(() => {
+    const partnerRows = partnerState.result?.rows ?? [];
+    return buildAccountRecords(partnerRows, normalizedPartnerMapping, "partner");
+  }, [buildAccountRecords, normalizedPartnerMapping, partnerState.result?.rows]);
 
   const vendorById = useMemo(
     () => new Map(vendorRecords.map((record) => [record.id, record])),

--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -62,6 +62,17 @@ type Inputs = {
 type NetAppMode = "auto" | "manual";
 type ViewMode = "energy" | "sustainability" | "both";
 
+type RowKey =
+  | "effectiveTb"
+  | "weightedW"
+  | "kwhPerYear"
+  | "annualCost"
+  | "costPct"
+  | "btuPerHour"
+  | "rackUnits"
+  | "co2eYear"
+  | "co2ePerTbYear";
+
 type ManualInputs = {
   controllerModel: string;
   expansionModel: string;
@@ -92,6 +103,43 @@ type VendorUpdateReport = {
   changed: VendorReportEntry[];
   missing: VendorReportEntry[];
   error: VendorReportEntry[];
+};
+
+const energyRowKeys = [
+  "effectiveTb",
+  "weightedW",
+  "kwhPerYear",
+  "annualCost",
+  "costPct",
+  "rackUnits",
+] as const satisfies readonly RowKey[];
+const energyTotalsRowKeys = [
+  "effectiveTb",
+  "weightedW",
+  "kwhPerYear",
+  "annualCost",
+  "costPct",
+  "btuPerHour",
+  "rackUnits",
+] as const satisfies readonly RowKey[];
+const sustainabilityRowKeys = ["effectiveTb", "co2eYear", "co2ePerTbYear"] as const satisfies readonly RowKey[];
+const energyRowKeySet = new Set<RowKey>(energyRowKeys);
+const combinedRowKeys = (primary: readonly RowKey[], secondary: readonly RowKey[]) => {
+  const seen = new Set<RowKey>();
+  const list: RowKey[] = [];
+  for (const key of primary) {
+    if (!seen.has(key)) {
+      seen.add(key);
+      list.push(key);
+    }
+  }
+  for (const key of secondary) {
+    if (!seen.has(key)) {
+      seen.add(key);
+      list.push(key);
+    }
+  }
+  return list;
 };
 
 const defaults: Omit<Inputs, "dfmTb" | "capacityPb"> = {
@@ -559,54 +607,6 @@ export function EnergyTool() {
   const formatCo2eYear = (kg: number | null) => (kg == null ? "—" : `${fmt2.format(kg / 1000)} tCO₂e/year`);
   const formatCo2ePerTbYear = (kg: number | null) =>
     kg == null ? "—" : `${fmt1.format(kg)} kgCO₂e / TB-year`;
-
-  type RowKey =
-    | "effectiveTb"
-    | "weightedW"
-    | "kwhPerYear"
-    | "annualCost"
-    | "costPct"
-    | "btuPerHour"
-    | "rackUnits"
-    | "co2eYear"
-    | "co2ePerTbYear";
-
-  const energyRowKeys = [
-    "effectiveTb",
-    "weightedW",
-    "kwhPerYear",
-    "annualCost",
-    "costPct",
-    "rackUnits",
-  ] as const satisfies readonly RowKey[];
-  const energyTotalsRowKeys = [
-    "effectiveTb",
-    "weightedW",
-    "kwhPerYear",
-    "annualCost",
-    "costPct",
-    "btuPerHour",
-    "rackUnits",
-  ] as const satisfies readonly RowKey[];
-  const sustainabilityRowKeys = ["effectiveTb", "co2eYear", "co2ePerTbYear"] as const satisfies readonly RowKey[];
-  const energyRowKeySet = new Set<RowKey>(energyRowKeys);
-  const combinedRowKeys = (primary: readonly RowKey[], secondary: readonly RowKey[]) => {
-    const seen = new Set<RowKey>();
-    const list: RowKey[] = [];
-    for (const key of primary) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        list.push(key);
-      }
-    }
-    for (const key of secondary) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        list.push(key);
-      }
-    }
-    return list;
-  };
 
   const totalsRowKeys = useMemo<RowKey[]>(() => {
     if (view === "energy") return [...energyTotalsRowKeys];
@@ -1369,7 +1369,7 @@ export function EnergyTool() {
                                     }
                                   }}
                                   role="button"
-                                  aria-selected={isSelected}
+                                  aria-pressed={isSelected}
                                   tabIndex={0}
                                 >
                                   <td className="py-2 pr-3 font-medium">


### PR DESCRIPTION
### Motivation
- Remove ESLint warnings `react-hooks/exhaustive-deps` and `jsx-a11y/role-supports-aria-props` emitted during `npm run build` without changing behavior or adding dependencies. 
- Stabilize hook dependencies that used ephemeral fallback arrays and correct invalid ARIA usage on interactive rows.

### Description
- Move the `vendorState.result?.rows ?? []` and `partnerState.result?.rows ?? []` fallbacks inside the `useMemo` callbacks and depend on `vendorState.result?.rows` / `partnerState.result?.rows` so memo dependencies remain stable in `AccountMappingTool.tsx`. 
- Hoist the `RowKey` type and the `energyRowKeys`, `energyTotalsRowKeys`, `sustainabilityRowKeys`, `energyRowKeySet`, and `combinedRowKeys` constants/helpers to module scope in `energy-tool.tsx` so the `totalsRowKeys` `useMemo` can safely depend only on `view`. 
- Replace `aria-selected={isSelected}` with `aria-pressed={isSelected}` on the NetApp candidate rows to use a supported ARIA property for the button-like interactive rows. 
- No new dependencies were added and TypeScript strictness was preserved.

### Testing
- Ran `npm run build` and the production build completed successfully with no ESLint warnings for the targeted rules (examples from the build: `✓ Compiled successfully`, `✓ Linting and checking validity of types`). 
- Ran `npm run lint` and it returned `✔ No ESLint warnings or errors`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969a6827dc08330817d1106288bf4b9)