### PR TITLE
Harden energy vendor switching & vendor-aware expansion labels

### DIFF
--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -476,41 +476,20 @@ export function EnergyTool() {
     if (competitorVendor === "Vast") {
       setMode("auto");
     }
+    setCandidates([]);
     setSelected(null);
     setManualCandidate(null);
+    setComputeError(null);
   }, [competitorVendor]);
 
   useEffect(() => {
     if (pureRows.length === 0) return;
-    const competitorData = competitorVendor === "Vast" ? vastRows : netappRows;
-    if (competitorData.length === 0) {
-      try {
-        setComputeError(null);
-        const fbResult = fbPower(
-          pureRows,
-          inputs.dfmTb,
-          inputs.capacityPb,
-          inputs.pureUtilPct / 100,
-          inputs.purePue,
-          inputs.purePrice,
-          inputs.pureDrr,
-        );
-        setFb(fbResult);
-        setCandidates([]);
-        setSelected(null);
-      } catch (err) {
-        setComputeError(err instanceof Error ? err.message : "Failed to compute results");
-        setFb(null);
-        setCandidates([]);
-        setSelected(null);
-      }
-      return;
-    }
     runModel();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [competitorVendor, netappRows.length, pureRows.length, vastRows.length]);
 
   useEffect(() => {
+    if (competitorVendor !== "NetApp") return;
     if (controllerModels.length === 0) return;
     const controllerModel = manualInputs.controllerModel || controllerModels[0];
     const controllerExpansionModels = getExpansionModels(netappCompat, controllerModel);
@@ -532,6 +511,7 @@ export function EnergyTool() {
     manualInputs.controllerModel,
     manualInputs.expansionModel,
     netappCompat,
+    competitorVendor,
   ]);
 
   useEffect(() => {
@@ -996,7 +976,7 @@ export function EnergyTool() {
                     </select>
                   </div>
                   <div className="space-y-1">
-                    <label className={LABEL_CLASSES}>Expansion shelf model</label>
+                    <label className={LABEL_CLASSES}>Expansion {expansionLabel} model</label>
                     <select
                       className={INPUT_BASE_CLASSES}
                       value={manualInputs.expansionModel}
@@ -1023,7 +1003,7 @@ export function EnergyTool() {
                     </select>
                   </div>
                   <NumberInput
-                    label="# of expansion shelves"
+                    label={`# of expansion ${expansionLabelPlural}`}
                     value={manualInputs.expansionQty}
                     step={1}
                     onChange={(value) =>


### PR DESCRIPTION
### Motivation
- Prevent stale NetApp candidates and errors when switching between NetApp and Vast by resetting competitor-specific state on vendor change. 
- Ensure recompute runs deterministically once per vendor/dataset change and that manual-mode behavior and validation remain NetApp-scoped. 
- Make expansion terminology vendor-aware so UI labels read “shelf/shelves” for NetApp and “unit/units” for Vast.

### Description
- Clear competitor-specific state on vendor switch by resetting `candidates`, `selected`, `manualCandidate`, and `computeError`, and force `mode` to `auto` for Vast. (file: `ui/partner-hub/components/energy/energy-tool.tsx`)
- Simplify the vendor/dataset recompute effect to always call `runModel()` when datasets are present and let `runModel()` handle the empty-data case and set `fb`/`candidates`/`selected` appropriately to avoid double/duplicate computes. 
- Scope NetApp manual defaults and updates to NetApp-only contexts with a guard `if (competitorVendor !== "NetApp") return;` and add `competitorVendor` to the effect dependencies to avoid cross-vendor contamination. 
- Replace hard-coded expansion labels with vendor-aware variables (`expansionLabel`, `expansionLabelPlural`, `expansionHeaderLabel`) and update manual UI labels to use them so NetApp shows “shelf/shelves” and Vast shows “unit/units”.

### Testing
- Attempted `npm run build`, but it could not be executed in this environment due to a missing `/workspace/accountlist/package.json` (build failed with ENOENT).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69705e28ba4c8330a52c85733f28826c)