### PR TITLE
Remove babel-loader from worker webpack rule

### DIFF
--- a/ui/partner-hub/next.config.mjs
+++ b/ui/partner-hub/next.config.mjs
@@ -18,12 +18,6 @@ const nextConfig = {
             esModule: false,
           },
         },
-        {
-          loader: "babel-loader",
-          options: {
-            presets: ["next/babel"],
-          },
-        },
       ],
     });
 


### PR DESCRIPTION
### Motivation
- Avoid requiring the heavy `babel-loader` dependency for worker builds by using only `worker-loader` for `*.worker.ts` files in `ui/partner-hub/next.config.mjs` to fix `Module not found: Can't resolve 'babel-loader'` during build.

### Description
- Delete the `babel-loader` entry from the custom webpack rule so the `*.worker.ts` rule uses only `worker-loader` with the existing options (`filename` and `esModule: false`) in `ui/partner-hub/next.config.mjs`.

### Testing
- Ran `npm run build` in `ui/partner-hub`, which failed with `sh: 1: next: not found` so a full Next build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ee87c6c188330a42f483ed504b539)