### PR TITLE
Partner Hub: Add 'Select All' filters, simplify Add Column UX, and refresh theme

### DIFF
--- a/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
+++ b/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
@@ -756,11 +756,13 @@ export default function AccountMappingTool() {
                         <button
                           key={field.key}
                           type="button"
-                          className="flex w-full items-center justify-between px-4 py-2 text-left hover:bg-muted/60"
+                          className="group flex w-full items-center justify-between px-4 py-2 text-left transition hover:bg-muted/60 focus-visible:bg-muted/60"
                           onClick={() => handleAddColumn(field.key)}
                         >
                           <span>{field.label}</span>
-                          <span className="text-xs text-foreground/40">Add</span>
+                          <span className="text-base text-foreground/40 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+                            +
+                          </span>
                         </button>
                       ))
                     )}

--- a/ui/partner-hub/components/account-mapping/MergedDatasetSearchPanelSimple.tsx
+++ b/ui/partner-hub/components/account-mapping/MergedDatasetSearchPanelSimple.tsx
@@ -349,21 +349,28 @@ const MergedDatasetSearchPanelSimple = ({
     options: ComboboxOption[],
     placeholder: string,
     disabled = false,
-  ) => (
-    <div className="min-w-[180px] flex-1 space-y-2">
-      <label className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
-        {label}
-      </label>
-      <Combobox
-        value={value}
-        onChange={onChange}
-        options={options}
-        placeholder={placeholder}
-        disabled={disabled}
-        emptyLabel="No matches"
-      />
-    </div>
-  );
+  ) => {
+    const optionsWithSelectAll: ComboboxOption[] = [
+      { value: "", label: "Select All" },
+      ...options,
+    ];
+
+    return (
+      <div className="min-w-[180px] flex-1 space-y-2">
+        <label className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
+          {label}
+        </label>
+        <Combobox
+          value={value}
+          onChange={onChange}
+          options={optionsWithSelectAll}
+          placeholder={placeholder}
+          disabled={disabled}
+          emptyLabel="No matches"
+        />
+      </div>
+    );
+  };
 
   return (
     <Card className="space-y-6">

--- a/ui/partner-hub/components/account-mapping/constants.ts
+++ b/ui/partner-hub/components/account-mapping/constants.ts
@@ -9,7 +9,7 @@ export const REVIEW_ROW_HEIGHT = 168;
 export const REVIEW_LIST_HEIGHT = 560;
 
 export const INPUT_BASE_CLASSES =
-  "h-10 rounded-lg border border-border/70 bg-background px-3 text-sm text-foreground shadow-sm transition placeholder:text-foreground/40 focus-visible:outline-none focus-visible:border-primary/60 focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+  "h-10 rounded-lg border border-border/70 bg-card px-3 text-sm text-foreground shadow-sm transition placeholder:text-foreground/40 focus-visible:outline-none focus-visible:border-primary/60 focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
 export const SIMPLE_SEARCH_COLUMNS = [
   "vendor_account_name",

--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -33,7 +33,7 @@ const fmt2 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 });
 const formatRackUnits = (value: number | null | undefined) => (value == null ? "—" : fmt0.format(value));
 const DEFAULT_GRID_KGCO2E_PER_KWH = 0.4;
 const INPUT_BASE_CLASSES =
