### PR TITLE
Add Vast enumeration support to energy tool

### DIFF
--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
+  enumerateVast,
   enumerateNetApp,
   fbPower,
   getTracks,
@@ -399,17 +400,30 @@ export function EnergyTool() {
         return;
       }
       const tolFrac = inputs.tolPct / 100;
-      const netapp = enumerateNetApp(
-        competitorRows,
-        fbResult.effectiveTb,
-        inputs.naUtilPct / 100,
-        inputs.naPue,
-        inputs.naPrice,
-        inputs.naOverhead,
-        inputs.naDrr,
-        inputs.naDriveSizeTb,
-        tolFrac,
-      );
+      const netapp =
+        competitorVendor === "Vast"
+          ? enumerateVast(
+              competitorRows,
+              fbResult.effectiveTb,
+              inputs.naUtilPct / 100,
+              inputs.naPue,
+              inputs.naPrice,
+              inputs.naOverhead,
+              inputs.naDrr,
+              inputs.naDriveSizeTb,
+              tolFrac,
+            )
+          : enumerateNetApp(
+              competitorRows,
+              fbResult.effectiveTb,
+              inputs.naUtilPct / 100,
+              inputs.naPue,
+              inputs.naPrice,
+              inputs.naOverhead,
+              inputs.naDrr,
+              inputs.naDriveSizeTb,
+              tolFrac,
+            );
       setFb(fbResult);
       setCandidates(netapp);
       setSelected((prev) => {

--- a/ui/partner-hub/lib/energy/energy-calc.test.ts
+++ b/ui/partner-hub/lib/energy/energy-calc.test.ts
@@ -1,7 +1,15 @@
 import { describe, it } from "node:test";
 import * as assert from "node:assert/strict";
 
-import { buildNetAppCandidate, enumerateNetApp, fbPower, type NetAppRow, type PureRow } from "./energy-calc";
+import {
+  buildNetAppCandidate,
+  enumerateNetApp,
+  enumerateVast,
+  fbPower,
+  type NetAppRow,
+  type PureRow,
+  type VastRow,
+} from "./energy-calc";
 
 const makePureRows = (): PureRow[] => [
   {
@@ -61,6 +69,26 @@ const makeNetAppRows = (): NetAppRow[] => [
     Idle_W: 75,
     Drives_per_unit: 60,
     Rack_Units: 4,
+  },
+];
+
+const makeVastRows = (): VastRow[] => [
+  {
+    Component_Type: "Controller_Shelf",
+    Model: "VastBase",
+    Typical_W: 180,
+    Idle_W: 90,
+    Drives_per_unit: 24,
+    Rack_Units: 4,
+  },
+  {
+    Component_Type: "Expansion_Shelf",
+    Model: "VastExpansion",
+    Typical_W: 120,
+    Idle_W: 60,
+    Drives_per_unit: 12,
+    Rack_Units: 2,
+    Auto_Default: "true",
   },
 ];
 
@@ -128,5 +156,13 @@ describe("NetApp candidates", () => {
     assert.ok(Math.abs((match?.weightedW ?? 0) - 375) < 1e-6);
     assert.ok(Math.abs((match?.kwhYearWithPue ?? 0) - 3942) < 1e-6);
     assert.ok(Math.abs((match?.annualEnergyCost ?? 0) - 394.2) < 1e-6);
+  });
+});
+
+describe("Vast candidates", () => {
+  it("returns at least one candidate within tolerance", () => {
+    const targetEffTb = 324;
+    const candidates = enumerateVast(makeVastRows(), targetEffTb, 0.5, 1.2, 0.1, 0.1, 1, 10, 0.05);
+    assert.ok(candidates.length > 0);
   });
 });

--- a/ui/partner-hub/lib/energy/energy-calc.ts
+++ b/ui/partner-hub/lib/energy/energy-calc.ts
@@ -37,6 +37,10 @@ export type NetAppRow = CsvRow & {
   Rack_Units: number | null;
 };
 
+export type VastRow = NetAppRow & {
+  Auto_Default?: boolean | string | number | null;
+};
+
 export type PowerModel = {
   model: string;
   typicalW: number;
@@ -87,6 +91,16 @@ export function loadNetApp(rows: CsvRow[]): NetAppRow[] {
     return out;
   });
 }
+
+const toBool = (v: unknown): boolean => {
+  if (typeof v === "boolean") return v;
+  if (typeof v === "number") return v === 1;
+  if (typeof v === "string") {
+    const t = v.trim().toLowerCase();
+    return t === "true" || t === "yes" || t === "1";
+  }
+  return false;
+};
 
 export function getTracks(pureRows: PureRow[]): number[] {
   return Array.from(new Set(pureRows.map((r) => r.DFM_Size_TB))).sort((a, b) => a - b);
@@ -394,6 +408,75 @@ export function enumerateNetApp(
           kwhPerEffectiveTbYear: eff > 0 ? kwhPue / eff : null,
         });
       }
