### PR TITLE
Fix TS typing for csvParse.worker default export

### DIFF
--- a/ui/partner-hub/lib/account-mapping/workers/csvParse.worker.ts
+++ b/ui/partner-hub/lib/account-mapping/workers/csvParse.worker.ts
@@ -5,4 +5,7 @@ self.onmessage = (e) => {
   // existing worker logic lives here
 };
 
-export default class WorkerShim {}
+// Type-only shim for TS in the app bundle.
+// Runtime is provided by worker-loader; this export is never used at runtime.
+const WorkerShim = (null as unknown) as { new (): Worker };
+export default WorkerShim;


### PR DESCRIPTION
### Motivation
- Fix a TypeScript error where the default export from `ui/partner-hub/lib/account-mapping/workers/csvParse.worker.ts` resolved to a plain class (`WorkerShim`) that does not satisfy the `Worker` constructor type required by the app bundle.

### Description
- Replace the runtime dummy `class WorkerShim {}` export with a type-only shim: `const WorkerShim = (null as unknown) as { new (): Worker }; export default WorkerShim;`, leaving the worker message handler logic unchanged.

### Testing
- Ran `npm run build` in `ui/partner-hub`, which failed in the current environment with `next: not found` (build could not complete here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f6f2fa07883309c8cc6ea3103eaf0)