### PR TITLE
Remove outer card from office schedule time panel

### DIFF
--- a/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
+++ b/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
@@ -821,7 +821,7 @@ export function OfficeScheduleClient({
                 </div>
 
                 {/* Times */}
-                <aside className="rounded-xl border border-border/70 bg-muted/20 p-4">
+                <aside className="flex flex-col">
                   <div className="text-sm font-semibold">{formatDayLabel(baseDate)}</div>
                   <div className="mt-1 text-xs text-foreground/60">
                     {selectedDayAvailableCount === 0


### PR DESCRIPTION
### Motivation
- Remove the extra outer rounded card around the right-side time panel so the day header, controls and slot list align with the calendar column and avoid a “card inside a card” appearance.

### Description
- Replace the outer wrapper on the right time panel by changing `<aside className="rounded-xl border border-border/70 bg-muted/20 p-4">` to `<aside className="flex flex-col">` in `ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx`, preserving the inner slot list container and its rounded border/scroll behavior.

### Testing
- Ran `npm run build` which failed in the environment due to `next: not found` so a full build could not be validated; `npm run dev` also failed for the same reason.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d67613c688330ba447bec81722a7b)