### PR TITLE
Fix worker-loader typings for TS worker imports

### DIFF
--- a/ui/partner-hub/tsconfig.json
+++ b/ui/partner-hub/tsconfig.json
@@ -34,7 +34,8 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    "types/**/*.d.ts"
   ],
   "exclude": [
     "node_modules"

--- a/ui/partner-hub/types/worker-loader.d.ts
+++ b/ui/partner-hub/types/worker-loader.d.ts
@@ -1,3 +1,10 @@
+declare module "*.worker" {
+  const WorkerFactory: {
+    new (): globalThis.Worker;
+  };
+  export default WorkerFactory;
+}
+
 declare module "*.worker.ts" {
   const WorkerFactory: {
     new (): globalThis.Worker;


### PR DESCRIPTION
### Motivation
- TypeScript reported "module ... has no default export" for imports like `csvParse.worker.ts` because the project only had a declaration for `*.worker.ts` while TS can resolve worker modules as `*.worker`.
- The runtime `worker-loader` is already configured to emit ES module default exports, so TypeScript needs matching declaration files and to actually load them.

### Description
- Added a `declare module "*.worker"` entry to `ui/partner-hub/types/worker-loader.d.ts` that exports a default `Worker` factory.
- Kept the existing `declare module "*.worker.ts"` declaration so both resolution patterns are covered in `ui/partner-hub/types/worker-loader.d.ts`.
- Updated `ui/partner-hub/tsconfig.json` `include` to add `types/**/*.d.ts` so TypeScript picks up the new declaration file.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eed1ae8f483309aa2fc1bed2d1551)