### PR TITLE
Vendor-aware wording for Energy Tool (shelf vs unit)

### DIFF
--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -794,6 +794,12 @@ export function EnergyTool() {
   const expansionLabel = competitorVendor === "Vast" ? "unit" : "shelf";
   const expansionLabelPlural = competitorVendor === "Vast" ? "units" : "shelves";
   const expansionHeaderLabel = competitorVendor === "Vast" ? "Exp units" : "Exp shelves";
+  const expansionLabelFor = (qty: number) => (qty === 1 ? expansionLabel : expansionLabelPlural);
+  const selectedConfigLabel = selectedCandidate
+    ? `${selectedCandidate.controllerModel} + ${selectedCandidate.expansionQty} ${expansionLabelFor(
+        selectedCandidate.expansionQty,
+      )} (${selectedCandidate.expansionModel})`
+    : null;
 
   return (
     <div className="space-y-8 md:space-y-10">
@@ -1155,8 +1161,8 @@ export function EnergyTool() {
                     {candidates.length === 0 ? (
                       <p className="text-sm text-foreground/70">
                         {competitorVendor === "Vast"
-                          ? "No Vast candidates found."
-                          : `No candidates found in the tolerance band. Try widening tolerance or adjusting ${competitorLabel} overhead / DRR / drive size.`}
+                          ? `No Vast candidates found within ±${fmt1.format(inputs.tolPct)}%.`
+                          : `No NetApp candidates found within ±${fmt1.format(inputs.tolPct)}%.`}
                       </p>
                     ) : (
                       <div className="overflow-x-auto">
@@ -1206,7 +1212,9 @@ export function EnergyTool() {
                                       ) : null}
                                     </div>
                                   </td>
-                                  <td className="py-2 pr-3">{c.expansionQty}</td>
+                                  <td className="py-2 pr-3">
+                                    {c.expansionQty} {expansionLabelFor(c.expansionQty)}
+                                  </td>
                                   <td className="py-2 pr-3">{formatRackUnits(c.rackUnits)}</td>
                                   <td className="py-2 pr-3">{fmt0.format(c.effectiveTb)}</td>
                                   <td className="py-2 pr-3">{fmt2.format(c.pctDiffFromTarget)}%</td>
@@ -1247,8 +1255,7 @@ export function EnergyTool() {
               <CardTitle className="text-base">Comparison</CardTitle>
               {selectedCandidate ? (
                 <div className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
-                  SELECTED: {selectedCandidate.controllerModel} + {selectedCandidate.expansionQty}{" "}
-                  {selectedCandidate.expansionQty === 1 ? expansionLabel : expansionLabelPlural}
+                  SELECTED: {selectedConfigLabel}
                 </div>
               ) : null}
             </CardHeader>
@@ -1337,11 +1344,7 @@ export function EnergyTool() {
                     </li>
                     <li>
                       Selected config:{" "}
-                      {selectedCandidate
-                        ? `${selectedCandidate.controllerModel} + ${selectedCandidate.expansionQty} ${
-                            selectedCandidate.expansionQty === 1 ? expansionLabel : expansionLabelPlural
-                          } (${selectedCandidate.expansionModel})`
-                        : `No ${competitorLabel} candidate selected`}
+                      {selectedCandidate ? selectedConfigLabel : `No ${competitorLabel} candidate selected`}
                     </li>
                   </ul>
                   {competitorVendor === "Vast" ? (


### PR DESCRIPTION
### Motivation
- Ensure candidate rows, empty states and selected-config summaries use vendor-appropriate wording (NetApp: shelf/shelves; Vast: unit/units) and avoid mixed wording when switching vendors.

### Description
- Add `expansionLabelFor` helper and `selectedConfigLabel` to consistently pluralize and include expansion model in selection summaries and the assumptions panel.
- Render expansion counts in candidate rows as “N shelf(s)” or “N unit(s)” and update the comparison header to use the consolidated selected label.
- Update empty-state messages to be vendor-aware and include the tolerance (e.g. "No Vast candidates found within ±X%" / "No NetApp candidates found within ±X%").

### Testing
- Ran `npm run build` at repository root which failed due to missing `/workspace/accountlist/package.json` (expected in this environment).
- Ran `npm run build` inside `ui/partner-hub` and the Next.js production build completed successfully (pages compiled and static pages generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69706a373d3083309af7eb40da58d36e)