-  "h-10 w-full rounded-lg border border-border/70 bg-background px-3 text-sm text-foreground shadow-sm transition placeholder:text-foreground/40 focus-visible:outline-none focus-visible:border-primary/60 focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+  "h-10 w-full rounded-lg border border-border/70 bg-card px-3 text-sm text-foreground shadow-sm transition placeholder:text-foreground/40 focus-visible:outline-none focus-visible:border-primary/60 focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 const LABEL_CLASSES = "text-xs font-semibold uppercase tracking-wide text-foreground/60";
 
 type EnergyMeta = {

--- a/ui/partner-hub/components/ui/card.tsx
+++ b/ui/partner-hub/components/ui/card.tsx
@@ -14,7 +14,7 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>(
     <div
       ref={ref}
       className={clsx(
-        "rounded-xl border border-border/60 bg-white/80 p-6 shadow-sm backdrop-blur transition-shadow duration-200 dark:bg-slate-900/80",
+        "rounded-xl border border-border/60 bg-card p-6 shadow-sm transition-shadow duration-200",
         className,
       )}
       {...props}

--- a/ui/partner-hub/components/ui/combobox.tsx
+++ b/ui/partner-hub/components/ui/combobox.tsx
@@ -10,7 +10,7 @@ import {
 } from "./comboboxUtils";
 
 const INPUT_BASE_CLASSES =
-  "h-10 rounded-lg border border-border/70 bg-background px-3 text-sm text-foreground shadow-sm transition placeholder:text-foreground/40 focus-visible:outline-none focus-visible:border-primary/60 focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+  "h-10 rounded-lg border border-border/70 bg-card px-3 text-sm text-foreground shadow-sm transition placeholder:text-foreground/40 focus-visible:outline-none focus-visible:border-primary/60 focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
 type ComboboxProps = {
   value: string;

--- a/ui/partner-hub/components/ui/multiCombobox.tsx
+++ b/ui/partner-hub/components/ui/multiCombobox.tsx
@@ -10,7 +10,7 @@ import {
 } from "./comboboxUtils";
 
 const INPUT_BASE_CLASSES =
-  "h-10 rounded-lg border border-border/70 bg-background px-3 text-sm text-foreground shadow-sm transition placeholder:text-foreground/40 focus-visible:outline-none focus-visible:border-primary/60 focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+  "h-10 rounded-lg border border-border/70 bg-card px-3 text-sm text-foreground shadow-sm transition placeholder:text-foreground/40 focus-visible:outline-none focus-visible:border-primary/60 focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 const DEFAULT_MAX_VISIBLE_OPTIONS = 300;
 
 type MultiComboboxProps = {

--- a/ui/partner-hub/styles/globals.css
+++ b/ui/partner-hub/styles/globals.css
@@ -3,26 +3,28 @@
 @tailwind utilities;
 
 :root {
-  --brand-primary: #ef4a00;
-  --brand-secondary: #003b5c;
-  --brand-accent: #00aeef;
-  --surface-base: #ffffff;
-  --surface-muted: #f1f5f9;
+  --brand-primary: #2563eb;
+  --brand-secondary: #1e293b;
+  --brand-accent: #0ea5e9;
+  --surface-base: #f5f7fb;
+  --surface-muted: #eef2f7;
   --surface-elevated: #ffffff;
+  --surface-card: #ffffff;
   --foreground: #0f172a;
-  --border-color: #cbd5e1;
+  --border-color: #d4dbe5;
   --background: var(--surface-base);
 }
 
 .dark {
-  --brand-primary: #ff7a00;
-  --brand-secondary: #4f94b8;
-  --brand-accent: #00aeef;
+  --brand-primary: #60a5fa;
+  --brand-secondary: #e2e8f0;
+  --brand-accent: #38bdf8;
   --surface-base: #0b1120;
-  --surface-muted: #1e293b;
-  --surface-elevated: #13203a;
+  --surface-muted: #182235;
+  --surface-elevated: #121b2d;
+  --surface-card: #0f172a;
   --foreground: #e2e8f0;
-  --border-color: #3b5675;
+  --border-color: #2a3953;
   --background: var(--surface-base);
 }
 

--- a/ui/partner-hub/tailwind.config.ts
+++ b/ui/partner-hub/tailwind.config.ts
@@ -6,6 +6,7 @@ const config: Config = {
     extend: {
       colors: {
         background: "var(--background)",
+        card: "var(--surface-card)",
         foreground: "var(--foreground)",
         primary: "var(--brand-primary)",
         secondary: "var(--brand-secondary)",


### PR DESCRIPTION
### Motivation
- Make the overlap-search filtering clearer and faster by providing an explicit “Select All” entry that resets each dropdown to the existing “no filter” state.
- Improve the Step 3 Add Column interaction so each row is the clickable target, removing the small “Add” buttons and improving hover/focus affordances.
- Modernize Partner Hub visuals with a subtle gray app background, white cards/inputs, updated primary accent, and consistent spacing/borders via theme tokens.

### Description
- Prepend a `Select All` option to filter comboboxes in the account-mapping search UI so selecting it clears the filter by mapping to the existing empty value; change implemented in `components/account-mapping/MergedDatasetSearchPanelSimple.tsx` by adding `{ value: "", label: "Select All" }` to options passed to `Combobox`.
- Replace the explicit small “Add” buttons in the Add Column popover with full-row clickable buttons and a subtle hover/plus indicator; updated the add-column menu rendering and styles in `components/account-mapping/AccountMappingTool.tsx` to make the entire row clickable and show a `+` on hover/focus.
- Refresh global theme tokens and Tailwind mapping by updating `styles/globals.css` with new CSS variables (gray background, `--surface-card`, new primary/accent colors) and adding a `card` color token in `tailwind.config.ts`.
- Apply the new card/input surface token across the UI by updating `components/ui/card.tsx` to use `bg-card` and switching `INPUT_BASE_CLASSES` usages to `bg-card` in `components/ui/combobox.tsx`, `components/ui/multiCombobox.tsx`, `components/account-mapping/constants.ts`, and `components/energy/energy-tool.tsx` to ensure consistent input styling.
- Files changed: `ui/partner-hub/components/account-mapping/MergedDatasetSearchPanelSimple.tsx`, `ui/partner-hub/components/account-mapping/AccountMappingTool.tsx`, `ui/partner-hub/components/account-mapping/constants.ts`, `ui/partner-hub/components/energy/energy-tool.tsx`, `ui/partner-hub/components/ui/card.tsx`, `ui/partner-hub/components/ui/combobox.tsx`, `ui/partner-hub/components/ui/multiCombobox.tsx`, `ui/partner-hub/styles/globals.css`, and `ui/partner-hub/tailwind.config.ts`.

### Testing
- Ran `npm run build` in `ui/partner-hub`, which failed in this environment with `next: not found`, so a full build/test could not be completed here (CI/build environment should be used to verify `next` is available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e83cd8a20833080d1f33a6291ff7b)