### PR TITLE
Remove .ts extension from CSV parse worker import

### DIFF
--- a/ui/partner-hub/components/account-mapping/hooks/useCsvParseWorkers.ts
+++ b/ui/partner-hub/components/account-mapping/hooks/useCsvParseWorkers.ts
@@ -7,7 +7,7 @@ import {
   type SetStateAction,
 } from "react";
 
-import CsvParseWorker from "@/lib/account-mapping/workers/csvParse.worker.ts";
+import CsvParseWorker from "@/lib/account-mapping/workers/csvParse.worker";
 
 import { DEFAULT_PROGRESS_STEP } from "../constants";
 import type { CsvParseResult, CsvParseState } from "../types";


### PR DESCRIPTION
### Motivation
- Fix Next/TypeScript build error caused by importing a worker with a `.ts` extension without enabling `allowImportingTsExtensions`.

### Description
- Remove the `.ts` extension from the worker import in `ui/partner-hub/components/account-mapping/hooks/useCsvParseWorkers.ts`, changing the import to `@/lib/account-mapping/workers/csvParse.worker`.

### Testing
- Ran `npm run build` in `ui/partner-hub`, which failed in this environment because `next` was not found so the build could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f6dcd9898833081fe7a050054f01a)