### PR TITLE
Adjust office schedule alignment spacing without transforms

### DIFF
--- a/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
+++ b/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
@@ -1450,7 +1450,7 @@ export function OfficeScheduleClient({
                 <h1 className="text-2xl font-semibold tracking-tight">Schedule a time</h1>
                 <button
                   type="button"
-                  className="inline-flex h-9 items-center gap-2 rounded-xl border border-border/70 bg-background px-3 text-xs font-semibold transition hover:bg-muted md:-translate-x-0.5"
+                  className="inline-flex h-9 items-center gap-2 rounded-xl border border-border/70 bg-background px-3 text-xs font-semibold transition hover:bg-muted md:-ml-0.5"
                   onClick={() => setAiOpen(true)}
                 >
                   <Sparkles className="h-4 w-4 text-foreground/60" />
@@ -1491,7 +1491,7 @@ export function OfficeScheduleClient({
                 </div>
 
                 <select
-                  className="h-10 w-full rounded-md border border-border/70 bg-background px-3 text-sm md:-translate-x-0.5 md:w-[calc(100%-0.25rem)]"
+                  className="h-10 w-full rounded-md border border-border/70 bg-background px-3 text-sm md:-ml-0.5"
                   value={officeId}
                   onChange={(e) => {
                     const next = Number(e.target.value);


### PR DESCRIPTION
### Motivation
- Fix a subtle horizontal misalignment on the Office Schedule page by removing transform- and calc-based nudges and using standard spacing so focus rings and hover outlines remain correct.

### Description
- Replace `md:-translate-x-0.5` and `md:w-[calc(100%-0.25rem)]` with `md:-ml-0.5` in `ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx` for the "Use AI" button and the office `select`, keeping the change md-only and preserving all functionality.

### Testing
- Ran `npm run build` in `ui/partner-hub` and the Next.js build completed successfully with compilation, linting, and type checks passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970040ed0a883308c7cfe9ca1f8bef6)