### PR TITLE
Harden Vast energy enumeration and parsing

### DIFF
--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -11,11 +11,13 @@ import {
   loadCsv,
   loadNetApp,
   loadPure,
+  loadVast,
   validCaps,
   type FbPowerResult,
   type NetAppCandidate,
   type NetAppRow,
   type PureRow,
+  type VastRow,
 } from "@/lib/energy/energy-calc";
 import {
   getControllerModels,
@@ -162,7 +164,7 @@ const defaults: Omit<Inputs, "dfmTb" | "capacityPb"> = {
 export function EnergyTool() {
   const [pureRows, setPureRows] = useState<PureRow[]>([]);
   const [netappRows, setNetappRows] = useState<NetAppRow[]>([]);
-  const [vastRows, setVastRows] = useState<NetAppRow[]>([]);
+  const [vastRows, setVastRows] = useState<VastRow[]>([]);
   const [netappCompat, setNetappCompat] = useState<NetAppDriveCompat | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -226,7 +228,7 @@ export function EnergyTool() {
         try {
           const vastCsv = await loadCsv(withBasePath("/data/energy/vast_data.csv"));
           if (!cancelled) {
-            setVastRows(loadNetApp(vastCsv));
+            setVastRows(loadVast(vastCsv));
           }
         } catch {
           if (!cancelled) {

--- a/ui/partner-hub/lib/energy/csv.ts
+++ b/ui/partner-hub/lib/energy/csv.ts
@@ -1,4 +1,4 @@
-export type CsvRow = Record<string, string | number | null>;
+export type CsvRow = Record<string, string | number | boolean | null>;
 
 // Minimal RFC4180-ish CSV parser with quote handling.
 // - Supports quoted fields with escaped quotes ("").

--- a/ui/partner-hub/lib/energy/energy-calc.test.ts
+++ b/ui/partner-hub/lib/energy/energy-calc.test.ts
@@ -76,8 +76,8 @@ const makeVastRows = (): VastRow[] => [
   {
     Component_Type: "Controller_Shelf",
     Model: "VastBase",
-    Typical_W: 180,
-    Idle_W: 90,
+    Typical_W: 200,
+    Idle_W: 100,
     Drives_per_unit: 24,
     Rack_Units: 4,
   },
@@ -88,7 +88,7 @@ const makeVastRows = (): VastRow[] => [
     Idle_W: 60,
     Drives_per_unit: 12,
     Rack_Units: 2,
-    Auto_Default: "true",
+    Auto_Default: true,
   },
 ];
 
@@ -160,9 +160,26 @@ describe("NetApp candidates", () => {
 });
 
 describe("Vast candidates", () => {
-  it("returns at least one candidate within tolerance", () => {
-    const targetEffTb = 324;
-    const candidates = enumerateVast(makeVastRows(), targetEffTb, 0.5, 1.2, 0.1, 0.1, 1, 10, 0.05);
+  it("returns empty when Vast rows are missing", () => {
+    const candidates = enumerateVast([], 100, 0.5, 1.2, 0.1, 0.1, 1, 10, 0.05);
+    assert.deepEqual(candidates, []);
+  });
+
+  it("returns the expected candidate within tolerance", () => {
+    const targetEffTb = 432;
+    const tolFrac = 0.02;
+    const candidates = enumerateVast(makeVastRows(), targetEffTb, 0.5, 1.2, 0.1, 0.1, 1, 10, tolFrac);
+
     assert.ok(candidates.length > 0);
+    const maxPct = Math.max(...candidates.map((candidate) => Math.abs(candidate.pctDiffFromTarget)));
+    assert.ok(maxPct <= tolFrac * 100 + 1e-9);
+
+    const match = candidates.find((candidate) => candidate.expansionQty === 2);
+    assert.ok(match);
+    assert.equal(match?.rackUnits, 8);
+    assert.ok(Math.abs((match?.effectiveTb ?? 0) - 432) < 1e-6);
+    assert.ok(Math.abs((match?.weightedW ?? 0) - 330) < 1e-6);
+    assert.ok(Math.abs((match?.kwhYearWithPue ?? 0) - 3468.96) < 1e-2);
+    assert.ok(Math.abs((match?.annualEnergyCost ?? 0) - 346.896) < 1e-3);
   });
 });

--- a/ui/partner-hub/lib/energy/energy-calc.ts
+++ b/ui/partner-hub/lib/energy/energy-calc.ts
@@ -38,7 +38,7 @@ export type NetAppRow = CsvRow & {
 };
 
 export type VastRow = NetAppRow & {
-  Auto_Default?: boolean | string | number | null;
+  Auto_Default?: boolean;
 };
 
 export type PowerModel = {
@@ -101,6 +101,24 @@ const toBool = (v: unknown): boolean => {
   }
   return false;
 };
+
+const isValidNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0;
+
+export function loadVast(rows: CsvRow[]): VastRow[] {
+  return rows.map((r) => {
+    const out: VastRow = {
+      ...r,
+      Typical_W: toFloat(r.Typical_W),
+      Idle_W: toFloat(r.Idle_W),
+      Drives_per_unit: toFloat(r.Drives_per_unit),
+      // Rack_Units is optional in source CSVs; keep null so the UI shows — and can warn intentionally.
+      Rack_Units: toOptionalFloat(r.Rack_Units),
+      Auto_Default: toBool(r.Auto_Default),
+    };
+    return out;
+  });
+}
 
 export function getTracks(pureRows: PureRow[]): number[] {
   return Array.from(new Set(pureRows.map((r) => r.DFM_Size_TB))).sort((a, b) => a - b);
@@ -431,22 +449,40 @@ export function enumerateVast(
   driveTb: number,
   tolFrac = 0.1,
 ): NetAppCandidate[] {
-  const controllerRows = vastRows.filter((r) => r.Component_Type === "Controller_Shelf");
-  const expansionRows = vastRows.filter((r) => r.Component_Type === "Expansion_Shelf");
-  if (controllerRows.length === 0) throw new Error("Missing Vast controller shelf row");
-  if (expansionRows.length === 0) throw new Error("Missing Vast expansion shelf row");
+  if (vastRows.length === 0) return [];
+  const controllerRows = vastRows.filter(
+    (r) =>
+      r.Component_Type === "Controller_Shelf" &&
+      isValidNumber(r.Typical_W) &&
+      isValidNumber(r.Idle_W) &&
+      isValidNumber(r.Drives_per_unit),
+  );
+  const expansionRows = vastRows.filter(
+    (r) =>
+      r.Component_Type === "Expansion_Shelf" &&
+      isValidNumber(r.Typical_W) &&
+      isValidNumber(r.Idle_W) &&
+      isValidNumber(r.Drives_per_unit),
+  );
+  if (controllerRows.length === 0 || expansionRows.length === 0) return [];
 
   const base = controllerRows[0];
-  const expansion = expansionRows.find((row) => toBool(row.Auto_Default)) ?? expansionRows[0];
-  if (!expansion) throw new Error("Missing Vast expansion shelf row");
+  const expansion = expansionRows.find((row) => row.Auto_Default) ?? expansionRows[0];
+  if (!expansion) return [];
 
   const baseWeighted = (u: number) => base.Idle_W + u * (base.Typical_W - base.Idle_W);
   const expWeighted = (u: number) => expansion.Idle_W + u * (expansion.Typical_W - expansion.Idle_W);
-  const baseDrives = toInt(base.Drives_per_unit);
-  const expDrives = toInt(expansion.Drives_per_unit);
+  const baseDrives = base.Drives_per_unit;
+  const expDrives = expansion.Drives_per_unit;
+  if (!isValidNumber(baseDrives) || !isValidNumber(expDrives)) return [];
 
   const out: NetAppCandidate[] = [];
-  for (let expQty = 0; expQty <= 40; expQty += 1) {
+  const maxExpansionQty = 200;
+  const maxOverToleranceSteps = 4;
+  let overToleranceSteps = 0;
+  const toleranceUpper = targetEffTb > 0 ? targetEffTb * (1 + tolFrac) : Number.POSITIVE_INFINITY;
+
+  for (let expQty = 0; expQty <= maxExpansionQty; expQty += 1) {
     const totalDrives = baseDrives + expQty * expDrives;
     const raw = totalDrives * driveTb;
     const usable = raw * (1 - overhead);
@@ -457,7 +493,7 @@ export function enumerateVast(
     const annual = kwhPue * price;
     const pct = targetEffTb > 0 ? ((eff - targetEffTb) / targetEffTb) * 100 : 0;
     const rackUnits =
-      base.Rack_Units != null && expansion.Rack_Units != null
+      isValidNumber(base.Rack_Units) && isValidNumber(expansion.Rack_Units)
         ? base.Rack_Units + expQty * expansion.Rack_Units
         : null;
 
@@ -477,6 +513,15 @@ export function enumerateVast(
         dollarsPerEffectiveTbYear: eff > 0 ? annual / eff : null,
         kwhPerEffectiveTbYear: eff > 0 ? kwhPue / eff : null,
       });
+    }
+
+    if (targetEffTb > 0) {
+      if (eff > toleranceUpper) {
+        overToleranceSteps += 1;
+        if (overToleranceSteps >= maxOverToleranceSteps) break;
+      } else {
+        overToleranceSteps = 0;
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
- Prevent crashes and inconsistent behavior when Vast CSV data is missing or malformed by making enumeration safe and deterministic. 
- Normalize Vast CSV fields (notably `Auto_Default`) and preserve source metadata for later rendering. 
- Replace hardcoded expansion bounds with a data-driven stop condition to support large targets without infinite loops.

### Description
- Add `loadVast(rows: CsvRow[])` that mirrors `loadNetApp` but normalizes `Auto_Default` into a boolean and preserves `Source_URL`/`Notes` via the existing `CsvRow` shape, and add the `VastRow` typing change to expect `Auto_Default?: boolean`.
- Extend CSV typing to allow boolean values (`CsvRow` now permits `boolean`) so parsed/normalized fields can be booleans.
- Harden `enumerateVast` to never throw on missing Vast data by returning `[]` when rows are missing or required numeric fields are invalid, validate numeric fields with `Number.isFinite` and `>= 0`, and skip invalid rows.
- Remove unnecessary string->int conversions in `enumerateVast` for already-numeric fields and compute drives directly from parsed numeric fields.
- Replace hardcoded 0..40 expansion loop with a data-driven loop capped at `maxExpansionQty` (200) that breaks after `maxOverToleranceSteps` consecutive iterations where `effectiveTb` exceeds the upper tolerance bound.
- Wire `EnergyTool` to use `loadVast` when loading `/data/energy/vast_data.csv` and update Vast-related unit tests to add deterministic checks for expansion quantity, effective TB, weighted watts, kWh/year and annual cost, and to assert empty behavior for missing Vast rows.

### Testing
- Ran `npm test` in `ui/partner-hub`; most suites passed but one unrelated test failed: `account-mapping/match.test.ts` (expected "weak" but got "exact"), resulting in 37 passed / 1 failed tests. 
- Ran `npm run build` for the app and the Next.js production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69705af84ebc83309f44a53248840640)