### PR TITLE
Make Partner Hub primary buttons black with white text via global tokens

### DIFF
--- a/ui/partner-hub/app/page.tsx
+++ b/ui/partner-hub/app/page.tsx
@@ -121,7 +121,7 @@ export default function HomePage() {
             <div className="flex flex-wrap items-center gap-3">
               <Link
                 href="/resume/James_Siejk_Resume.pdf"
-                className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-semibold text-foreground shadow-sm transition hover:bg-primary/90"
+                className="inline-flex h-10 items-center gap-2 rounded-md bg-button-primary px-4 text-sm font-semibold text-button-primary-foreground shadow-sm transition hover:bg-button-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               >
                 <Download className="h-4 w-4" aria-hidden />
                 Download Resume

--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -959,9 +959,9 @@ export function EnergyTool() {
   const exportDisabled = loading || exportLoading != null || !fb || !selectedCandidate;
   const toggleButtonClass = (isActive: boolean) =>
     [
-      "inline-flex h-10 items-center justify-center rounded-lg border px-4 text-sm font-semibold transition-colors",
+      "inline-flex h-10 items-center justify-center rounded-lg border px-4 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
       isActive
-        ? "border-primary bg-primary text-foreground hover:bg-primary/90 ring-1 ring-primary/30"
+        ? "border-button-primary bg-button-primary text-button-primary-foreground hover:bg-button-primary/90 ring-1 ring-button-primary/30"
         : "border-border bg-background text-foreground hover:bg-muted/50",
     ].join(" ");
 
@@ -1193,7 +1193,7 @@ export function EnergyTool() {
               {mode === "auto" ? (
                 <button
                   type="button"
-                  className="inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-foreground transition hover:opacity-90 disabled:opacity-50"
+                  className="inline-flex h-10 items-center justify-center rounded-lg bg-button-primary px-4 text-sm font-semibold text-button-primary-foreground transition hover:bg-button-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:bg-muted disabled:text-foreground/50"
                   onClick={runModel}
                   disabled={loading || pureRows.length === 0 || netappRows.length === 0}
                 >
@@ -1202,7 +1202,7 @@ export function EnergyTool() {
               ) : (
                 <button
                   type="button"
-                  className="inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-foreground transition hover:opacity-90 disabled:opacity-50"
+                  className="inline-flex h-10 items-center justify-center rounded-lg bg-button-primary px-4 text-sm font-semibold text-button-primary-foreground transition hover:bg-button-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:bg-muted disabled:text-foreground/50"
                   onClick={runManual}
                   disabled={manualApplyDisabled}
                 >

--- a/ui/partner-hub/components/ui/button.tsx
+++ b/ui/partner-hub/components/ui/button.tsx
@@ -2,10 +2,11 @@ import * as React from "react";
 import { clsx } from "clsx";
 
 const baseStyles =
-  "inline-flex items-center justify-center gap-2 rounded-md font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50";
+  "inline-flex items-center justify-center gap-2 rounded-md font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:bg-muted disabled:text-foreground/50 disabled:shadow-none";
 
 const variants: Record<string, string> = {
-  primary: "bg-primary text-foreground shadow-sm hover:bg-primary/90",
+  primary:
+    "bg-button-primary text-button-primary-foreground shadow-sm hover:bg-button-primary/90",
   secondary: "border border-border bg-muted/80 text-foreground hover:bg-muted",
   ghost: "bg-transparent text-foreground/80 hover:bg-muted/60",
 };

--- a/ui/partner-hub/styles/globals.css
+++ b/ui/partner-hub/styles/globals.css
@@ -4,6 +4,8 @@
 
 :root {
   --brand-primary: #2563eb;
+  --button-primary: #0b0b0b;
+  --button-primary-foreground: #ffffff;
   --brand-secondary: #1e293b;
   --brand-accent: #0ea5e9;
   --surface-base: #f5f7fb;
@@ -17,6 +19,8 @@
 
 .dark {
   --brand-primary: #60a5fa;
+  --button-primary: #0b0b0b;
+  --button-primary-foreground: #ffffff;
   --brand-secondary: #e2e8f0;
   --brand-accent: #38bdf8;
   --surface-base: #0b1120;

--- a/ui/partner-hub/tailwind.config.ts
+++ b/ui/partner-hub/tailwind.config.ts
@@ -9,6 +9,8 @@ const config: Config = {
         card: "var(--surface-card)",
         foreground: "var(--foreground)",
         primary: "var(--brand-primary)",
+        "button-primary": "var(--button-primary)",
+        "button-primary-foreground": "var(--button-primary-foreground)",
         secondary: "var(--brand-secondary)",
         accent: "var(--brand-accent)",
         muted: "var(--surface-muted)",


### PR DESCRIPTION
### Motivation

- Standardize primary button appearance across Partner Hub to a black background with white text and ensure consistent hover, focus, and disabled states without changing component behavior.
- Apply the change globally using theme tokens and Tailwind tokens so individual button consumers inherit the new styling rather than editing every consumer.

### Description

- Added button-specific CSS variables `--button-primary` and `--button-primary-foreground` to `ui/partner-hub/styles/globals.css` and preserved them in dark mode so buttons remain consistent across themes. 
- Mapped those variables into Tailwind as `button-primary` and `button-primary-foreground` in `ui/partner-hub/tailwind.config.ts` so utility classes can reference the tokens. 
- Updated the shared `Button` component at `ui/partner-hub/components/ui/button.tsx` to use the new tokens for the `primary` variant, and improved focus and disabled styles (visible focus ring, muted disabled background/text, removed disabled shadow). 
- Aligned custom primary button usages that bypass the `Button` component to the new tokens and focus styles in `ui/partner-hub/app/page.tsx` and `ui/partner-hub/components/energy/energy-tool.tsx` so hero CTAs and tool actions match the global primary styling. 
- Left secondary/ghost variants unchanged so outline/secondary behaviors stay consistent.

### Testing

- Attempted to run the production build with `npm run build` in `ui/partner-hub`, but it failed because project dependencies were not installed (`next` not found). 
- Attempted `npm install` to install dependencies, but it failed with a registry `403` while fetching `@prisma/client`, preventing a complete build and further automated checks. 
- Code-level checks: verified token usage and updated occurrences via project search/grep to ensure primary usage was switched to the new `button-primary` tokens; these searches succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e86691cdc8330bab75abe7a3912a0)