### PR TITLE
Add configurable visible columns to Step 3 (Map Columns) with Add/Remove UX

### DIFF
--- a/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
+++ b/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
@@ -6,8 +6,11 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { inferMappingFromHeaders } from "@/lib/account-mapping/inference";
 import {
+  canonicalFields,
   createEmptyRawMapping,
+  DEFAULT_VISIBLE_FIELD_KEYS,
   validateMapping,
+  type CanonicalFieldKey,
   type RawAccountMapping,
 } from "@/lib/account-mapping/schema";
 import { buildCsv, downloadCsv } from "@/lib/account-mapping/csv";
@@ -75,6 +78,11 @@ export default function AccountMappingTool() {
   const [partnerMapping, setPartnerMapping] = useState<RawAccountMapping>(
     createEmptyRawMapping(),
   );
+  const [visibleColumns, setVisibleColumns] = useState<CanonicalFieldKey[]>(
+    DEFAULT_VISIBLE_FIELD_KEYS,
+  );
+  const [isAddColumnOpen, setIsAddColumnOpen] = useState(false);
+  const addColumnRef = useRef<HTMLDivElement | null>(null);
 
   const [activeTab, setActiveTab] = useState<"auto" | "review" | "unmatched">("review");
   const [searchTerm, setSearchTerm] = useState("");
@@ -414,8 +422,44 @@ export default function AccountMappingTool() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [handleDecision, selectedRow]);
 
