### PR TITLE
Allow ngrok dev origin in partner-hub Next.js config

### DIFF
--- a/ui/partner-hub/next.config.mjs
+++ b/ui/partner-hub/next.config.mjs
@@ -3,6 +3,7 @@ const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "/partner-hub";
 
 const nextConfig = {
   reactStrictMode: true,
+  allowedDevOrigins: ["https://jann-noneastern-adolph.ngrok-free.dev"],
   basePath,
   images: { unoptimized: true },
   trailingSlash: false,


### PR DESCRIPTION
### Motivation
- Suppress the Next.js dev warning about cross-origin requests from the ngrok dev host by explicitly allowing the current ngrok origin in the app config.

### Description
- Added `allowedDevOrigins: ["https://jann-noneastern-adolph.ngrok-free.dev"]` to `ui/partner-hub/next.config.mjs` and preserved all existing config fields.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f71bb2f68833085a6c8c30427246e)