### PR TITLE
Relax noImplicitAny for partner hub build

### DIFF
--- a/ui/partner-hub/tsconfig.json
+++ b/ui/partner-hub/tsconfig.json
@@ -9,6 +9,7 @@
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
+    "noImplicitAny": false,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
### Motivation
- Prevent Next.js build failures caused by TypeScript "parameter implicitly has an 'any' type" errors in the partner-hub app by relaxing only the `noImplicitAny` check without changing runtime behavior.

### Description
- Added `"noImplicitAny": false` to `ui/partner-hub/tsconfig.json` under `compilerOptions`, keeping `strict` enabled.

### Testing
- Ran `npm run build` in `ui/partner-hub`; implicit-any errors no longer block compilation, but the build still fails due to an unrelated type mismatch in `app/(routes)/bookings/page.tsx` (conflict between `officeId` types).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696faf747b2883309a58ae4d0f48f0f2)