### PR TITLE
Use shared CsvRows type for account-mapping CSV exports

### DIFF
--- a/ui/partner-hub/components/account-mapping/hooks/useAccountMappingViewModel.ts
+++ b/ui/partner-hub/components/account-mapping/hooks/useAccountMappingViewModel.ts
@@ -8,6 +8,7 @@ import {
   type MergedAccountExportRow,
   type TargetExportRow,
 } from "@/lib/account-mapping/exportSchema";
+import type { CsvRows } from "@/lib/account-mapping/csv";
 import type { MergedSearchRow } from "@/lib/account-mapping/mergedSearch";
 import {
   resolveMergedSearchDataset,
@@ -36,17 +37,17 @@ export type AccountMappingViewModel = {
   statusOptions: string[];
   matchPairs: MatchPairSnapshot[];
   mergedExportRows: MergedAccountExportRow[];
-  mergedExportCsvRows: string[][];
+  mergedExportCsvRows: CsvRows;
   targetRows: TargetExportRow[];
   targetPreview: TargetExportRow[];
-  targetExportCsvRows: string[][];
+  targetExportCsvRows: CsvRows;
   activeMergedSearchDataset: MergedSearchDatasetSelection;
   mergedSearchRows: MergedSearchRow[];
   mergedSearchHeaders: string[];
   mergedSearchLabel: string;
   latestComparableRun?: AccountMappingRun;
   diffSummary: DiffSummary | null;
-  buildMergedSearchCsvRows: (rows: MergedSearchRow[], headers: string[]) => string[][];
+  buildMergedSearchCsvRows: (rows: MergedSearchRow[], headers: string[]) => CsvRows;
 };
 
 type AccountMappingViewModelArgs = {

--- a/ui/partner-hub/lib/account-mapping/csv.ts
+++ b/ui/partner-hub/lib/account-mapping/csv.ts
@@ -1,4 +1,7 @@
 export type CsvValue = string | number | boolean | null | undefined;
+export type CsvCell = CsvValue;
+export type CsvRow = CsvCell[];
+export type CsvRows = CsvRow[];
 
 export const escapeCsvValue = (value: CsvValue): string => {
   if (value === null || value === undefined) {


### PR DESCRIPTION
### Motivation
- Fix a TypeScript type mismatch where CSV row builders produce `string | number | boolean` but the view-model declared `string[][]`, causing a type error when returning `mergedExportCsvRows`.

### Description
- Add shared type aliases `CsvCell`, `CsvRow`, and `CsvRows` to `ui/partner-hub/lib/account-mapping/csv.ts` to represent CSV cell/row types.
- Update `AccountMappingViewModel` in `ui/partner-hub/components/account-mapping/hooks/useAccountMappingViewModel.ts` to use `CsvRows` for `mergedExportCsvRows`, `targetExportCsvRows`, and `buildMergedSearchCsvRows`, with no runtime behavior changes.

### Testing
- Ran `npm run build` in `ui/partner-hub` which failed due to a missing `next` binary in the environment (error: `sh: 1: next: not found`), so a full build/typecheck could not be completed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d6093707483309cdf5d78d7dcc204)