+  useEffect(() => {
+    if (!isAddColumnOpen) {
+      return;
+    }
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!addColumnRef.current?.contains(event.target as Node)) {
+        setIsAddColumnOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [isAddColumnOpen]);
+
   const vendorHeaders = vendorState.result?.headers ?? [];
   const partnerHeaders = partnerState.result?.headers ?? [];
+
+  const hiddenColumns = useMemo(
+    () => canonicalFields.filter((field) => !visibleColumns.includes(field.key)),
+    [visibleColumns],
+  );
+  const removableColumns = useMemo(
+    () => visibleColumns.filter((fieldKey) => !DEFAULT_VISIBLE_FIELD_KEYS.includes(fieldKey)),
+    [visibleColumns],
+  );
+
+  const handleAddColumn = useCallback((fieldKey: CanonicalFieldKey) => {
+    setVisibleColumns((prev) => (prev.includes(fieldKey) ? prev : [...prev, fieldKey]));
+    setIsAddColumnOpen(false);
+  }, []);
+
+  const handleRemoveColumn = useCallback((fieldKey: CanonicalFieldKey) => {
+    if (DEFAULT_VISIBLE_FIELD_KEYS.includes(fieldKey)) {
+      return;
+    }
+    setVisibleColumns((prev) => prev.filter((key) => key !== fieldKey));
+    setVendorMapping((prev) => ({ ...prev, [fieldKey]: "" }));
+    setPartnerMapping((prev) => ({ ...prev, [fieldKey]: "" }));
+  }, []);
 
   const saveRunSnapshot = useCallback(async () => {
     if (!vendorState.result || !partnerState.result) {
@@ -684,10 +728,47 @@ export default function AccountMappingTool() {
 
       <Card className="space-y-6">
         <CardHeader className="gap-2">
-          <CardTitle className="text-lg">Step 3: Map columns</CardTitle>
-          <p className="text-sm text-foreground/60">
-            Required fields must be mapped before saving templates. Auto-mapping uses header inference.
-          </p>
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="space-y-2">
+              <CardTitle className="text-lg">Step 3: Map columns</CardTitle>
+              <p className="text-sm text-foreground/60">
+                Required fields must be mapped before saving templates. Auto-mapping uses header inference.
+              </p>
+            </div>
+            <div className="relative" ref={addColumnRef}>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setIsAddColumnOpen((prev) => !prev)}
+                disabled={hiddenColumns.length === 0}
+              >
+                Add Column
+              </Button>
+              {isAddColumnOpen ? (
+                <div className="absolute right-0 z-20 mt-2 w-64 rounded-md border border-foreground/10 bg-background shadow-lg">
+                  <div className="max-h-64 overflow-auto py-2 text-sm">
+                    {hiddenColumns.length === 0 ? (
+                      <div className="px-4 py-2 text-xs text-foreground/50">
+                        All columns are already visible.
+                      </div>
+                    ) : (
+                      hiddenColumns.map((field) => (
+                        <button
+                          key={field.key}
+                          type="button"
+                          className="flex w-full items-center justify-between px-4 py-2 text-left hover:bg-muted/60"
+                          onClick={() => handleAddColumn(field.key)}
+                        >
+                          <span>{field.label}</span>
+                          <span className="text-xs text-foreground/40">Add</span>
+                        </button>
+                      ))
+                    )}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="grid gap-6 lg:grid-cols-2">
@@ -697,6 +778,9 @@ export default function AccountMappingTool() {
               mapping={vendorMapping}
               setMapping={setVendorMapping}
               validation={vendorValidation}
+              visibleFields={visibleColumns}
+              removableFields={removableColumns}
+              onRemoveField={handleRemoveColumn}
             />
             <MappingTableCard
               title="Partner mapping"
@@ -704,6 +788,9 @@ export default function AccountMappingTool() {
               mapping={partnerMapping}
               setMapping={setPartnerMapping}
               validation={partnerValidation}
+              visibleFields={visibleColumns}
+              removableFields={removableColumns}
+              onRemoveField={handleRemoveColumn}
             />
           </div>
 

--- a/ui/partner-hub/components/account-mapping/MappingTableCard.tsx
+++ b/ui/partner-hub/components/account-mapping/MappingTableCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { Dispatch, SetStateAction } from "react";
+import { useMemo, type Dispatch, type SetStateAction } from "react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -18,6 +18,9 @@ type MappingTableCardProps = {
   mapping: RawAccountMapping;
   setMapping: Dispatch<SetStateAction<RawAccountMapping>>;
   validation: ReturnType<typeof validateMapping>;
+  visibleFields: Array<(typeof canonicalFields)[number]["key"]>;
+  removableFields: Array<(typeof canonicalFields)[number]["key"]>;
+  onRemoveField: (fieldKey: (typeof canonicalFields)[number]["key"]) => void;
 };
 
 export function MappingTableCard({
@@ -26,7 +29,24 @@ export function MappingTableCard({
   mapping,
   setMapping,
   validation,
+  visibleFields,
+  removableFields,
+  onRemoveField,
 }: MappingTableCardProps) {
+  const fieldMap = useMemo(
+    () => new Map(canonicalFields.map((field) => [field.key, field])),
+    [],
+  );
+  const removableSet = useMemo(() => new Set(removableFields), [removableFields]);
+
+  const visibleFieldConfigs = useMemo(
+    () =>
+      visibleFields
+        .map((fieldKey) => fieldMap.get(fieldKey))
+        .filter((field): field is (typeof canonicalFields)[number] => Boolean(field)),
+    [fieldMap, visibleFields],
+  );
+
   return (
     <Card className="space-y-4">
       <CardHeader className="gap-2">
@@ -37,13 +57,25 @@ export function MappingTableCard({
       </CardHeader>
       <CardContent className="space-y-3">
         <div className="grid gap-3">
-          {canonicalFields.map((field) => {
+          {visibleFieldConfigs.map((field) => {
             const fieldId = `${title.replace(/\s+/g, "-").toLowerCase()}-${field.key}`;
             return (
               <label key={field.key} className="grid gap-1 text-sm" htmlFor={fieldId}>
-                <span className="font-medium">
-                  {field.label}
-                  {field.required ? <span className="text-destructive"> *</span> : null}
+                <span className="flex items-center justify-between gap-2">
+                  <span className="font-medium">
+                    {field.label}
+                    {field.required ? <span className="text-destructive"> *</span> : null}
+                  </span>
+                  {removableSet.has(field.key) ? (
+                    <button
+                      type="button"
+                      className="rounded-full px-1 text-xs text-foreground/50 hover:text-destructive"
+                      aria-label={`Remove ${field.label}`}
+                      onClick={() => onRemoveField(field.key)}
+                    >
+                      ✕
+                    </button>
+                  ) : null}
                 </span>
                 <select
                   id={fieldId}

--- a/ui/partner-hub/lib/account-mapping/inference.ts
+++ b/ui/partner-hub/lib/account-mapping/inference.ts
@@ -9,6 +9,7 @@ const normalizeHeader = (header: string) =>
 const aliasMap: Record<string, string[]> = {
   account_name: ["account", "accountname", "company", "companyname", "customer", "customername"],
   owner_name: ["owner", "ownername", "accountowner", "accountrep", "salesrep", "ae"],
+  owner_email: ["owneremail", "owneremailaddress", "accountowneremail", "owner email"],
   manager_name: ["manager", "managername", "accountmanager", "teamlead"],
   pam_name: ["pam", "partneraccountmanager", "partner manager", "partnerowner"],
   status: ["status", "accountstatus", "lifecycle", "stage"],

--- a/ui/partner-hub/lib/account-mapping/schema.ts
+++ b/ui/partner-hub/lib/account-mapping/schema.ts
@@ -3,25 +3,31 @@ import { z } from "zod";
 export const canonicalFields = [
   {
     key: "account_name",
-    label: "Account name",
+    label: "Account Name",
     required: true,
     description: "Primary account or company name.",
   },
   {
     key: "owner_name",
-    label: "Owner name",
+    label: "Account Owner",
     required: false,
     description: "Account owner or salesperson assigned.",
   },
   {
+    key: "owner_email",
+    label: "Account Owner Email Address",
+    required: false,
+    description: "Email address for the account owner.",
+  },
+  {
     key: "manager_name",
-    label: "Manager name",
+    label: "Manager Name",
     required: false,
     description: "Manager or team lead for the account.",
   },
   {
     key: "pam_name",
-    label: "PAM name",
+    label: "PAM Name",
     required: false,
     description: "Partner account manager name.",
   },
@@ -33,7 +39,7 @@ export const canonicalFields = [
   },
   {
     key: "segment_type",
-    label: "Segment / Type",
+    label: "Segment",
     required: false,
     description: "Segment or account type.",
   },
@@ -86,9 +92,22 @@ export type CanonicalFieldKey = (typeof canonicalFields)[number]["key"];
 export type RawAccountMapping = Record<CanonicalFieldKey, string>;
 export type AccountMapping = Record<CanonicalFieldKey, string | null>;
 
+export const DEFAULT_VISIBLE_FIELD_KEYS: CanonicalFieldKey[] = [
+  "account_name",
+  "owner_name",
+  "owner_email",
+  "manager_name",
+  "pam_name",
+  "status",
+  "segment_type",
+  "organization",
+  "region",
+];
+
 export const accountMappingSchema = z.object({
   account_name: z.string().min(1, "Account name is required."),
   owner_name: z.string().nullable().optional(),
+  owner_email: z.string().nullable().optional(),
   manager_name: z.string().nullable().optional(),
   pam_name: z.string().nullable().optional(),
   status: z.string().nullable().optional(),


### PR DESCRIPTION
### Motivation

- Reduce visual noise in Step 3 by showing a curated default column set instead of all canonical fields.  
- Let users add additional columns on demand and ensure any added column appears in both Vendor and Partner mapping UIs.  
- Preserve existing mapping behavior and require no removal of default fields while keeping user-added columns removable.

### Description

- Introduce `DEFAULT_VISIBLE_FIELD_KEYS` and add an `owner_email` canonical field in `lib/account-mapping/schema.ts` to represent the requested default 9 columns (order preserved by the list).  
- Extend header inference to recognize owner email headers in `lib/account-mapping/inference.ts`.  
- Add `visibleColumns` state and Add Column UI in `components/account-mapping/AccountMappingTool.tsx`, including a top-right `Add Column` menu that lists currently hidden canonical fields; selecting a field adds it to `visibleColumns` and closes the menu.  
- Update `MappingTableCard` to accept `visibleFields`, `removableFields` and `onRemoveField`, render only visible fields (in order), show an “✕” remove control for user-added fields, and prevent removing default fields; removing a field clears the mapped values for that canonical key in both vendor and partner mappings to keep them in sync.

### Testing

- Attempted `npm run build` in `ui/partner-hub`, but build could not be executed in this environment because `next` is not available (`sh: 1: next: not found`).  
- Attempted `npm install` to run full build/test, but dependency install failed due to registry access (`403 Forbidden` fetching `@prisma/client`) so automated test suite could not be executed.  
- Static verification performed via code inspection and local TypeScript edits (no runtime regressions observed in the diff); integration/unit test runs could not be completed due to the environment limitations described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e4b83c13c8330814463374232d999)