### PR TITLE
Stabilize AI scheduling steps and availability checks

### DIFF
--- a/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
+++ b/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
@@ -872,7 +872,16 @@ export function OfficeScheduleClient({
     const timeExactMin = state.timeExact ? parseTimeExact(state.timeExact) : null;
     const timeWindow = !timeExactMin && state.timeWindow ? parseTimeWindow(state.timeWindow) : null;
 
-    if (!dateISO || !duration || (timeExactMin === null && !timeWindow)) return;
+    if (!dateISO || !duration || (timeExactMin === null && !timeWindow)) {
+      const nextStep = deriveAiStep(state);
+      setAiStep(nextStep);
+      setAiNeedsDuration(nextStep === "collect_duration");
+      const message = promptForStep(nextStep);
+      if (message) {
+        setAiMessages((prev) => [...prev, { role: "assistant", content: message }]);
+      }
+      return;
+    }
 
     setAiChecking(true);
     setAiNeedsDuration(false);
@@ -910,17 +919,23 @@ export function OfficeScheduleClient({
         ...prev,
         {
           role: "assistant",
-          content: "I couldn’t find availability for that request. Let me know another time to try.",
+          content: "I couldn’t find an opening at that time. What time should I try instead?",
         },
       ]);
       setAiOptions([]);
-      setAiStep("choose_option");
+      setAiSelectedOption(null);
+      setAiStep("collect_time");
+      setAiNeedsDuration(false);
       setAiChecking(false);
       return;
     }
 
     setAiOptions(result.options);
     setAiStep("choose_option");
+    setAiMessages((prev) => [
+      ...prev,
+      { role: "assistant", content: "Reply with 1, 2, or 3." },
+    ]);
     setAiChecking(false);
   }
 
@@ -1103,21 +1118,24 @@ export function OfficeScheduleClient({
       if (requestChanged) {
         setAiOptions([]);
         setAiSelectedOption(null);
-        if (aiStep === "choose_option" || aiStep === "confirm" || aiStep === "done") {
-          setAiStep("collect_date");
-        }
+        setAiStep(deriveAiStep(merged));
       }
       advanceAiStep(merged);
     } catch (error: any) {
       setAiError("AI isn’t available right now. You can still book manually.");
       const detail = error instanceof Error ? error.message : String(error);
-      setAiMessages((prev) => [
-        ...prev,
-        {
-          role: "assistant",
-          content: detail || "I couldn’t reach the AI right now.",
-        },
-      ]);
+      const detailMessage = detail || "I couldn’t reach the AI right now.";
+      setAiChecking(false);
+      setAiMessages((prev) => {
+        const lastAssistant = [...prev].reverse().find((msg) => msg.role === "assistant");
+        if (lastAssistant?.content === detailMessage) {
+          return prev;
+        }
+        return [...prev, { role: "assistant", content: detailMessage }];
+      });
+      if (aiStep === "checking_availability") {
+        setAiStep(deriveAiStep(aiDraft));
+      }
     } finally {
       setAiLoading(false);
       setAiSending(false);


### PR DESCRIPTION
### Motivation
- Prevent the UI from entering a selection state with no options and guide the user to provide the next-best input instead. 
- Ensure availability checks only run when the required inputs (`dateISO`, `timePref`/window, and a valid `durationMinutes`) are present. 
- Make error and request-change recovery deterministic so the modal doesn't get stuck or spam duplicate assistant messages.

### Description
- Update `checkAiAvailability` to short-circuit when required fields are missing by deriving the next step via `deriveAiStep` and prompting the user for that input. 
- When availability returns zero `options`, keep the draft date/duration, clear selection, prompt: "I couldn’t find an opening at that time. What time should I try instead?", and set the step to `collect_time` (no `choose_option`).
- When availability returns options, set `aiOptions` and `aiStep` to `choose_option` and add an assistant prompt: "Reply with 1, 2, or 3." to lock selection-mode expectations.
- On user edits (`requestChanged`) use `setAiStep(deriveAiStep(merged))` rather than aggressively resetting to `collect_date`.
- Improve error handling in the `catch` path by setting `aiChecking` false, avoiding duplicate assistant error messages (by checking the last assistant message), and reverting the step out of `checking_availability` to a derived sane step when necessary.

### Testing
- Ran `npm run build` in `ui/partner-hub` which failed due to the environment missing `next` (build did not run to completion).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696da8a45da0833092f5ef2a82a44b16)