### PR TITLE
Fix /partner-hub routing and asset 404s by removing assetPrefix

### DIFF
--- a/ui/partner-hub/next.config.mjs
+++ b/ui/partner-hub/next.config.mjs
@@ -5,7 +5,6 @@ const nextConfig = {
   reactStrictMode: true,
   output: "export",
   basePath,
-  assetPrefix: basePath,
   images: { unoptimized: true },
   trailingSlash: true,
   env: {


### PR DESCRIPTION
### Motivation
- The app was serving HTML that requested assets under `/partner-hub/_next/...` while the Next server wasn’t using `basePath`, causing 404s for `_next` assets and route 404s for `/partner-hub`.
- The intent is to make the app work under the `/partner-hub` subpath by using Next’s `basePath` only and avoid an `assetPrefix` mismatch.

### Description
- Removed `assetPrefix: basePath` from `ui/partner-hub/next.config.mjs` so only `basePath` is configured and runtime asset prefixing comes from Next itself.
- Kept `basePath` defined via `process.env.NEXT_PUBLIC_BASE_PATH || "/partner-hub"` and preserved existing config (`reactStrictMode`, `output`, `images`, `trailingSlash`, and `env`).
- No other files or dependencies were added or changed.

### Testing
- Ran `npm run build` in `ui/partner-hub` and the build completed successfully. 
- The build included lint/type checks and static page generation without errors.

Restart dev server after this PR; basePath config is applied at startup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969abf7d5608330860cf922224a9d48)