### PR TITLE
Fix account mapping step completion logic

### DIFF
--- a/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
+++ b/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
@@ -282,21 +282,20 @@ export default function AccountMappingTool() {
     [manualLinkRowId, reviewRows],
   );
 
-  const hasUploads = Boolean(vendorState.result && partnerState.result);
+  const hasUploads = vendorRecords.length > 0 || partnerRecords.length > 0;
   const hasMappings = vendorValidation.success && partnerValidation.success;
-  const hasMatches = matchResults.length > 0;
+  const hasMatches = reviewRows.length > 0;
 
-  const currentStep = mergedExportRows.length
-    ? 5
-    : mergedSearchHeaders.length
-      ? 4
-      : hasMatches
-        ? 3
-        : hasMappings
-          ? 2
-          : hasUploads
-            ? 1
-            : 0;
+  let currentStep = -1;
+  if (hasUploads) {
+    currentStep = 0;
+  }
+  if (hasMappings) {
+    currentStep = 1;
+  }
+  if (hasMatches) {
+    currentStep = 2;
+  }
 
   const tourSteps = useMemo<TourStep[]>(
     () => [


### PR DESCRIPTION
### Motivation
- Correct off-by-one step completion so steps are only marked complete when the corresponding signals are present, matching the 6-step flow (Upload(0) → Map(1) → Match(2) → Review(3) → Search(4) → Export(5)).
- Avoid automatically marking Review/Search/Export complete without explicit signals and keep existing UI/actions intact.

### Description
- Change `hasUploads` to derive from `vendorRecords.length > 0 || partnerRecords.length > 0` instead of `vendorState.result && partnerState.result`.
- Change `hasMatches` to derive from `reviewRows.length > 0` instead of `matchResults.length > 0`.
- Replace the nested ternary that computed `currentStep` with an incremental computation that starts `let currentStep = -1;` and sets it to `0`, `1`, or `2` based on `hasUploads`, `hasMappings`, and `hasMatches` respectively.
- Kept all existing UI, tour steps, and actions unchanged; only step completion logic was modified in `AccountMappingTool.tsx`.

### Testing
- Ran `npm run build` in `ui/partner-hub` which failed with `sh: 1: next: not found` so a full build could not be completed in this environment.
- No automated unit tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ec8e61f7c8330a2c1bca3aca3db53)