### PR TITLE
Remove unnecessary buildCsvRows from useCallback deps in AccountMappingTool

### DIFF
--- a/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
+++ b/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
@@ -720,7 +720,7 @@ export default function AccountMappingTool() {
     );
     downloadCsv("merged_accounts.csv", csv);
     await saveRunSnapshot();
-  }, [buildCsvRows, mergedExportRows, saveRunSnapshot]);
+  }, [mergedExportRows, saveRunSnapshot]);
 
   const handleDownloadTargets = useCallback(async () => {
     const csv = buildCsv(
@@ -729,7 +729,7 @@ export default function AccountMappingTool() {
     );
     downloadCsv("targets.csv", csv);
     await saveRunSnapshot();
-  }, [buildCsvRows, saveRunSnapshot, targetRows]);
+  }, [saveRunSnapshot, targetRows]);
 
   const handleDownloadMergedSearch = useCallback(
     (rows: MergedSearchRow[], headers: string[]) => {
@@ -739,7 +739,7 @@ export default function AccountMappingTool() {
       );
       downloadCsv("merged_search.csv", csv);
     },
-    [buildCsvRows],
+    [],
   );
 
   const handleOpenRun = useCallback(


### PR DESCRIPTION
### Motivation
- Silence ESLint `react-hooks/exhaustive-deps` warnings by removing `buildCsvRows` from `useCallback` dependency arrays where it is an outer-scope stable value, with no behavioral change.

### Description
- Removed `buildCsvRows` from the dependency arrays of three export callbacks in `ui/partner-hub/components/account-mapping/AccountMappingTool.tsx` and stabilized the merged-search export callback with an empty dependency array.

### Testing
- Ran `npm run build` in three locations: repo root (failed: missing `/workspace/accountlist/package.json`), `/workspace/accountlist/ui` (failed: missing `package.json`), and `/workspace/accountlist/ui/partner-hub` (failed: `next` not found), so build could not be completed in this environment; changes are limited to hook dependency arrays and introduce no runtime behavior changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d595361108330a758ab2a6b920961)