### PR TITLE
Include Account Owner Email in merged search results and rename schema label

### DIFF
--- a/ui/partner-hub/components/account-mapping/constants.ts
+++ b/ui/partner-hub/components/account-mapping/constants.ts
@@ -16,6 +16,8 @@ export const SIMPLE_SEARCH_COLUMNS = [
   "partner_account_name",
   "vendor_owner",
   "partner_owner",
+  "vendor_owner_email",
+  "partner_owner_email",
   "vendor_status",
   "partner_status",
   "vendor_region",

--- a/ui/partner-hub/components/account-mapping/hooks/useAccountMappingModel.ts
+++ b/ui/partner-hub/components/account-mapping/hooks/useAccountMappingModel.ts
@@ -62,6 +62,7 @@ const buildAccountRecords = (
       rawName,
       normalizedName: normalized,
       ownerName: mapping.owner_name ? row[mapping.owner_name] ?? "" : "",
+      ownerEmail: mapping.owner_email ? row[mapping.owner_email] ?? "" : "",
       managerName: mapping.manager_name ? row[mapping.manager_name] ?? "" : "",
       pamName: mapping.pam_name ? row[mapping.pam_name] ?? "" : "",
       status: mapping.status ? row[mapping.status] ?? "" : "",

--- a/ui/partner-hub/components/account-mapping/hooks/useAccountMappingViewModel.ts
+++ b/ui/partner-hub/components/account-mapping/hooks/useAccountMappingViewModel.ts
@@ -188,6 +188,8 @@ export const useAccountMappingViewModel = ({
           partner_account_name: row.partner?.rawName ?? "",
           vendor_owner: row.vendor.ownerName ?? "",
           partner_owner: row.partner?.ownerName ?? "",
+          vendor_owner_email: row.vendor.ownerEmail ?? "",
+          partner_owner_email: row.partner?.ownerEmail ?? "",
           vendor_status: row.vendor.status ?? "",
           partner_status: row.partner?.status ?? "",
           vendor_crm_account_id: row.vendor.crmAccountId ?? "",

--- a/ui/partner-hub/components/account-mapping/types.ts
+++ b/ui/partner-hub/components/account-mapping/types.ts
@@ -25,6 +25,7 @@ export type AccountRecord = {
   rawName: string;
   normalizedName: string;
   ownerName?: string;
+  ownerEmail?: string;
   managerName?: string;
   pamName?: string;
   status?: string;

--- a/ui/partner-hub/lib/account-mapping/schema.ts
+++ b/ui/partner-hub/lib/account-mapping/schema.ts
@@ -15,7 +15,7 @@ export const canonicalFields = [
   },
   {
     key: "owner_email",
-    label: "Account Owner Email Address",
+    label: "Account Owner Email",
     required: false,
     description: "Email address for the account owner.",
   },


### PR DESCRIPTION
### Motivation
- Search results for the merged dataset should surface mapped owner email for both vendor and partner when Step 3 maps that field. 
- The Step 3 canonical field label should be simplified from `Account Owner Email Address` to `Account Owner Email`.

### Description
- Add `ownerEmail?: string` to `AccountRecord` in `ui/partner-hub/components/account-mapping/types.ts` to carry owner email values.
- Populate `ownerEmail` from the normalized mapping in `buildAccountRecords(...)` inside `ui/partner-hub/components/account-mapping/hooks/useAccountMappingModel.ts` using `mapping.owner_email`.
- Include `vendor_owner_email` and `partner_owner_email` in the run dataset produced in `ui/partner-hub/components/account-mapping/hooks/useAccountMappingViewModel.ts` so the “Current run” merged search rows include emails.
- Expose the new email columns by adding `vendor_owner_email` and `partner_owner_email` to `SIMPLE_SEARCH_COLUMNS` in `ui/partner-hub/components/account-mapping/constants.ts`, while keeping them out of `SIMPLE_SEARCH_REQUIRED_UPLOAD_COLUMNS` so they remain optional.
- Rename the canonical field label for `owner_email` to `Account Owner Email` in `ui/partner-hub/lib/account-mapping/schema.ts` and keep the data key as `owner_email`.

### Testing
- Ran `npm run build` in `ui/partner-hub`, which failed in this environment with `next: not found` so a full production build could not be completed. 
- Ran `npm test` in `ui/partner-hub`, which reported missing dependencies/type declarations (errors for packages like `zod`, `pdf-lib`, and missing Node types), so the TypeScript test run could not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eb37e9f2c83308df586c349b48229)