### PR TITLE
Fix match completion detection

### DIFF
--- a/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
+++ b/ui/partner-hub/components/account-mapping/AccountMappingTool.tsx
@@ -284,10 +284,7 @@ export default function AccountMappingTool() {
 
   const hasUploads = vendorRecords.length > 0 || partnerRecords.length > 0;
   const hasMappings = vendorValidation.success && partnerValidation.success;
-  const hasMatches =
-    matchResults.length > 0 ||
-    reviewRows.length > 0 ||
-    unmatchedRows.length > 0;
+  const hasMatches = matchResults.length > 0 || reviewRows.length > 0;
 
   let currentStep = -1;
   if (hasUploads) {


### PR DESCRIPTION
### Motivation
- Update `hasMatches` logic to consider only `matchResults` and `reviewRows` so the match step is marked complete for auto-matches and partial/ambiguous matches without relying on `unmatchedRows`.

### Description
- Change `hasMatches` in `ui/partner-hub/components/account-mapping/AccountMappingTool.tsx` from `matchResults.length > 0 || reviewRows.length > 0 || unmatchedRows.length > 0` to `matchResults.length > 0 || reviewRows.length > 0`.

### Testing
- Ran `npm run build` which failed due to a missing `/workspace/accountlist/package.json`, so the build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eccac5358833080a767574211e70e)