### PR TITLE
Fix AccountMappingTool effect ref dependency

### DIFF
--- a/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
+++ b/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
@@ -513,17 +513,17 @@ export default function AccountMappingTool() {
   const matchResults = useMemo(() => matchComputation.results, [matchComputation.results]);
 
   useEffect(() => {
+    const runStart = runStartRef;
     if (!matchComputation.durationMs && matchResults.length === 0) {
       return;
     }
     const endTime = performance.now();
-    // runStartRef is a stable ref; exhaustive-deps warning is a false positive for refs.
     setRunStats((prev) => ({
       ...prev,
       matchMs: matchComputation.durationMs,
-      totalMs: runStartRef.current ? endTime - runStartRef.current : prev.totalMs,
+      totalMs: runStart.current ? endTime - runStart.current : prev.totalMs,
     }));
-  }, [matchComputation.durationMs, matchResults.length]);
+  }, [matchComputation.durationMs, matchResults.length, runStartRef]);
 
   const baseReviewRows = useMemo(() => {
     return matchResults


### PR DESCRIPTION
### Motivation
- Eliminate an ESLint `react-hooks/exhaustive-deps` warning about `runStartRef` used inside a `useEffect` that updates match run statistics without changing runtime behavior.

### Description
- Move the ref access into a local alias inside the effect (`const runStart = runStartRef;`) and use `runStart.current` inside the effect, and include `runStartRef` in the dependency array to satisfy ESLint.
- Changed file: `ui/partner-hub/components/account-mapping/AccountMappingTool.tsx`.

### Testing
- Attempted `npm run build` at the repository root which failed due to a missing `package.json` with error `Could not read package.json: Error: ENOENT: no such file or directory, open '/workspace/accountlist/package.json'`.
- Attempted `npm run build` in `ui/partner-hub` which failed because `next` is not installed/available, with error `sh: 1: next: not found`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d4d4c7cf48330920796ef4453a1cf)