### PR TITLE
Fix worker-loader config for TypeScript workers (Next 14)

### DIFF
--- a/ui/partner-hub/next.config.mjs
+++ b/ui/partner-hub/next.config.mjs
@@ -9,12 +9,19 @@ const nextConfig = {
   webpack: (config) => {
     config.module.rules.push({
       test: /\.worker\.ts$/,
+      issuer: { and: [/\.[jt]sx?$/] },
       use: [
         {
           loader: "worker-loader",
           options: {
             filename: "static/chunks/[name].[contenthash].worker.js",
-            esModule: true,
+            esModule: false,
+          },
+        },
+        {
+          loader: "babel-loader",
+          options: {
+            presets: ["next/babel"],
           },
         },
       ],


### PR DESCRIPTION
### Motivation
- Worker files with TypeScript were not being reliably transpiled and the default ESM output from `worker-loader` caused fragile import/interop behavior.
- The webpack rule needs to be scoped so Next's TS/SWC/Babel pipeline still processes worker sources before they are wrapped by the loader.

### Description
- Updated `ui/partner-hub/next.config.mjs` to set `esModule: false` for `worker-loader` so workers emit CommonJS-compatible modules.
- Added `issuer: { and: [/\.[jt]sx?$/] }` to the `.worker.ts` rule so the rule only applies when workers are imported from JS/TS modules.
- Appended a `babel-loader` entry with `presets: ["next/babel"]` to the rule so worker sources are transpiled with Next's Babel preset before being processed by `worker-loader`.

### Testing
- Ran `npm run build` in `ui/partner-hub` and the build failed with `next` not found in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ee6fcb47c8330b175324589ec4264)