### PR TITLE
Use ES module worker-loader and default export for csvParse.worker

### DIFF
--- a/ui/partner-hub/components/account-mapping/hooks/useCsvParseWorkers.ts
+++ b/ui/partner-hub/components/account-mapping/hooks/useCsvParseWorkers.ts
@@ -7,7 +7,7 @@ import {
   type SetStateAction,
 } from "react";
 
-import { Worker as CsvParseWorker } from "@/lib/account-mapping/workers/csvParse.worker.ts";
+import CsvParseWorker from "@/lib/account-mapping/workers/csvParse.worker.ts";
 
 import { DEFAULT_PROGRESS_STEP } from "../constants";
 import type { CsvParseResult, CsvParseState } from "../types";

--- a/ui/partner-hub/next.config.mjs
+++ b/ui/partner-hub/next.config.mjs
@@ -15,7 +15,7 @@ const nextConfig = {
           loader: "worker-loader",
           options: {
             filename: "static/chunks/[name].[contenthash].worker.js",
-            esModule: false,
+            esModule: true,
           },
         },
       ],

--- a/ui/partner-hub/types/worker-loader.d.ts
+++ b/ui/partner-hub/types/worker-loader.d.ts
@@ -1,5 +1,6 @@
 declare module "*.worker.ts" {
-  export const Worker: {
+  const WorkerFactory: {
     new (): globalThis.Worker;
   };
+  export default WorkerFactory;
 }


### PR DESCRIPTION
### Motivation
- Builds were failing due to a TypeScript import shape mismatch when importing the worker as a named `Worker` because `worker-loader` was emitting a non-ESM shape.
- The worker module must expose a default constructor-compatible export to satisfy the TypeScript usage and bundler expectations.
- Change the loader output and the declaration to align the module shape with TypeScript imports and runtime behavior.

### Description
- Enabled `esModule: true` for the `worker-loader` rule in `ui/partner-hub/next.config.mjs` so workers are emitted as ES modules.
- Replaced the named `Worker` declaration with a default `WorkerFactory` export in `ui/partner-hub/types/worker-loader.d.ts` to represent the worker constructor shape.
- Switched the csv parse hook to import the worker as the default export in `ui/partner-hub/components/account-mapping/hooks/useCsvParseWorkers.ts` and instantiate it via `new CsvParseWorker()`.

### Testing
- Ran `npm run build` in `ui/partner-hub`, which failed in this environment with `next: not found` so a full production build could not be verified here.
- No other automated tests were executed in this rollout environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eec0aab2483308a30856a9ed3525f)