### PR TITLE
Export named Worker from *.worker.ts and update CSV worker import

### DIFF
--- a/ui/partner-hub/components/account-mapping/hooks/useCsvParseWorkers.ts
+++ b/ui/partner-hub/components/account-mapping/hooks/useCsvParseWorkers.ts
@@ -7,7 +7,7 @@ import {
   type SetStateAction,
 } from "react";
 
-import CsvParseWorker from "@/lib/account-mapping/workers/csvParse.worker.ts";
+import { Worker as CsvParseWorker } from "@/lib/account-mapping/workers/csvParse.worker.ts";
 
 import { DEFAULT_PROGRESS_STEP } from "../constants";
 import type { CsvParseResult, CsvParseState } from "../types";

--- a/ui/partner-hub/types/worker-loader.d.ts
+++ b/ui/partner-hub/types/worker-loader.d.ts
@@ -1,7 +1,5 @@
 declare module "*.worker.ts" {
-  class WebpackWorker extends Worker {
-    constructor();
-  }
-
-  export default WebpackWorker;
+  export const Worker: {
+    new (): globalThis.Worker;
+  };
 }


### PR DESCRIPTION
### Motivation
- Fix build failure caused by importing a non-existent default export from `csvParse.worker.ts` because the worker loader exposes a named `Worker` constructor.

### Description
- Update `ui/partner-hub/types/worker-loader.d.ts` to export a named `Worker` constructor instead of a default class.
- Change the CSV parse worker import in `ui/partner-hub/components/account-mapping/hooks/useCsvParseWorkers.ts` to `import { Worker as CsvParseWorker } ...` and preserve `new CsvParseWorker()` instantiation.

### Testing
- Ran `npm run build` in `ui/partner-hub`, which failed due to `next` not being available in the environment so the full build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eeb06768083308914cd92905343d2)