### PR TITLE
Mark csvParse.worker.ts as module to fix TypeScript import

### DIFF
--- a/ui/partner-hub/lib/account-mapping/workers/csvParse.worker.ts
+++ b/ui/partner-hub/lib/account-mapping/workers/csvParse.worker.ts
@@ -1,3 +1,5 @@
 self.onmessage = (e) => {
   // existing worker logic lives here
 };
+
+export {};


### PR DESCRIPTION
### Motivation
- TypeScript treated `lib/account-mapping/workers/csvParse.worker.ts` as not a module because it had no exports, breaking the default import used by the worker-loader pattern.

### Description
- Add an empty export to `ui/partner-hub/lib/account-mapping/workers/csvParse.worker.ts` (`export {};`) so the file is treated as a module while preserving existing `self.onmessage` worker behavior.

### Testing
- Ran `npm run build` in this environment which failed with `sh: 1: next: not found`, so a full build could not be completed here; the change is a minimal typing fix and should allow the build to proceed where `next` is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f8260c4d0833088454194461c93a0)