### PR TITLE
Fix csv parse worker bundling for ngrok

### DIFF
--- a/ui/partner-hub/components/account-mapping/hooks/useCsvParseWorkers.ts
+++ b/ui/partner-hub/components/account-mapping/hooks/useCsvParseWorkers.ts
@@ -7,6 +7,8 @@ import {
   type SetStateAction,
 } from "react";
 
+import CsvParseWorker from "@/lib/account-mapping/workers/csvParse.worker.ts";
+
 import { DEFAULT_PROGRESS_STEP } from "../constants";
 import type { CsvParseResult, CsvParseState } from "../types";
 
@@ -28,10 +30,7 @@ type CsvWorkerOptions = {
   setRunStats: Dispatch<SetStateAction<RunStats>>;
 };
 
-const buildWorker = () =>
-  new Worker(new URL("../../../lib/account-mapping/workers/csvParse.worker.ts", import.meta.url), {
-    type: "module",
-  });
+const buildWorker = () => new CsvParseWorker();
 
 export const useCsvParseWorkers = ({ setRunStats }: CsvWorkerOptions) => {
   const vendorWorkerRef = useRef<Worker | null>(null);

--- a/ui/partner-hub/next.config.mjs
+++ b/ui/partner-hub/next.config.mjs
@@ -6,6 +6,22 @@ const nextConfig = {
   basePath,
   images: { unoptimized: true },
   trailingSlash: false,
+  webpack: (config) => {
+    config.module.rules.push({
+      test: /\.worker\.ts$/,
+      use: [
+        {
+          loader: "worker-loader",
+          options: {
+            filename: "static/chunks/[name].[contenthash].worker.js",
+            esModule: true,
+          },
+        },
+      ],
+    });
+
+    return config;
+  },
   env: {
     NEXT_PUBLIC_BASE_PATH: basePath,
   },

--- a/ui/partner-hub/package.json
+++ b/ui/partner-hub/package.json
@@ -39,7 +39,8 @@
         "postcss": "^8.4.31",
         "prisma": "^6.19.2",
         "tailwindcss": "^3.4.0",
-        "typescript": "^5.3.0"
+        "typescript": "^5.3.0",
+        "worker-loader": "^3.0.8"
     },
     "overrides": {
         "glob": "^10.4.6"

--- a/ui/partner-hub/types/worker-loader.d.ts
+++ b/ui/partner-hub/types/worker-loader.d.ts
@@ -1,0 +1,7 @@
+declare module "*.worker.ts" {
+  class WebpackWorker extends Worker {
+    constructor();
+  }
+
+  export default WebpackWorker;
+}


### PR DESCRIPTION
### Motivation
- The CSV parser worker was created via a constructed `URL` which breaks when the app is served through ngrok, causing `Failed to construct 'URL': Invalid URL` when loading the demo dataset.
- The worker should be provided by the bundler so worker assets are emitted correctly for both dev and prod origins without runtime URL construction.

### Description
- Added `worker-loader` as a dev dependency in `ui/partner-hub/package.json` to enable bundling of `*.worker.ts` modules via webpack.
- Wired a webpack rule into `ui/partner-hub/next.config.mjs` to load `/.worker.ts$/` files with `worker-loader` and emit worker assets with a stable filename pattern.
- Replaced manual `new Worker(new URL(...))` construction with a bundler-imported worker in `ui/partner-hub/components/account-mapping/hooks/useCsvParseWorkers.ts` by importing `CsvParseWorker` and using `const buildWorker = () => new CsvParseWorker();`.
- Added TypeScript module declarations in `ui/partner-hub/types/worker-loader.d.ts` so `*.worker.ts` imports type-check correctly.

### Testing
- Ran `npm install -D worker-loader` in this environment which failed with a `403` from the npm registry, so the package was added to `package.json` but not actually installed here.
- Ran `npm run build` which failed in this environment with `sh: 1: next: not found`, so a full build could not be completed here.
- No automated build/test succeeded in this sandbox; changes were validated by static edits and local type declaration addition only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ee5ba19b48330936aaaa2d458ab62)