### PR TITLE
Adjust Office Schedule header alignment (Use AI button & Office select)

### DIFF
--- a/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
+++ b/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
@@ -1450,7 +1450,7 @@ export function OfficeScheduleClient({
                 <h1 className="text-2xl font-semibold tracking-tight">Schedule a time</h1>
                 <button
                   type="button"
-                  className="inline-flex h-9 items-center gap-2 rounded-xl border border-border/70 bg-background px-3 text-xs font-semibold transition hover:bg-muted"
+                  className="inline-flex h-9 items-center gap-2 rounded-xl border border-border/70 bg-background px-3 text-xs font-semibold transition hover:bg-muted md:-translate-x-0.5"
                   onClick={() => setAiOpen(true)}
                 >
                   <Sparkles className="h-4 w-4 text-foreground/60" />
@@ -1491,7 +1491,7 @@ export function OfficeScheduleClient({
                 </div>
 
                 <select
-                  className="h-10 w-full rounded-md border border-border/70 bg-background px-3 text-sm"
+                  className="h-10 w-full rounded-md border border-border/70 bg-background px-3 text-sm md:-translate-x-0.5 md:w-[calc(100%-0.25rem)]"
                   value={officeId}
                   onChange={(e) => {
                     const next = Number(e.target.value);


### PR DESCRIPTION
### Motivation
- Subtly improve horizontal balance between the left “Schedule a time” column and the calendar/time-slots column by shifting a couple of left-column controls slightly left without changing layout or behavior.

### Description
- In `app/(routes)/offices/schedule/OfficeScheduleClient.tsx` nudge desktop positioning of the “Use AI” button and the office `select` by adding `md:-translate-x-0.5` and reduce the select’s desktop width with `md:w-[calc(100%-0.25rem)]`, keeping all functionality and breakpoints unchanged.

### Testing
- Ran `npm run build` which completed successfully; the production build and type/lint checks passed. Attempted an automated Playwright screenshot for visual verification but the browser crashed in this environment, so no screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697001ec2a8c83308126728db1dab95e)