### PR TITLE
Remove TS shim from CSV parse worker runtime

### DIFF
--- a/ui/partner-hub/lib/account-mapping/workers/csvParse.worker.ts
+++ b/ui/partner-hub/lib/account-mapping/workers/csvParse.worker.ts
@@ -1,11 +1,3 @@
-// NOTE: Worker implementation unchanged.
-// This default export exists ONLY to satisfy TypeScript during next build.
-
 self.onmessage = (e) => {
   // existing worker logic lives here
 };
-
-// Type-only shim for TS in the app bundle.
-// Runtime is provided by worker-loader; this export is never used at runtime.
-const WorkerShim = (null as unknown) as { new (): Worker };
-export default WorkerShim;


### PR DESCRIPTION
### Motivation
- The worker bundle contained TypeScript-only assertions exported from `ui/partner-hub/lib/account-mapping/workers/csvParse.worker.ts` which produced runtime parse errors (e.g. `Unexpected token`) when the worker was loaded.

### Description
- Remove the TS-only default export shim from `ui/partner-hub/lib/account-mapping/workers/csvParse.worker.ts` so the emitted worker bundle contains only runtime message handlers and logic while preserving module declarations in `ui/partner-hub/types/worker-loader.d.ts` for TypeScript.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f7e6e5bb483308a5dd8b20e3de224)