### PR TITLE
Fix callback dependencies in AccountMappingTool

### DIFF
--- a/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
+++ b/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
@@ -1072,6 +1072,8 @@ export default function AccountMappingTool() {
     selectedTemplateId,
     targetRows.length,
     templates,
+    setRunHistoryError,
+    setRunHistoryStatus,
     vendorFileName,
     vendorMapping,
     vendorRecords.length,
@@ -1140,7 +1142,14 @@ export default function AccountMappingTool() {
       setDecisions(run.decisions);
       setSelectedTemplateId(run.templateId ?? "");
     },
-    [],
+    [
+      setDecisions,
+      setPartnerMapping,
+      setPartnerState,
+      setSelectedTemplateId,
+      setVendorMapping,
+      setVendorState,
+    ],
   );
 
   const loadDemoDataset = useCallback(async () => {
@@ -1193,7 +1202,14 @@ export default function AccountMappingTool() {
     } finally {
       setIsDemoLoading(false);
     }
-  }, [handlePartnerFile, handleVendorFile, resetRunTracking]);
+  }, [
+    handlePartnerFile,
+    handleVendorFile,
+    resetRunTracking,
+    setDecisions,
+    setSelectedTemplateId,
+    setTemplateName,
+  ]);
 
   return (
     <section className="space-y-8 md:space-y-10">


### PR DESCRIPTION
### Motivation

- Silence `react-hooks/exhaustive-deps` warnings by ensuring callbacks include the stable state setters they reference without changing runtime behavior.

### Description

- Add `setRunHistoryError` and `setRunHistoryStatus` to the `saveRunSnapshot` `useCallback` dependency array.
- Populate the `handleOpenRun` `useCallback` dependency array with the setters it uses: `setDecisions`, `setPartnerMapping`, `setPartnerState`, `setSelectedTemplateId`, `setVendorMapping`, and `setVendorState`.
- Add `setDecisions`, `setSelectedTemplateId`, and `setTemplateName` to the `loadDemoDataset` `useCallback` dependency array.

### Testing

- Ran `npm run build` at the repo root which failed due to missing `package.json` at `/workspace/accountlist` (expected environment limitation).
- Ran `npm run build` in `/workspace/accountlist/ui` which failed due to missing `package.json` in that directory (environment limitation).
- Ran `npm run build` in `/workspace/accountlist/ui/partner-hub` which invoked `next build` and failed because `next` is not installed in the environment (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d51b3c02c8330991cbd977e461114)