### PR TITLE
Support Vast vendor in Energy Tool: default drive sizes and vendor-aware phrasing

### DIFF
--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -31,6 +31,7 @@ const fmt1 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
 const fmt2 = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 });
 const formatRackUnits = (value: number | null | undefined) => (value == null ? "—" : fmt0.format(value));
 const DEFAULT_GRID_KGCO2E_PER_KWH = 0.4;
+const VAST_DRIVE_SIZES_TB = [16, 18, 20, 22];
 const INPUT_BASE_CLASSES =
   "h-10 w-full rounded-lg border border-border/70 bg-card px-3 text-sm text-foreground shadow-sm transition placeholder:text-foreground/40 focus-visible:outline-none focus-visible:border-primary/60 focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 const LABEL_CLASSES = "text-xs font-semibold uppercase tracking-wide text-foreground/60";
@@ -361,18 +362,23 @@ export function EnergyTool() {
     }
     return Array.from(sizes).sort((a, b) => a - b);
   }, [netappCompat]);
-  const driveSizeOptions = effectiveMode === "manual" ? driveSizes : allDriveSizes;
+  const driveSizeOptions = useMemo(() => {
+    if (competitorVendor === "Vast") return VAST_DRIVE_SIZES_TB;
+    return effectiveMode === "manual" ? driveSizes : allDriveSizes;
+  }, [allDriveSizes, competitorVendor, driveSizes, effectiveMode]);
   const manualDriveSizeMissing =
+    competitorVendor === "NetApp" &&
     effectiveMode === "manual" &&
     manualInputs.controllerModel.length > 0 &&
     manualInputs.expansionModel.length > 0 &&
     driveSizes.length === 0;
   const manualApplyDisabled =
-    loading ||
-    manualInputs.controllerModel.length === 0 ||
-    manualInputs.expansionModel.length === 0 ||
-    manualDriveSizeMissing ||
-    netappRows.length === 0;
+    competitorVendor === "NetApp" &&
+    (loading ||
+      manualInputs.controllerModel.length === 0 ||
+      manualInputs.expansionModel.length === 0 ||
+      manualDriveSizeMissing ||
+      netappRows.length === 0);
 
   const runModel = () => {
     try {
@@ -783,6 +789,9 @@ export function EnergyTool() {
         ? "border-button-primary bg-button-primary text-button-primary-foreground hover:bg-button-primary/90 ring-1 ring-button-primary/30"
         : "border-border bg-background text-foreground hover:bg-muted/50",
     ].join(" ");
+  const expansionLabel = competitorVendor === "Vast" ? "unit" : "shelf";
+  const expansionLabelPlural = competitorVendor === "Vast" ? "units" : "shelves";
+  const expansionHeaderLabel = competitorVendor === "Vast" ? "Exp units" : "Exp shelves";
 
   return (
     <div className="space-y-8 md:space-y-10">
@@ -1153,7 +1162,7 @@ export function EnergyTool() {
                           <thead className="border-b border-border text-foreground/60">
                             <tr>
                               <th className="py-2 pr-3 font-semibold">Controller</th>
-                              <th className="py-2 pr-3 font-semibold">Exp shelves</th>
+                              <th className="py-2 pr-3 font-semibold">{expansionHeaderLabel}</th>
                               <th className="py-2 pr-3 font-semibold whitespace-nowrap">Total rack units</th>
                               <th className="py-2 pr-3 font-semibold">Eff TB</th>
                               <th className="py-2 pr-3 font-semibold">Δ vs target</th>
@@ -1236,8 +1245,8 @@ export function EnergyTool() {
               <CardTitle className="text-base">Comparison</CardTitle>
               {selectedCandidate ? (
                 <div className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
-                  SELECTED: {selectedCandidate.controllerModel} + {selectedCandidate.expansionQty} shelf
-                  {selectedCandidate.expansionQty === 1 ? "" : "es"}
+                  SELECTED: {selectedCandidate.controllerModel} + {selectedCandidate.expansionQty}{" "}
+                  {selectedCandidate.expansionQty === 1 ? expansionLabel : expansionLabelPlural}
                 </div>
               ) : null}
             </CardHeader>
@@ -1318,12 +1327,18 @@ export function EnergyTool() {
                     <li>DRR: {fmt2.format(inputs.naDrr)}</li>
                     <li>
                       Drive size selection: {fmt0.format(inputs.naDriveSizeTb)} TB{" "}
-                      {effectiveMode === "manual" ? "(compat pairing)" : "(compat list)"}
+                      {competitorVendor === "NetApp"
+                        ? effectiveMode === "manual"
+                          ? "(compat pairing)"
+                          : "(compat list)"
+                        : "(default list)"}
                     </li>
                     <li>
                       Selected config:{" "}
                       {selectedCandidate
-                        ? `${selectedCandidate.controllerModel} + ${selectedCandidate.expansionQty} ${selectedCandidate.expansionQty === 1 ? "shelf" : "shelves"} (${selectedCandidate.expansionModel})`
+                        ? `${selectedCandidate.controllerModel} + ${selectedCandidate.expansionQty} ${
+                            selectedCandidate.expansionQty === 1 ? expansionLabel : expansionLabelPlural
+                          } (${selectedCandidate.expansionModel})`
                         : `No ${competitorLabel} candidate selected`}
                     </li>
                   </ul>


### PR DESCRIPTION
### Motivation
- Make the competitor "Vast" mode usable even when NetApp compatibility data is absent so UI controls never become empty or disabled.
- Ensure manual mode and NetApp-specific validation do not affect Vast UI state by gating manual controls to NetApp only.
- Replace hard-coded "shelf/shelves" wording with vendor-aware labels so Vast uses "unit/units" consistently.

### Description
- Added `VAST_DRIVE_SIZES_TB` default constant and return it for drive size dropdowns when `competitorVendor === "Vast"`, keeping NetApp behavior unchanged otherwise (file: `ui/partner-hub/components/energy/energy-tool.tsx`).
- Made manual-drive validations and the `Apply manual config` gating conditional on `competitorVendor === "NetApp"` so Vast mode is forced to auto and is not blocked by NetApp-only state.
- Introduced `expansionLabel`, `expansionLabelPlural`, and `expansionHeaderLabel` computed from `competitorVendor` and updated table headers, summary text, and helper text to render vendor-aware wording (e.g., "Exp units" / "unit/units").
- Updated drive-size helper wording to show `(default list)` for Vast and retain `(compat pairing)` / `(compat list)` for NetApp.

### Testing
- Started the dev server with `npm run dev` in `ui/partner-hub` and confirmed the app compiled and served the ` /partner-hub/energy` page (server ran and routes compiled successfully).
- Ran a Playwright script that loaded `/partner-hub/energy`, selected the `Vast` vendor from the UI, and captured a screenshot; the script completed and produced `artifacts/energy-vast.png` demonstrating the Vast view renders and is interactive.
- Observed a missing Vast CSV (`GET /data/energy/vast_data.csv 404`) during testing but the UI remained stable and did not throw, which verifies the fallback behavior. No automated unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697057cdf5208330958d49babc32236a)