### PR TITLE
Adjust Office Schedule left column width (md+) and remove control offsets

### DIFF
--- a/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
+++ b/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
@@ -1443,14 +1443,14 @@ export function OfficeScheduleClient({
         ) : null}
 
         <div className={locked ? "pointer-events-none select-none opacity-40 grayscale" : ""}>
-          <div className="grid grid-cols-1 md:grid-cols-[360px_1fr]">
+          <div className="grid grid-cols-1 md:grid-cols-[356px_1fr]">
             {/* Left panel */}
             <section className="p-6">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <h1 className="text-2xl font-semibold tracking-tight">Schedule a time</h1>
                 <button
                   type="button"
-                  className="inline-flex h-9 items-center gap-2 rounded-xl border border-border/70 bg-background px-3 text-xs font-semibold transition hover:bg-muted md:-ml-0.5"
+                  className="inline-flex h-9 items-center gap-2 rounded-xl border border-border/70 bg-background px-3 text-xs font-semibold transition hover:bg-muted"
                   onClick={() => setAiOpen(true)}
                 >
                   <Sparkles className="h-4 w-4 text-foreground/60" />
@@ -1491,7 +1491,7 @@ export function OfficeScheduleClient({
                 </div>
 
                 <select
-                  className="h-10 w-full rounded-md border border-border/70 bg-background px-3 text-sm md:-ml-0.5"
+                  className="h-10 w-full rounded-md border border-border/70 bg-background px-3 text-sm"
                   value={officeId}
                   onChange={(e) => {
                     const next = Number(e.target.value);


### PR DESCRIPTION
### Motivation
- Shift the left "Schedule a time" column slightly left at md+ so the vertical divider aligns closer to the calendar without changing mobile/tablet behavior or using transforms.

### Description
- Update `ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx` to change `md:grid-cols-[360px_1fr]` to `md:grid-cols-[356px_1fr]` and remove the `md:-ml-0.5` negative-margin nudges from the Use AI button and the office `select` so controls no longer stack per-control offsets.

### Testing
- Ran `npm run build` in `ui/partner-hub` and the Next.js build completed successfully (`✓ Compiled successfully` and static pages were generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697009b1f9348330861849527e8ab23f)