### PR TITLE
Update account mapping step logic and add Help modal

### DIFF
--- a/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
+++ b/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
@@ -286,7 +286,17 @@ export default function AccountMappingTool() {
   const hasMappings = vendorValidation.success && partnerValidation.success;
   const hasMatches = matchResults.length > 0;
 
-  const currentStep = hasMatches ? 5 : hasMappings ? 2 : hasUploads ? 1 : 0;
+  const currentStep = mergedExportRows.length
+    ? 5
+    : mergedSearchHeaders.length
+      ? 4
+      : hasMatches
+        ? 3
+        : hasMappings
+          ? 2
+          : hasUploads
+            ? 1
+            : 0;
 
   const tourSteps = useMemo<TourStep[]>(
     () => [

--- a/ui/partner-hub/components/account-mapping/ui/AccountMappingHeader.tsx
+++ b/ui/partner-hub/components/account-mapping/ui/AccountMappingHeader.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
+
 import { Button } from "@/components/ui/button";
 
 type AccountMappingHeaderProps = {
@@ -18,53 +20,111 @@ export const AccountMappingHeader = ({
   isTourActive,
   onLoadDemo,
   onStartTour,
-}: AccountMappingHeaderProps) => (
-  <header className="space-y-4">
-    <div className="flex flex-wrap items-start justify-between gap-4">
-      <div className="space-y-2">
-        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Account Mapping</h1>
-        <p className="max-w-2xl text-base text-foreground/70">
-          Match partner + vendor accounts, reduce review queues, and generate target lists in minutes.
-        </p>
-      </div>
-      <div className="flex flex-wrap items-center gap-2">
-        <Button
-          onClick={onLoadDemo}
-          disabled={isDemoLoading}
-          aria-label="Load demo dataset"
-          aria-busy={isDemoLoading}
-        >
-          {isDemoLoading ? "Loading demo…" : "Load demo dataset"}
-        </Button>
-        <Button
-          variant="secondary"
-          onClick={onStartTour}
-          aria-label="Start walkthrough"
-          disabled={isTourActive}
-        >
-          Walkthrough
-        </Button>
-      </div>
-    </div>
-    {demoError && (
-      <p className="text-sm text-destructive" role="alert">
-        {demoError}
-      </p>
-    )}
-    <div className="flex flex-wrap items-center gap-2 text-xs font-medium">
-      {["Upload", "Map", "Match", "Review", "Search", "Export"].map((step, index) => (
-        <div
-          key={step}
-          data-tour={step.toLowerCase()}
-          className={`rounded-full px-3 py-1 shadow-sm ${
-            index <= currentStep
-              ? "bg-confirm text-confirm-foreground border border-confirm-strong"
-              : "bg-confirm-soft text-confirm-foreground/70 border border-confirm"
-          }`}
-        >
-          {step}
+}: AccountMappingHeaderProps) => {
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
+
+  const steps = useMemo(() => ["Upload", "Map", "Match", "Review", "Search", "Export"], []);
+
+  useEffect(() => {
+    if (!isHelpOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsHelpOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isHelpOpen]);
+
+  return (
+    <header className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Account Mapping</h1>
+          <p className="max-w-2xl text-base text-foreground/70">
+            Match partner + vendor accounts, reduce review queues, and generate target lists in minutes.
+          </p>
         </div>
-      ))}
-    </div>
-  </header>
-);
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            onClick={onLoadDemo}
+            disabled={isDemoLoading}
+            aria-label="Load demo dataset"
+            aria-busy={isDemoLoading}
+          >
+            {isDemoLoading ? "Loading demo…" : "Load demo dataset"}
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={onStartTour}
+            aria-label="Start walkthrough"
+            disabled={isTourActive}
+          >
+            Walkthrough
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => setIsHelpOpen(true)}
+            aria-label="Open account mapping help"
+          >
+            Help
+          </Button>
+        </div>
+      </div>
+      {demoError && (
+        <p className="text-sm text-destructive" role="alert">
+          {demoError}
+        </p>
+      )}
+      <div className="flex flex-wrap items-center gap-2 text-xs font-medium">
+        {steps.map((step, index) => (
+          <div
+            key={step}
+            data-tour={step.toLowerCase()}
+            className={`rounded-full px-3 py-1 shadow-sm ${
+              index <= currentStep
+                ? "bg-confirm text-confirm-foreground border border-confirm-strong"
+                : "bg-confirm-soft text-confirm-foreground/70 border border-confirm"
+            }`}
+          >
+            {step}
+          </div>
+        ))}
+      </div>
+      {isHelpOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-10">
+          <div
+            className="w-full max-w-lg rounded-xl border border-foreground/10 bg-background p-6 shadow-xl"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Account mapping walkthrough"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-xl font-semibold">Account mapping flow</h2>
+                <p className="mt-1 text-sm text-foreground/70">
+                  Follow the end-to-end flow from data upload to export.
+                </p>
+              </div>
+              <Button variant="ghost" size="sm" onClick={() => setIsHelpOpen(false)}>
+                Close
+              </Button>
+            </div>
+            <div className="mt-4 flex flex-wrap items-center gap-2 text-sm font-medium">
+              {steps.map((step, index) => (
+                <div key={step} className="flex items-center gap-2 text-foreground/80">
+                  <span className="rounded-full border border-border px-3 py-1">{step}</span>
+                  {index < steps.length - 1 && <span aria-hidden="true">→</span>}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </header>
+  );
+};


### PR DESCRIPTION
### Motivation
- Fix the progress step mapping so the UI reflects the correct 0–5 flow (Upload → Map → Match → Review → Search → Export). 
- Provide an inline Help modal in the header to explain the end-to-end account mapping flow to users.

### Description
- Change `currentStep` calculation in `AccountMappingTool.tsx` to compute indices as `5` when `mergedExportRows.length` is present, `4` when `mergedSearchHeaders.length` is present, `3` for `hasMatches`, `2` for `hasMappings`, `1` for `hasUploads`, and `0` otherwise. 
- Add a `Help` button and modal to `AccountMappingHeader.tsx` that shows the flow `Upload → Map → Match → Review → Search → Export` and reuses a `steps` array for the header badges. 
- Introduce local state and hooks (`useState`, `useEffect`, `useMemo`) in `AccountMappingHeader.tsx` to manage modal visibility and keyboard (`Escape`) closing, and update header badge rendering to use the `steps` array.

### Testing
- Attempted to run the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` but the run failed because the `next` binary was not available in this environment. 
- No automated test suite was executed in this environment after the change due to the missing `next` runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ec70990288330a3931fc3564ee335)