### PR TITLE
Fix missing normalizeDuration in OfficeScheduleClient

### DIFF
--- a/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
+++ b/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
@@ -214,6 +214,27 @@ function parseTimeWindow(value: string) {
   return null;
 }
 
+const ALLOWED_DURATIONS = new Set([15, 30, 45, 60]);
+
+function normalizeDuration(input?: string | number): 15 | 30 | 45 | 60 | null {
+  if (input == null) return null;
+
+  const n =
+    typeof input === "number"
+      ? input
+      : Number(String(input).trim().replace(/[^\d]/g, ""));
+
+  if (!Number.isFinite(n)) return null;
+
+  if (ALLOWED_DURATIONS.has(n)) return n as 15 | 30 | 45 | 60;
+
+  if (n === 1) return 60;
+  if (n === 90) return null;
+  if (n === 120) return null;
+
+  return null;
+}
+
 function extractLocalAiFields(input: string): Partial<AiExtracted> {
   const trimmed = input.trim();
   if (!trimmed) return {};


### PR DESCRIPTION
### Motivation
- Resolve a TypeScript error caused by a missing `normalizeDuration` helper referenced in `ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx` and ensure deterministic duration parsing limited to allowed values.

### Description
- Added `ALLOWED_DURATIONS` set and implemented `function normalizeDuration(input?: string | number): 15 | 30 | 45 | 60 | null` alongside other parsing helpers in `OfficeScheduleClient.tsx`.
- The helper accepts numeric or string input, strips non-digits, returns one of `15`, `30`, `45`, `60` when valid, maps `1` to `60`, and returns `null` for unsupported values.
- Kept the existing call site `normalizeDuration(durationCandidate ?? undefined)` used by `extractLocalAiFields` so no other behavioral changes were introduced.

### Testing
- Ran `npm run build` in the project; the build could not complete due to the environment missing the `next` binary (`sh: 1: next: not found`).
- No automated unit tests were added or modified; the TypeScript reference error is resolved by the local helper implementation (Option A).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696daf00aa7c833084a6464fc0c0cdce)