### PR TITLE
Fix match step completion detection in AccountMappingTool

### DIFF
--- a/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
+++ b/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
@@ -284,7 +284,10 @@ export default function AccountMappingTool() {
 
   const hasUploads = vendorRecords.length > 0 || partnerRecords.length > 0;
   const hasMappings = vendorValidation.success && partnerValidation.success;
-  const hasMatches = reviewRows.length > 0;
+  const hasMatches =
+    matchResults.length > 0 ||
+    reviewRows.length > 0 ||
+    unmatchedRows.length > 0;
 
   let currentStep = -1;
   if (hasUploads) {


### PR DESCRIPTION
### Motivation
- Ensure the Match step is marked complete when any matching output exists (auto-matches, review rows, or unmatched rows) so step progress reflects completed match runs.

### Description
- Replace `const hasMatches = reviewRows.length > 0;` with `const hasMatches = matchResults.length > 0 || reviewRows.length > 0 || unmatchedRows.length > 0;` in `ui/partner-hub/components/account-mapping/AccountMappingTool.tsx`.

### Testing
- Ran `npm run build`, which failed because `package.json` is missing at the repository root so the build could not be completed; no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ec9febe448330b5b73dc728e03e39)