### PR TITLE
Align office schedule content sections with times column

### DIFF
--- a/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
+++ b/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
@@ -1382,6 +1382,7 @@ export function OfficeScheduleClient({
   }
 
   const locked = !unlocked;
+  const contentTopOffset = "pt-6";
 
   return (
     <main className="mx-auto max-w-6xl p-6">
@@ -1436,7 +1437,7 @@ export function OfficeScheduleClient({
         <div className={locked ? "pointer-events-none select-none opacity-40 grayscale" : ""}>
           <div className="grid grid-cols-1 md:grid-cols-[360px_1fr]">
             {/* Left panel */}
-            <section className="p-6">
+            <section className={`p-6 ${contentTopOffset}`}>
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <h1 className="text-2xl font-semibold tracking-tight">Schedule a time</h1>
                 <button
@@ -1558,7 +1559,7 @@ export function OfficeScheduleClient({
               </div>
 
               <div className="mt-4 grid grid-cols-1 gap-6 lg:grid-cols-[1fr_260px] lg:items-start">
-                <div>
+                <div className={contentTopOffset}>
                   <div className="grid grid-cols-7 gap-2 text-[11px] font-semibold uppercase tracking-wide text-foreground/60">
                     {["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"].map((d) => (
                       <div key={d} className="text-center">


### PR DESCRIPTION
### Motivation
- Adjust the vertical alignment so the left "Duration/Office" panel and the calendar days grid start at the same level as the times column without changing the top header row.

### Description
- Add a shared spacing constant `const contentTopOffset = "pt-6"` and apply it to the left panel section wrapper (`<section className={`p-6 ${contentTopOffset}}`>`) and the calendar column wrapper (`<div className={contentTopOffset}>`) in `ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx` to keep spacing consistent.

### Testing
- Ran `npm run build` in `ui/partner-hub`, which failed with `sh: 1: next: not found` (build did not complete).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e9309e1688330ba2ee9419271fa82)