### PR TITLE
Import normalizeMapping in AccountMappingTool

### DIFF
--- a/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
+++ b/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
@@ -17,6 +17,7 @@ import { inferMappingFromHeaders } from "@/lib/account-mapping/inference";
 import {
   canonicalFields,
   createEmptyRawMapping,
+  normalizeMapping,
   validateMapping,
   type RawAccountMapping,
 } from "@/lib/account-mapping/schema";


### PR DESCRIPTION
### Motivation
- Restore access to `normalizeMapping` after the helpers/hooks refactor because the build failed with `Cannot find name 'normalizeMapping'`.

### Description
- Add `normalizeMapping` import from `ui/partner-hub/lib/account-mapping/schema.ts` into `ui/partner-hub/components/account-mapping/AccountMappingTool.tsx` without changing the helper logic or behavior.

### Testing
- Ran `npm run build`, which could not be completed here because the command failed with an error about a missing `/workspace/accountlist/package.json`, so the TypeScript build could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d548097c88330a545e73bcbbd38a8)