### PR TITLE
Add worker-loader to partner-hub dependencies

### DIFF
--- a/ui/partner-hub/package.json
+++ b/ui/partner-hub/package.json
@@ -25,6 +25,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.0.0",
         "reactflow": "^11.11.4",
+        "worker-loader": "^3.0.8",
         "zod": "^3.25.76"
     },
     "devDependencies": {
@@ -39,8 +40,7 @@
         "postcss": "^8.4.31",
         "prisma": "^6.19.2",
         "tailwindcss": "^3.4.0",
-        "typescript": "^5.3.0",
-        "worker-loader": "^3.0.8"
+        "typescript": "^5.3.0"
     },
     "overrides": {
         "glob": "^10.4.6"


### PR DESCRIPTION
### Motivation
- Ensure `worker-loader` is present during production/CI builds for `ui/partner-hub` because `next.config.mjs` uses `loader: "worker-loader"` and keeping it only in `devDependencies` causes resolution failures at build time.

### Description
- Move `worker-loader` from `devDependencies` into `dependencies` in `ui/partner-hub/package.json` and commit the updated `package.json` so builds can resolve the loader in environments that skip devDependencies; the lockfile could not be regenerated in this environment.

### Testing
- Ran `npm install` in `ui/partner-hub`, which failed with a `403` fetching `@prisma/client` so `package-lock.json` was not updated in this environment.
- Ran `npm run build` in `ui/partner-hub`, which failed because dependencies were not installed and `next` was not found (expected when `npm install` did not complete).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ee98cb708833094a5315437819ff7)