### PR TITLE
Add CHIP-8 tool page with emulator core and client UI

### DIFF
--- a/ui/partner-hub/app/(routes)/tools/chip8/page.tsx
+++ b/ui/partner-hub/app/(routes)/tools/chip8/page.tsx
@@ -1,0 +1,5 @@
+import { Chip8Tool } from "@/components/chip8/chip8-tool";
+
+export default function Chip8Page() {
+  return <Chip8Tool />;
+}

--- a/ui/partner-hub/components/chip8/chip8-tool.tsx
+++ b/ui/partner-hub/components/chip8/chip8-tool.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Chip8 } from "@/lib/chip8/chip8";
+
+const KEY_MAPPING: Record<string, number> = {
+  "1": 0x1,
+  "2": 0x2,
+  "3": 0x3,
+  "4": 0xc,
+  q: 0x4,
+  w: 0x5,
+  e: 0x6,
+  r: 0xd,
+  a: 0x7,
+  s: 0x8,
+  d: 0x9,
+  f: 0xe,
+  z: 0xa,
+  x: 0x0,
+  c: 0xb,
+  v: 0xf,
+};
+
+const DEMO_PROGRAM = new Uint8Array([
+  0x00, 0xe0, // CLS
+  0x60, 0x00, // V0 = 0
+  0x61, 0x00, // V1 = 0
+  0x62, 0x00, // V2 = 0
+  0xf2, 0x29, // I = font(V2)
+  0xd0, 0x15, // draw
+  0x60, 0x08, // V0 = 8
+  0x62, 0x01, // V2 = 1
+  0xf2, 0x29,
+  0xd0, 0x15,
+  0x60, 0x10, // V0 = 16
+  0x62, 0x02, // V2 = 2
+  0xf2, 0x29,
+  0xd0, 0x15,
+  0x60, 0x18, // V0 = 24
+  0x62, 0x03, // V2 = 3
+  0xf2, 0x29,
+  0xd0, 0x15,
+  0x12, 0x00, // jump to start
+]);
+
+export function Chip8Tool() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const chip8Ref = useRef<Chip8 | null>(null);
+  const animationRef = useRef<number | null>(null);
+  const audioRef = useRef<{
+    context: AudioContext;
+    gain: GainNode;
+    oscillator: OscillatorNode;
+  } | null>(null);
+
+  const [isRunning, setIsRunning] = useState(false);
+  const [romName, setRomName] = useState("None loaded");
+  const [status, setStatus] = useState("Paused");
+
+  const keypadHelp = useMemo(
+    () => [
+      ["1", "2", "3", "4"],
+      ["Q", "W", "E", "R"],
+      ["A", "S", "D", "F"],
+      ["Z", "X", "C", "V"],
+    ],
+    [],
+  );
+
+  useEffect(() => {
+    chip8Ref.current = new Chip8();
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const key = KEY_MAPPING[event.key.toLowerCase()];
+      if (key === undefined) {
+        return;
+      }
+      event.preventDefault();
+      chip8Ref.current?.setKey(key, true);
+    };
+
+    const handleKeyUp = (event: KeyboardEvent) => {
+      const key = KEY_MAPPING[event.key.toLowerCase()];
+      if (key === undefined) {
+        return;
+      }
+      event.preventDefault();
+      chip8Ref.current?.setKey(key, false);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+    };
+  }, []);
+
+  useEffect(() => {
+    const render = () => {
+      const canvas = canvasRef.current;
+      const chip8 = chip8Ref.current;
+      if (!canvas || !chip8) {
+        animationRef.current = requestAnimationFrame(render);
+        return;
+      }
+
+      const context = canvas.getContext("2d");
+      if (!context) {
+        animationRef.current = requestAnimationFrame(render);
+        return;
+      }
+
+      context.imageSmoothingEnabled = false;
+      const buffer = chip8.getFrameBuffer();
+      const imageData = context.createImageData(64, 32);
+      for (let index = 0; index < buffer.length; index += 1) {
+        const value = buffer[index] ? 255 : 0;
+        const offset = index * 4;
+        imageData.data[offset] = value;
+        imageData.data[offset + 1] = value;
+        imageData.data[offset + 2] = value;
+        imageData.data[offset + 3] = 255;
+      }
+      context.putImageData(imageData, 0, 0);
+
+      animationRef.current = requestAnimationFrame(render);
+    };
+
+    animationRef.current = requestAnimationFrame(render);
+
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isRunning) {
+      setStatus("Paused");
+      return;
+    }
+
+    setStatus("Running");
+    const cpuInterval = window.setInterval(() => {
+      chip8Ref.current?.cycle();
+    }, 2);
+
+    const timerInterval = window.setInterval(() => {
+      const chip8 = chip8Ref.current;
+      if (!chip8) {
+        return;
+      }
+      chip8.tickTimers();
+      const soundTimer = chip8.getSoundTimer();
+      if (audioRef.current) {
+        audioRef.current.gain.gain.value = soundTimer > 0 ? 0.2 : 0;
+      }
+    }, 1000 / 60);
+
+    return () => {
+      window.clearInterval(cpuInterval);
+      window.clearInterval(timerInterval);
+    };
+  }, [isRunning]);
+
+  const ensureAudio = async () => {
+    if (!audioRef.current) {
+      const context = new AudioContext();
+      const oscillator = context.createOscillator();
+      oscillator.type = "square";
+      oscillator.frequency.value = 440;
+      const gain = context.createGain();
+      gain.gain.value = 0;
+      oscillator.connect(gain).connect(context.destination);
+      oscillator.start();
+      audioRef.current = { context, gain, oscillator };
+    }
+
+    if (audioRef.current.context.state === "suspended") {
+      await audioRef.current.context.resume();
+    }
+  };
+
+  const handleStart = async () => {
+    await ensureAudio();
+    setIsRunning(true);
+  };
+
+  const handlePause = () => {
+    setIsRunning(false);
+    if (audioRef.current) {
+      audioRef.current.gain.gain.value = 0;
+    }
+  };
+
+  const handleReset = () => {
+    chip8Ref.current?.reset();
+    setIsRunning(false);
+    setStatus("Paused");
+    setRomName("None loaded");
+    if (audioRef.current) {
+      audioRef.current.gain.gain.value = 0;
+    }
+  };
+
+  const handleLoadDemo = () => {
+    chip8Ref.current?.loadProgram(DEMO_PROGRAM);
+    setRomName("Font demo");
+    setIsRunning(false);
+    setStatus("Paused");
+  };
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+    const buffer = await file.arrayBuffer();
+    chip8Ref.current?.loadProgram(new Uint8Array(buffer));
+    setRomName(file.name);
+    setIsRunning(false);
+    setStatus("Paused");
+  };
+
+  return (
+    <Card className="mx-auto w-full max-w-5xl">
+      <CardHeader>
+        <CardTitle>CHIP-8 Tool</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex flex-col gap-6 lg:flex-row">
+          <div className="flex flex-1 flex-col items-center gap-4">
+            <canvas
+              ref={canvasRef}
+              width={64}
+              height={32}
+              className="h-[320px] w-full max-w-[640px] rounded-lg border border-border bg-black"
+              style={{ imageRendering: "pixelated" }}
+            />
+            <div className="text-sm text-muted-foreground">
+              Status: <span className="font-semibold text-foreground">{status}</span>
+            </div>
+          </div>
+          <div className="flex w-full flex-col gap-4 lg:max-w-xs">
+            <div className="flex flex-wrap gap-2">
+              <Button onClick={handleStart} disabled={isRunning}>
+                Start
+              </Button>
+              <Button onClick={handlePause} variant="secondary" disabled={!isRunning}>
+                Pause
+              </Button>
+              <Button onClick={handleReset} variant="outline">
+                Reset
+              </Button>
+            </div>
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium text-foreground" htmlFor="chip8-rom">
+                ROM upload
+              </label>
+              <input
+                id="chip8-rom"
+                type="file"
+                accept=".ch8,application/octet-stream"
+                onChange={handleFileChange}
+                className="text-sm"
+              />
+              <Button onClick={handleLoadDemo} variant="secondary">
+                Load Demo
+              </Button>
+            </div>
+            <div className="rounded-lg border border-border/60 bg-muted/40 p-3 text-sm">
+              <div className="font-semibold text-foreground">Current ROM</div>
+              <div className="text-muted-foreground">{romName}</div>
+            </div>
+            <div className="rounded-lg border border-border/60 bg-muted/40 p-3 text-sm">
+              <div className="font-semibold text-foreground">Keypad mapping</div>
+              <div className="mt-2 grid grid-cols-4 gap-2 text-center text-xs font-medium text-muted-foreground">
+                {keypadHelp.flat().map((label) => (
+                  <div
+                    key={label}
+                    className="rounded bg-background/70 px-2 py-1 text-foreground"
+                  >
+                    {label}
+                  </div>
+                ))}
+              </div>
+              <p className="mt-3 text-xs text-muted-foreground">
+                1 2 3 4 ➜ 1 2 3 C · Q W E R ➜ 4 5 6 D · A S D F ➜ 7 8 9 E · Z X C V ➜ A 0 B
+                F
+              </p>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui/partner-hub/components/left-nav.tsx
+++ b/ui/partner-hub/components/left-nav.tsx
@@ -12,6 +12,7 @@ const links = [
   { name: "Presales Studio", href: "/tools/architecture-explorer" },
   { name: "Account Mapping", href: "/estimator" },
   { name: "Energy Tool", href: "/tools/energy" },
+  { name: "CHIP-8", href: "/tools/chip8" },
   { name: "Office Schedule", href: "/offices/schedule" },
   { name: "About / Contact", href: "/about" },
 ];

--- a/ui/partner-hub/lib/chip8/chip8.ts
+++ b/ui/partner-hub/lib/chip8/chip8.ts
@@ -1,0 +1,295 @@
+export class Chip8 {
+  private readonly memory: Uint8Array;
+  private readonly v: Uint8Array;
+  private readonly stack: Uint16Array;
+  private readonly frameBuffer: Uint8Array;
+  private readonly keys: boolean[];
+  private i: number;
+  private pc: number;
+  private sp: number;
+  private delayTimer: number;
+  private soundTimer: number;
+  private waitingForKey: boolean;
+  private waitingRegister: number | null;
+
+  constructor() {
+    this.memory = new Uint8Array(4096);
+    this.v = new Uint8Array(16);
+    this.stack = new Uint16Array(16);
+    this.frameBuffer = new Uint8Array(64 * 32);
+    this.keys = new Array(16).fill(false);
+    this.i = 0;
+    this.pc = 0x200;
+    this.sp = 0;
+    this.delayTimer = 0;
+    this.soundTimer = 0;
+    this.waitingForKey = false;
+    this.waitingRegister = null;
+    this.loadFontset();
+  }
+
+  reset() {
+    this.memory.fill(0);
+    this.v.fill(0);
+    this.stack.fill(0);
+    this.frameBuffer.fill(0);
+    this.keys.fill(false);
+    this.i = 0;
+    this.pc = 0x200;
+    this.sp = 0;
+    this.delayTimer = 0;
+    this.soundTimer = 0;
+    this.waitingForKey = false;
+    this.waitingRegister = null;
+    this.loadFontset();
+  }
+
+  loadProgram(program: Uint8Array) {
+    this.reset();
+    this.memory.set(program, 0x200);
+  }
+
+  cycle() {
+    if (this.waitingForKey) {
+      return;
+    }
+
+    const opcode = (this.memory[this.pc] << 8) | this.memory[this.pc + 1];
+    this.pc = (this.pc + 2) & 0xfff;
+
+    const nnn = opcode & 0x0fff;
+    const nn = opcode & 0x00ff;
+    const n = opcode & 0x000f;
+    const x = (opcode & 0x0f00) >> 8;
+    const y = (opcode & 0x00f0) >> 4;
+
+    switch (opcode & 0xf000) {
+      case 0x0000: {
+        switch (nn) {
+          case 0x00e0:
+            this.frameBuffer.fill(0);
+            break;
+          case 0x00ee:
+            this.sp = Math.max(0, this.sp - 1);
+            this.pc = this.stack[this.sp];
+            break;
+          default:
+            break;
+        }
+        break;
+      }
+      case 0x1000:
+        this.pc = nnn;
+        break;
+      case 0x2000:
+        this.stack[this.sp] = this.pc;
+        this.sp = (this.sp + 1) & 0xf;
+        this.pc = nnn;
+        break;
+      case 0x3000:
+        if (this.v[x] === nn) {
+          this.pc = (this.pc + 2) & 0xfff;
+        }
+        break;
+      case 0x4000:
+        if (this.v[x] !== nn) {
+          this.pc = (this.pc + 2) & 0xfff;
+        }
+        break;
+      case 0x5000:
+        if (n === 0 && this.v[x] === this.v[y]) {
+          this.pc = (this.pc + 2) & 0xfff;
+        }
+        break;
+      case 0x6000:
+        this.v[x] = nn;
+        break;
+      case 0x7000:
+        this.v[x] = (this.v[x] + nn) & 0xff;
+        break;
+      case 0x8000:
+        switch (n) {
+          case 0x0:
+            this.v[x] = this.v[y];
+            break;
+          case 0x1:
+            this.v[x] |= this.v[y];
+            break;
+          case 0x2:
+            this.v[x] &= this.v[y];
+            break;
+          case 0x3:
+            this.v[x] ^= this.v[y];
+            break;
+          case 0x4: {
+            const sum = this.v[x] + this.v[y];
+            this.v[0xf] = sum > 0xff ? 1 : 0;
+            this.v[x] = sum & 0xff;
+            break;
+          }
+          case 0x5: {
+            this.v[0xf] = this.v[x] > this.v[y] ? 1 : 0;
+            this.v[x] = (this.v[x] - this.v[y]) & 0xff;
+            break;
+          }
+          case 0x6:
+            this.v[0xf] = this.v[x] & 0x1;
+            this.v[x] >>= 1;
+            break;
+          case 0x7: {
+            this.v[0xf] = this.v[y] > this.v[x] ? 1 : 0;
+            this.v[x] = (this.v[y] - this.v[x]) & 0xff;
+            break;
+          }
+          case 0xe:
+            this.v[0xf] = (this.v[x] & 0x80) >> 7;
+            this.v[x] = (this.v[x] << 1) & 0xff;
+            break;
+          default:
+            break;
+        }
+        break;
+      case 0x9000:
+        if (n === 0 && this.v[x] !== this.v[y]) {
+          this.pc = (this.pc + 2) & 0xfff;
+        }
+        break;
+      case 0xa000:
+        this.i = nnn;
+        break;
+      case 0xb000:
+        this.pc = (nnn + this.v[0]) & 0xfff;
+        break;
+      case 0xc000:
+        this.v[x] = (Math.floor(Math.random() * 256) & nn) & 0xff;
+        break;
+      case 0xd000:
+        this.drawSprite(this.v[x], this.v[y], n);
+        break;
+      case 0xe000:
+        if (nn === 0x9e) {
+          if (this.keys[this.v[x]]) {
+            this.pc = (this.pc + 2) & 0xfff;
+          }
+        } else if (nn === 0xa1) {
+          if (!this.keys[this.v[x]]) {
+            this.pc = (this.pc + 2) & 0xfff;
+          }
+        }
+        break;
+      case 0xf000:
+        switch (nn) {
+          case 0x07:
+            this.v[x] = this.delayTimer;
+            break;
+          case 0x0a:
+            this.waitingForKey = true;
+            this.waitingRegister = x;
+            break;
+          case 0x15:
+            this.delayTimer = this.v[x];
+            break;
+          case 0x18:
+            this.soundTimer = this.v[x];
+            break;
+          case 0x1e:
+            this.i = (this.i + this.v[x]) & 0xfff;
+            break;
+          case 0x29:
+            this.i = this.v[x] * 5;
+            break;
+          case 0x33: {
+            const value = this.v[x];
+            this.memory[this.i] = Math.floor(value / 100);
+            this.memory[this.i + 1] = Math.floor((value % 100) / 10);
+            this.memory[this.i + 2] = value % 10;
+            break;
+          }
+          case 0x55:
+            for (let index = 0; index <= x; index += 1) {
+              this.memory[this.i + index] = this.v[index];
+            }
+            break;
+          case 0x65:
+            for (let index = 0; index <= x; index += 1) {
+              this.v[index] = this.memory[this.i + index];
+            }
+            break;
+          default:
+            break;
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  tickTimers() {
+    if (this.delayTimer > 0) {
+      this.delayTimer -= 1;
+    }
+    if (this.soundTimer > 0) {
+      this.soundTimer -= 1;
+    }
+  }
+
+  setKey(key: number, down: boolean) {
+    this.keys[key] = down;
+    if (down && this.waitingForKey && this.waitingRegister !== null) {
+      this.v[this.waitingRegister] = key;
+      this.waitingForKey = false;
+      this.waitingRegister = null;
+    }
+  }
+
+  getFrameBuffer() {
+    return this.frameBuffer;
+  }
+
+  getSoundTimer() {
+    return this.soundTimer;
+  }
+
+  private drawSprite(x: number, y: number, height: number) {
+    this.v[0xf] = 0;
+    for (let row = 0; row < height; row += 1) {
+      const sprite = this.memory[this.i + row];
+      for (let col = 0; col < 8; col += 1) {
+        const spritePixel = (sprite >> (7 - col)) & 0x1;
+        if (spritePixel === 0) {
+          continue;
+        }
+        const xPos = (x + col) % 64;
+        const yPos = (y + row) % 32;
+        const index = xPos + yPos * 64;
+        if (this.frameBuffer[index] === 1) {
+          this.v[0xf] = 1;
+        }
+        this.frameBuffer[index] ^= 1;
+      }
+    }
+  }
+
+  private loadFontset() {
+    const fontset = [
+      0xf0, 0x90, 0x90, 0x90, 0xf0, // 0
+      0x20, 0x60, 0x20, 0x20, 0x70, // 1
+      0xf0, 0x10, 0xf0, 0x80, 0xf0, // 2
+      0xf0, 0x10, 0xf0, 0x10, 0xf0, // 3
+      0x90, 0x90, 0xf0, 0x10, 0x10, // 4
+      0xf0, 0x80, 0xf0, 0x10, 0xf0, // 5
+      0xf0, 0x80, 0xf0, 0x90, 0xf0, // 6
+      0xf0, 0x10, 0x20, 0x40, 0x40, // 7
+      0xf0, 0x90, 0xf0, 0x90, 0xf0, // 8
+      0xf0, 0x90, 0xf0, 0x10, 0xf0, // 9
+      0xf0, 0x90, 0xf0, 0x90, 0x90, // A
+      0xe0, 0x90, 0xe0, 0x90, 0xe0, // B
+      0xf0, 0x80, 0x80, 0x80, 0xf0, // C
+      0xe0, 0x90, 0x90, 0x90, 0xe0, // D
+      0xf0, 0x80, 0xf0, 0x80, 0xf0, // E
+      0xf0, 0x80, 0xf0, 0x80, 0x80, // F
+    ];
+
+    this.memory.set(fontset, 0x0);
+  }
+}


### PR DESCRIPTION
### Motivation
- Add an in-browser CHIP-8 playground under the existing tools area so users can upload/run small CHIP-8 programs and experiment with keypad input and audio.
- Keep the UI client-only to avoid SSR/hydration issues and to enable user-gesture WebAudio for the beep sound.
- Provide a self-contained TypeScript emulator core implementing the standard CHIP-8 features so the tool can run without third-party ROMs.

### Description
- Implemented the emulator core in `ui/partner-hub/lib/chip8/chip8.ts` with 4K memory, V0-VF, I, PC, stack/SP, `delayTimer`/`soundTimer` at 60Hz, opcode fetch/decode/execute (including `00E0`, `00EE`, `1nnn`..`Fx65`), `Dxyn` sprite drawing with XOR and VF collision, fontset loading and `Fx29`, `Cxnn` random, `Fx0A` wait-for-key, and public methods `reset()`, `loadProgram()`, `cycle()`, `tickTimers()`, `setKey()`, `getFrameBuffer()`, and `getSoundTimer()`.
- Added a client-only CHIP-8 UI component at `ui/partner-hub/components/chip8/chip8-tool.tsx` (with `"use client"`) that renders a 64x32 canvas (scaled via CSS to e.g. 640x320 with pixelated rendering), accepts ROM uploads (`.ch8` and `application/octet-stream`) loading at `0x200`, exposes `Start`/`Pause`/`Reset` controls, shows running status and current ROM name, displays keypad mapping, and includes a small builtin demo byte array that draws font sprites.
- Implemented simple WebAudio beep controlled by the emulator `soundTimer` and initialized on a user gesture (`Start`) to prevent autoplay, and used existing UI components (`Button`, `Card`) for consistent styling.
- Added the route `ui/partner-hub/app/(routes)/tools/chip8/page.tsx` which renders the `Chip8Tool`, and added a left-nav entry in `ui/partner-hub/components/left-nav.tsx` linking to `/tools/chip8`.

### Testing
- Ran `npm run lint` in `ui/partner-hub` which failed because `next` is not installed/available in the execution environment so the linter could not run.
- Ran `npm run typecheck` (`tsc --noEmit`) which reported many type errors related to missing dependencies/type declarations in the environment (missing `react`, `next`, node/@types, and other project dev dependencies), so a full project typecheck could not complete successfully.
- Ran `npm run build` which failed because `next` is not available in the environment so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d4846cf50833087660be1b607977e)