### PR TITLE
Filter "Current run" merged search dataset to include only auto-match and confirmed/manual matches

### DIFF
--- a/ui/partner-hub/components/account-mapping/hooks/useAccountMappingViewModel.ts
+++ b/ui/partner-hub/components/account-mapping/hooks/useAccountMappingViewModel.ts
@@ -174,20 +174,29 @@ export const useAccountMappingViewModel = ({
 
   const runSearchDataset = useMemo<MergedSearchRow[]>(
     () =>
-      reviewRows.map((row) => ({
-        vendor_account_name: row.vendor.rawName ?? "",
-        partner_account_name: row.partner?.rawName ?? "",
-        vendor_owner: row.vendor.ownerName ?? "",
-        partner_owner: row.partner?.ownerName ?? "",
-        vendor_status: row.vendor.status ?? "",
-        partner_status: row.partner?.status ?? "",
-        vendor_crm_account_id: row.vendor.crmAccountId ?? "",
-        partner_crm_account_id: row.partner?.crmAccountId ?? "",
-        vendor_region: row.vendor.region ?? "",
-        partner_region: row.partner?.region ?? "",
-        vendor_organization: row.vendor.organization ?? "",
-        partner_organization: row.partner?.organization ?? "",
-      })),
+      reviewRows
+        .filter(
+          (row) =>
+            row.partnerAccountKey &&
+            row.status !== "rejected" &&
+            (row.baseStatus === "autoMatch" ||
+              row.status === "confirmed" ||
+              row.status === "manual"),
+        )
+        .map((row) => ({
+          vendor_account_name: row.vendor.rawName ?? "",
+          partner_account_name: row.partner?.rawName ?? "",
+          vendor_owner: row.vendor.ownerName ?? "",
+          partner_owner: row.partner?.ownerName ?? "",
+          vendor_status: row.vendor.status ?? "",
+          partner_status: row.partner?.status ?? "",
+          vendor_crm_account_id: row.vendor.crmAccountId ?? "",
+          partner_crm_account_id: row.partner?.crmAccountId ?? "",
+          vendor_region: row.vendor.region ?? "",
+          partner_region: row.partner?.region ?? "",
+          vendor_organization: row.vendor.organization ?? "",
+          partner_organization: row.partner?.organization ?? "",
+        })),
     [reviewRows],
   );
 


### PR DESCRIPTION
### Motivation

- The "Current run" merged search dataset was including review (suggestion) rows and populating `partner_*` fields from best candidates even when users had not confirmed matches, causing questionable matches to appear in overlap results. 
- The expected behavior is to surface only auto-matched rows (`baseStatus === "autoMatch"`) and user-confirmed matches (`status === "confirmed"` or `status === "manual"`) while excluding review suggestions and rejected matches.

### Description

- Update the `runSearchDataset` builder in `ui/partner-hub/components/account-mapping/hooks/useAccountMappingViewModel.ts` to filter `reviewRows` so rows are included only when `row.partnerAccountKey` exists, `row.status !== "rejected"`, and `(row.baseStatus === "autoMatch" || row.status === "confirmed" || row.status === "manual")`.
- The key filter applied is: `reviewRows.filter(row => row.partnerAccountKey && row.status !== "rejected" && (row.baseStatus === "autoMatch" || row.status === "confirmed" || row.status === "manual"))` which then maps to the merged search row shape.
- All other behavior is preserved, including CSV exports, target rules, tabs, decision filters, diff summary, and the uploaded merged CSV path.

### Testing

- Attempted a full build with `npm run build` at `/workspace/accountlist/ui` which failed because `package.json` was not present in that directory. 
- Attempted `npm run build` in the package at `/workspace/accountlist/ui/partner-hub` which started the `next build` script but failed in this environment with `sh: 1: next: not found`, so a production build could not be validated here. 
- No existing unit tests for this view model were found or modified in this change; behavior is enforced via the clear filter change in the view model and should be covered by integration/manual acceptance (load demo dataset → run overlap search → confirm only auto-match and manually confirmed rows appear).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3fb343c88330bc478fb507ceaf65)