### PR TITLE
Fix time parsing regexes in OfficeScheduleClient

### DIFF
--- a/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
+++ b/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
@@ -145,7 +145,7 @@ function isValidDateISO(value?: string) {
 function parseTimeString(value: string) {
   const raw = value.trim().toLowerCase();
   if (!raw) return null;
-  const match = raw.match(/(\\d{1,2})(?::(\\d{2}))?\\s*(am|pm)?/);
+  const match = raw.match(/(\d{1,2})(?::(\d{2}))?\s*(am|pm)?/);
   if (!match) return null;
   const hoursRaw = Number(match[1]);
   const minutesRaw = match[2] ? Number(match[2]) : 0;
@@ -180,7 +180,7 @@ function parseTimeWindow(value: string) {
   if (raw.includes("evening")) return { startMin: 17 * 60, endMin: 19 * 60 };
   if (raw.includes("noon")) return { startMin: 12 * 60, endMin: 13 * 60 };
 
-  const betweenMatch = raw.match(/between\\s+(.+)\\s+and\\s+(.+)/);
+  const betweenMatch = raw.match(/between\s+(.+)\s+and\s+(.+)/);
   if (betweenMatch) {
     const start = parseTimeString(betweenMatch[1]);
     const end = parseTimeString(betweenMatch[2]);
@@ -189,13 +189,13 @@ function parseTimeWindow(value: string) {
     }
   }
 
-  const afterMatch = raw.match(/after\\s+(.+)/);
+  const afterMatch = raw.match(/after\s+(.+)/);
   if (afterMatch) {
     const start = parseTimeString(afterMatch[1]);
     if (start !== null) return { startMin: start, endMin: WORK_END_MIN };
   }
 
-  const beforeMatch = raw.match(/before\\s+(.+)/);
+  const beforeMatch = raw.match(/before\s+(.+)/);
   if (beforeMatch) {
     const end = parseTimeString(beforeMatch[1]);
     if (end !== null) return { startMin: WORK_START_MIN, endMin: end };


### PR DESCRIPTION
### Motivation
- Fix an infinite loop in the "Use AI to schedule" modal where valid user times (e.g. "3pm") were not recognized and the flow re-asked for a time. 
- Root cause: regex literals in `OfficeScheduleClient.tsx` used double-escaped sequences like `\\d` and `\\s` inside `/.../`, preventing matches.

### Description
- Updated `ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx` to use correct regex literals (single-escaped sequences). 
- Replaced `/(\\d{1,2})(?::(\\d{2}))?\\s*(am|pm)?/` with `/( d{1,2})(?::( d{2}))? s*(am|pm)?/` (shown in file as `/(\d{1,2})(?::(\d{2}))?\s*(am|pm)?/` -> `/(
 d{1,2})(?::(
 d{2}))?
 s*(am|pm)?/`).
- Corrected `between\\s+(.+)\\s+and\\s+(.+)` to `between\s+(.+)\s+and\s+(.+)`, `after\\s+(.+)` to `after\s+(.+)`, and `before\\s+(.+)` to `before\s+(.+)`, applying the rule `\\d -> \d` and `\\s -> \s` inside regex literals.

### Testing
- Ran `npm run build` at the repository root and it failed with `Could not read package.json` (environment missing repo-level `package.json`).
- Ran `npm run build` in `ui` and it failed with `Could not read package.json` (missing `package.json` in that directory).
- Ran `npm run build` in `ui/partner-hub` and it failed because `next` was not found in the environment, so build could not complete there.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696da2e8a5ac83309d1519d8dca9e6e7)