### PR TITLE
Add `confirm` Button variant and update Account Mapping to use “Confirm Match”

### DIFF
--- a/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
+++ b/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
@@ -995,13 +995,14 @@ export default function AccountMappingTool() {
                             <Button
                               size="sm"
                               className="w-fit min-w-[112px] whitespace-nowrap"
+                              variant="confirm"
                               onClick={(event) => {
                                 event.stopPropagation();
                                 setSelectedRowId(row.id);
                                 handleDecision(row, "confirmed");
                               }}
                             >
-                              Confirm match
+                              Confirm Match
                             </Button>
                             <Button
                               size="sm"

--- a/ui/partner-hub/components/ui/button.tsx
+++ b/ui/partner-hub/components/ui/button.tsx
@@ -9,6 +9,8 @@ const variants: Record<string, string> = {
     "bg-button-primary text-button-primary-foreground shadow-sm hover:bg-button-primary/90",
   secondary: "border border-border bg-muted/80 text-foreground hover:bg-muted",
   ghost: "bg-transparent text-foreground/80 hover:bg-muted/60",
+  confirm:
+    "bg-orange-200 text-orange-950 shadow-sm hover:bg-orange-300 focus-visible:ring-orange-300 disabled:bg-orange-200/60 disabled:text-orange-950/60",
 };
 
 const sizes: Record<string, string> = {


### PR DESCRIPTION
### Motivation
- Standardize the Account Mapping confirm action by updating the label to `Confirm Match` and applying a shared light-orange button style so the action is consistent and reusable across the Partner Hub UI.

### Description
- Add a reusable `confirm` button variant in `ui/partner-hub/components/ui/button.tsx` with a light orange background and matching hover/focus/disabled states.
- Update the Account Mapping review button in `ui/partner-hub/components/account-mapping/AccountMappingTool.tsx` to use `variant="confirm"` and change the label to `Confirm Match`.

### Testing
- Attempted `npm run build` in `ui/partner-hub`, but the build could not be completed in this environment (`next: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e89a282bc8330a9abd654f9d61ed1)