+    }
+  }
+
+  out.sort((a, b) => {
+    const da = Math.abs(a.pctDiffFromTarget);
+    const db = Math.abs(b.pctDiffFromTarget);
+    if (da !== db) return da - db;
+    return a.annualEnergyCost - b.annualEnergyCost;
+  });
+  return out;
+}
+
+export function enumerateVast(
+  vastRows: VastRow[],
+  targetEffTb: number,
+  util: number,
+  pue: number,
+  price: number,
+  overhead: number,
+  drr: number,
+  driveTb: number,
+  tolFrac = 0.1,
+): NetAppCandidate[] {
+  const controllerRows = vastRows.filter((r) => r.Component_Type === "Controller_Shelf");
+  const expansionRows = vastRows.filter((r) => r.Component_Type === "Expansion_Shelf");
+  if (controllerRows.length === 0) throw new Error("Missing Vast controller shelf row");
+  if (expansionRows.length === 0) throw new Error("Missing Vast expansion shelf row");
+
+  const base = controllerRows[0];
+  const expansion = expansionRows.find((row) => toBool(row.Auto_Default)) ?? expansionRows[0];
+  if (!expansion) throw new Error("Missing Vast expansion shelf row");
+
+  const baseWeighted = (u: number) => base.Idle_W + u * (base.Typical_W - base.Idle_W);
+  const expWeighted = (u: number) => expansion.Idle_W + u * (expansion.Typical_W - expansion.Idle_W);
+  const baseDrives = toInt(base.Drives_per_unit);
+  const expDrives = toInt(expansion.Drives_per_unit);
+
+  const out: NetAppCandidate[] = [];
+  for (let expQty = 0; expQty <= 40; expQty += 1) {
+    const totalDrives = baseDrives + expQty * expDrives;
+    const raw = totalDrives * driveTb;
+    const usable = raw * (1 - overhead);
+    const eff = usable * drr;
+
+    const w = baseWeighted(util) + expQty * expWeighted(util);
+    const kwhPue = kwhYear(w) * pue;
+    const annual = kwhPue * price;
+    const pct = targetEffTb > 0 ? ((eff - targetEffTb) / targetEffTb) * 100 : 0;
+    const rackUnits =
+      base.Rack_Units != null && expansion.Rack_Units != null
+        ? base.Rack_Units + expQty * expansion.Rack_Units
+        : null;
+
+    if (Math.abs(pct) <= tolFrac * 100 + 1e-9) {
+      out.push({
+        controllerModel: String(base.Model ?? ""),
+        expansionModel: String(expansion.Model ?? ""),
+        controllerQty: 1,
+        expansionQty: expQty,
+        effectiveTb: eff,
+        rackUnits,
+        pctDiffFromTarget: pct,
+        weightedW: w,
+        kwhYearWithPue: kwhPue,
+        annualEnergyCost: annual,
+        wPerEffectiveTb: eff > 0 ? w / eff : null,
+        dollarsPerEffectiveTbYear: eff > 0 ? annual / eff : null,
+        kwhPerEffectiveTbYear: eff > 0 ? kwhPue / eff : null,
+      });
     }
   }
 


### PR DESCRIPTION
### Motivation
- Support Vast competitor enumeration alongside NetApp so the UI can reuse the same candidate rendering and compare energy/capacity automatically.
- Mirror the existing NetApp enumeration behavior (capacity matching, weighted power, PUE/cost, tolerance filtering and stable sorting) for Vast configurations.

### Description
- Add a `VastRow` type and a `toBool` helper to parse `Auto_Default` from CSV-derived rows and keep field mapping compatible with `NetAppRow`.
- Implement `enumerateVast(...)` that selects a base `Controller_Shelf` row, picks an `Expansion_Shelf` (preferring rows with `Auto_Default=true`), iterates `expQty` (0..40), computes `totalDrives`, `rawTB`, `usableTB`, `effectiveTB`, weighted `watts`, `kwh`/`annual cost`, filters candidates within ± `tolFrac` of `targetEffTb`, and returns candidates using the same `NetAppCandidate` shape and sorting logic as `enumerateNetApp`.
- Wire `enumerateVast` into the energy UI so `competitorVendor === "Vast"` uses the new enumerator while preserving the existing candidate structure and labels.
- Add a unit test (`enumerateVast` synthetic dataset) that asserts at least one candidate is returned for a small target and verifies `enumerateNetApp`/`buildNetAppCandidate` behavior remains unchanged.

### Testing
- Ran the full test suite with `npm test`; the energy tests including the new `Vast candidates` test passed and `enumerateNetApp` tests are unchanged. 
- The test run reported 36 passing tests and 1 failing test in the unrelated account-mapping `match` suite (existing expectation mismatch), so CI is currently not green due to that unrelated failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69705964ce00833093104aaf67e97436)