### PR TITLE
QA: Responsive fixes for Case Studies (mobile/tablet/desktop)

### DIFF
--- a/ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx
+++ b/ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx
@@ -203,7 +203,7 @@ export default function CaseStudyPage({ params }: CaseStudyPageProps) {
       <CaseStudyHero caseStudy={caseStudy} />
 
       <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <div className="space-y-10">
+        <div className="min-w-0 space-y-10">
           <CaseStudySection title="Executive overview" eyebrow="Engagement summary">
             {caseStudy.sections.slice(0, 1).map((section) => (
               <p key={section.id}>{section.body}</p>
@@ -216,7 +216,7 @@ export default function CaseStudyPage({ params }: CaseStudyPageProps) {
               workloads while isolating recovery lanes for cyber resilience.
             </p>
             {params.slug === "healthcare-data-center-refresh" ? (
-              <Card className="border-border/70 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800 motion-safe:transition motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-md motion-reduce:transition-none">
+              <Card className="border-border/70 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800 p-4 sm:p-6 motion-safe:transition motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-md motion-reduce:transition-none">
                 <CardHeader>
                   <CardTitle className="text-white">Reference Architecture</CardTitle>
                   <p className="text-sm text-white/70">
@@ -371,12 +371,12 @@ export default function CaseStudyPage({ params }: CaseStudyPageProps) {
                           href={source.url}
                           target="_blank"
                           rel="noreferrer noopener"
-                          className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-muted/40 px-2 py-1 text-[11px] font-semibold text-foreground/80 transition hover:underline"
+                          className="flex max-w-full flex-wrap items-center gap-2 rounded-full border border-border/70 bg-muted/40 px-2 py-1 text-[11px] font-semibold text-foreground/80 transition hover:underline"
                         >
                           <span className="text-foreground/50">
                             [{source.index}]
                           </span>
-                          <span>{source.title}</span>
+                          <span className="break-words">{source.title}</span>
                           <span className="text-foreground/50">
                             ({source.domain})
                           </span>
@@ -401,12 +401,12 @@ export default function CaseStudyPage({ params }: CaseStudyPageProps) {
                           href={source.url}
                           target="_blank"
                           rel="noreferrer noopener"
-                          className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-muted/40 px-2 py-1 text-[11px] font-semibold text-foreground/80 transition hover:underline"
+                          className="flex max-w-full flex-wrap items-center gap-2 rounded-full border border-border/70 bg-muted/40 px-2 py-1 text-[11px] font-semibold text-foreground/80 transition hover:underline"
                         >
                           <span className="text-foreground/50">
                             [{source.index}]
                           </span>
-                          <span>{source.title}</span>
+                          <span className="break-words">{source.title}</span>
                           <span className="text-foreground/50">
                             ({source.domain})
                           </span>
@@ -502,7 +502,9 @@ export default function CaseStudyPage({ params }: CaseStudyPageProps) {
           ) : null}
         </div>
 
-        <CaseStudyRail caseStudy={caseStudy} />
+        <div className="min-w-0">
+          <CaseStudyRail caseStudy={caseStudy} />
+        </div>
       </div>
     </div>
   );

--- a/ui/partner-hub/components/case-studies/CaseStudyHero.tsx
+++ b/ui/partner-hub/components/case-studies/CaseStudyHero.tsx
@@ -37,12 +37,12 @@ export function CaseStudyHero({ caseStudy }: CaseStudyHeroProps) {
             <p className="text-base text-foreground/70">
               {caseStudy.heroSummary}
             </p>
-            <p className="rounded-md border border-border/70 bg-muted/30 px-4 py-3 text-sm font-semibold text-foreground/80">
-              <span className="text-foreground/50">Transformation:</span>{" "}
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-md border border-border/70 bg-muted/30 px-4 py-3 text-sm font-semibold text-foreground/80">
+              <span className="text-foreground/50">Transformation:</span>
               <span>{caseStudy.stack.before}</span>
-              <span className="mx-2 text-foreground/40">→</span>
+              <span className="text-foreground/40">→</span>
               <span>{caseStudy.stack.after}</span>
-            </p>
+            </div>
           </div>
         </div>
         <div className="relative overflow-hidden rounded-2xl border border-border/70 bg-gradient-to-br from-primary/20 via-background to-muted/60 p-4">

--- a/ui/partner-hub/components/case-studies/CaseStudyRail.tsx
+++ b/ui/partner-hub/components/case-studies/CaseStudyRail.tsx
@@ -35,7 +35,7 @@ export function CaseStudyRail({ caseStudy }: CaseStudyRailProps) {
   );
 
   return (
-    <aside className="space-y-4 lg:sticky lg:top-24">
+    <aside className="space-y-4 lg:sticky lg:top-24 lg:self-start">
       <Card className="space-y-3 border-border/70 p-4 motion-safe:transition motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-sm motion-reduce:transition-none">
         <h2 className={sectionTitleStyles}>Share</h2>
         <CopyLinkButton />
@@ -167,10 +167,10 @@ export function CaseStudyRail({ caseStudy }: CaseStudyRailProps) {
                       href={source.url}
                       target="_blank"
                       rel="noreferrer noopener"
-                      className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-muted/40 px-2 py-1 text-[11px] font-semibold text-foreground/80 transition hover:underline"
+                      className="flex max-w-full flex-wrap items-center gap-2 rounded-full border border-border/70 bg-muted/40 px-2 py-1 text-[11px] font-semibold text-foreground/80 transition hover:underline"
                     >
                       <span className="text-foreground/50">[{source.index}]</span>
-                      <span>{source.title}</span>
+                      <span className="break-words">{source.title}</span>
                       <span className="text-foreground/50">({source.domain})</span>
                     </a>
                   ))
@@ -191,10 +191,10 @@ export function CaseStudyRail({ caseStudy }: CaseStudyRailProps) {
                       href={source.url}
                       target="_blank"
                       rel="noreferrer noopener"
-                      className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-muted/40 px-2 py-1 text-[11px] font-semibold text-foreground/80 transition hover:underline"
+                      className="flex max-w-full flex-wrap items-center gap-2 rounded-full border border-border/70 bg-muted/40 px-2 py-1 text-[11px] font-semibold text-foreground/80 transition hover:underline"
                     >
                       <span className="text-foreground/50">[{source.index}]</span>
-                      <span>{source.title}</span>
+                      <span className="break-words">{source.title}</span>
                       <span className="text-foreground/50">({source.domain})</span>
                     </a>
                   ))


### PR DESCRIPTION
### Motivation

- Prevent horizontal overflow and improve readability of the Case Studies pages at common breakpoints by tightening wrapping and sticky/sidebar behavior.
- Make the reference architecture card and rail/sidebar behave sensibly on small screens and ensure nav/source chips don't cause layout breakage.

### Description

- Updated the hero transformation line to a wrapping flex container (`CaseStudyHero.tsx`) so the before/after text no longer overflows on narrow viewports.
- Added `min-w-0` to the main content column and wrapped the rail in a `min-w-0` container in the case study page (`[slug]/page.tsx`) to prevent flex overflow in grid layouts.
- Reduced architecture card padding on mobile by adding `p-4 sm:p-6` to the architecture `Card` to improve compact readability on small screens (`[slug]/page.tsx`).
- Improved sidebar sticky alignment by adding `lg:self-start` to the rail (`CaseStudyRail.tsx`) and made source/reference chips wrap safely by switching to `flex max-w-full flex-wrap` with `break-words` for long titles.

### Testing

- Ran `npm run lint` and there were no ESLint warnings or errors.
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed without type errors.
- Ran `npm run build` (`next build`) and the site compiled and prerendered pages successfully (static pages and SSG output listed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969b68e6540833090504633e272684f)