### PR TITLE
AI booking modal: replace Confirm with Exit + “Book another time” on success

### DIFF
--- a/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
+++ b/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
@@ -477,8 +477,7 @@ export function OfficeScheduleClient({
     }
   }, []);
 
-  useEffect(() => {
-    if (!aiOpen) return;
+  function resetAiFlow() {
     setAiMessages([
       {
         role: "assistant",
@@ -497,6 +496,11 @@ export function OfficeScheduleClient({
     setAiDateOptions([]);
     setAiStep("collect_date");
     setAiChecking(false);
+  }
+
+  useEffect(() => {
+    if (!aiOpen) return;
+    resetAiFlow();
   }, [aiOpen]);
 
   // Keep UI state in sync with URL navigation (back/forward).
@@ -658,6 +662,7 @@ export function OfficeScheduleClient({
   }, [selectedDaySlots]);
 
   const todayKey = useMemo(() => toDateKey(now), [now]);
+  const aiBookingComplete = aiStep === "done" || Boolean(aiBookingSuccess);
 
   function pushState(next: { officeId?: number; dateKey?: string; durationMin?: number }) {
     const qs = new URLSearchParams(sp?.toString());
@@ -665,6 +670,11 @@ export function OfficeScheduleClient({
     qs.set("office", String(next.officeId ?? officeId));
     qs.set("duration", String(next.durationMin ?? durationMin));
     router.push(`/offices/schedule?${qs.toString()}`);
+  }
+
+  function handleAiExit() {
+    setAiOpen(false);
+    pushState({});
   }
 
   const selectedSlotSet = useMemo(() => new Set(selectedSlotStarts), [selectedSlotStarts]);
@@ -1893,19 +1903,41 @@ export function OfficeScheduleClient({
               {aiBookingSuccess ? (
                 <div className="mt-2 text-xs font-semibold text-emerald-700">{aiBookingSuccess}</div>
               ) : null}
-              <button
-                type="button"
-                className={
-                  "mt-3 h-10 w-full rounded-md border border-border/70 px-3 text-sm font-semibold transition " +
-                  (aiBookingSubmitting
-                    ? "bg-muted/30 text-foreground/50"
-                    : "bg-foreground text-background hover:opacity-90")
-                }
-                onClick={() => submitAiBooking(aiSelectedOption)}
-                disabled={aiBookingSubmitting}
-              >
-                {aiBookingSubmitting ? "Booking..." : "Confirm booking"}
-              </button>
+              {aiBookingComplete ? (
+                <div className="mt-3 grid gap-2">
+                  <button
+                    type="button"
+                    className="h-10 w-full rounded-md border border-border/70 bg-foreground px-3 text-sm font-semibold text-background transition hover:opacity-90"
+                    onClick={handleAiExit}
+                  >
+                    Exit
+                  </button>
+                  <button
+                    type="button"
+                    className="text-sm font-semibold text-foreground/70 transition hover:text-foreground"
+                    onClick={() => {
+                      // Guardrail: reset the AI booking flow after success so the confirm button never reappears.
+                      resetAiFlow();
+                    }}
+                  >
+                    Book another time
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  className={
+                    "mt-3 h-10 w-full rounded-md border border-border/70 px-3 text-sm font-semibold transition " +
+                    (aiBookingSubmitting
+                      ? "bg-muted/30 text-foreground/50"
+                      : "bg-foreground text-background hover:opacity-90")
+                  }
+                  onClick={() => submitAiBooking(aiSelectedOption)}
+                  disabled={aiBookingSubmitting}
+                >
+                  {aiBookingSubmitting ? "Booking..." : "Confirm booking"}
+                </button>
+              )}
             </div>
           ) : null}
 


### PR DESCRIPTION
### Motivation
- After an AI-created booking succeeds the modal must stop showing the primary “Confirm booking” CTA and instead present an “Exit” primary action plus a secondary “Book another time” action while keeping the success message visible.
- The post-success UI must be state-driven and deterministic so the Confirm CTA cannot reappear after success across re-renders.

### Description
- Added a `resetAiFlow()` helper to centrally reset AI modal state and wired it to open/restart flows so restarting clears success and re-initializes the AI chat.
- Introduced `aiBookingComplete` derived state (`aiStep === "done" || Boolean(aiBookingSuccess)`) and a `handleAiExit()` which closes the modal and navigates back to the schedule route using existing `pushState`/router conventions.
- Swapped the modal render for the selected AI option so that when `aiBookingComplete` is true the UI shows an `Exit` button (primary) and a `Book another time` action underneath that calls `resetAiFlow()`, otherwise the existing `Confirm booking` button is shown; the Confirm CTA is therefore never visible/clickable once success is true.
- One file changed: `ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx` (updated full implementation to implement the above behavior and guardrails).

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`, Next reported a successful start but the `/offices/schedule` route returned `404` and there was a cross-origin dev-assets warning (server ready output included in rollout transcript). 
- Attempted an automated UI check with Playwright but the script timed out after 30s due to the dev server route/asset issues and no screenshot was captured. 
- No unit/integration tests were added or run in this rollout; commit was created with the change (`Update AI booking success actions`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ffbf5b2508330bba58fe7a416770f)