### PR TITLE
Add optional competitor overhead (W) input and apply to competitor energy calculations

### DIFF
--- a/ui/partner-hub/components/energy/energy-tool.tsx
+++ b/ui/partner-hub/components/energy/energy-tool.tsx
@@ -58,6 +58,7 @@ type Inputs = {
   naPue: number;
   naPrice: number;
   naOverhead: number;
+  competitorExtraWatts: number;
   naDrr: number;
   naDriveSizeTb: number;
   tolPct: number;
@@ -156,6 +157,7 @@ const defaults: Omit<Inputs, "dfmTb" | "capacityPb"> = {
   naPue: 1.35,
   naPrice: 0.12,
   naOverhead: 0.2,
+  competitorExtraWatts: 0,
   naDrr: 1.3,
   naDriveSizeTb: 18,
   tolPct: 10,
@@ -414,6 +416,7 @@ export function EnergyTool() {
               inputs.naPue,
               inputs.naPrice,
               inputs.naOverhead,
+              inputs.competitorExtraWatts,
               inputs.naDrr,
               inputs.naDriveSizeTb,
               tolFrac,
@@ -425,6 +428,7 @@ export function EnergyTool() {
               inputs.naPue,
               inputs.naPrice,
               inputs.naOverhead,
+              inputs.competitorExtraWatts,
               inputs.naDrr,
               inputs.naDriveSizeTb,
               tolFrac,
@@ -462,6 +466,7 @@ export function EnergyTool() {
         inputs.naPue,
         inputs.naPrice,
         inputs.naOverhead,
+        inputs.competitorExtraWatts,
         inputs.naDrr,
         inputs.naDriveSizeTb,
       );
@@ -537,6 +542,7 @@ export function EnergyTool() {
     inputs.naPue,
     inputs.naPrice,
     inputs.naOverhead,
+    inputs.competitorExtraWatts,
     inputs.naDrr,
     inputs.naDriveSizeTb,
     netappRows.length,
@@ -924,6 +930,13 @@ export function EnergyTool() {
               <NumberInput label="PUE" value={inputs.naPue} step={0.01} onChange={(v) => setInputs((p) => ({ ...p, naPue: v }))} />
               <NumberInput label="$ / kWh" value={inputs.naPrice} step={0.001} onChange={(v) => setInputs((p) => ({ ...p, naPrice: v }))} />
               <NumberInput label="Overhead (raw→usable)" value={inputs.naOverhead} step={0.01} onChange={(v) => setInputs((p) => ({ ...p, naOverhead: v }))} />
+              <NumberInput
+                label="Extra overhead (W)"
+                helperText="Optional: networking / non-modeled hardware"
+                value={inputs.competitorExtraWatts}
+                step={1}
+                onChange={(v) => setInputs((p) => ({ ...p, competitorExtraWatts: v }))}
+              />
               <NumberInput label="DRR" value={inputs.naDrr} step={0.1} onChange={(v) => setInputs((p) => ({ ...p, naDrr: v }))} />
               <div className="space-y-1">
                 <label className={LABEL_CLASSES}>Drive size (TB)</label>
@@ -1333,6 +1346,7 @@ export function EnergyTool() {
                     <li>PUE: {fmt2.format(inputs.naPue)}</li>
                     <li>$ / kWh: ${fmt2.format(inputs.naPrice)}</li>
                     <li>Overhead (raw→usable): {fmt2.format(inputs.naOverhead)}</li>
+                    <li>Extra overhead: {fmt0.format(inputs.competitorExtraWatts)} W</li>
                     <li>DRR: {fmt2.format(inputs.naDrr)}</li>
                     <li>
                       Drive size selection: {fmt0.format(inputs.naDriveSizeTb)} TB{" "}
@@ -1515,11 +1529,13 @@ function NumberInput({
   value,
   onChange,
   step,
+  helperText,
 }: {
   label: string;
   value: number;
   step?: number;
   onChange: (value: number) => void;
+  helperText?: string;
 }) {
   return (
     <div className="space-y-1">
@@ -1531,6 +1547,7 @@ function NumberInput({
         onChange={(e) => onChange(Number(e.target.value))}
         className={INPUT_BASE_CLASSES}
       />
+      {helperText ? <p className="text-xs text-foreground/60">{helperText}</p> : null}
     </div>
   );
 }

--- a/ui/partner-hub/lib/energy/energy-calc.test.ts
+++ b/ui/partner-hub/lib/energy/energy-calc.test.ts
@@ -129,7 +129,19 @@ describe("fbPower", () => {
 
 describe("NetApp candidates", () => {
   it("computes rack units in buildNetAppCandidate", () => {
-    const candidate = buildNetAppCandidate(makeNetAppRows(), "C1", "DE460C 60-bay", 2, 0.5, 1.2, 0.1, 0.2, 1.3, 18);
+    const candidate = buildNetAppCandidate(
+      makeNetAppRows(),
+      "C1",
+      "DE460C 60-bay",
+      2,
+      0.5,
+      1.2,
+      0.1,
+      0.2,
+      0,
+      1.3,
+      18,
+    );
 
     assert.equal(candidate.rackUnits, 12);
     assert.ok(Math.abs(candidate.weightedW - 375) < 1e-6);
@@ -141,14 +153,26 @@ describe("NetApp candidates", () => {
   it("returns null rack units when any NetApp RU input is missing", () => {
     const rows = makeNetAppRows();
     rows[0] = { ...rows[0], Rack_Units: null };
-    const candidate = buildNetAppCandidate(rows, "C1", "DE460C 60-bay", 2, 0.5, 1.2, 0.1, 0.2, 1.3, 18);
+    const candidate = buildNetAppCandidate(
+      rows,
+      "C1",
+      "DE460C 60-bay",
+      2,
+      0.5,
+      1.2,
+      0.1,
+      0.2,
+      0,
+      1.3,
+      18,
+    );
     assert.equal(candidate.rackUnits, null);
     assert.ok(Math.abs(candidate.weightedW - 375) < 1e-6);
   });
 
   it("computes rack units in enumerateNetApp", () => {
     const targetEffTb = 2695.68;
-    const candidates = enumerateNetApp(makeNetAppRows(), targetEffTb, 0.5, 1.2, 0.1, 0.2, 1.3, 18, 0.5);
+    const candidates = enumerateNetApp(makeNetAppRows(), targetEffTb, 0.5, 1.2, 0.1, 0.2, 0, 1.3, 18, 0.5);
     const match = candidates.find((candidate) => candidate.expansionQty === 2);
 
     assert.ok(match);
@@ -161,14 +185,14 @@ describe("NetApp candidates", () => {
 
 describe("Vast candidates", () => {
   it("returns empty when Vast rows are missing", () => {
-    const candidates = enumerateVast([], 100, 0.5, 1.2, 0.1, 0.1, 1, 10, 0.05);
+    const candidates = enumerateVast([], 100, 0.5, 1.2, 0.1, 0.1, 0, 1, 10, 0.05);
     assert.deepEqual(candidates, []);
   });
 
   it("returns the expected candidate within tolerance", () => {
     const targetEffTb = 432;
     const tolFrac = 0.02;
-    const candidates = enumerateVast(makeVastRows(), targetEffTb, 0.5, 1.2, 0.1, 0.1, 1, 10, tolFrac);
+    const candidates = enumerateVast(makeVastRows(), targetEffTb, 0.5, 1.2, 0.1, 0.1, 0, 1, 10, tolFrac);
 
     assert.ok(candidates.length > 0);
     const maxPct = Math.max(...candidates.map((candidate) => Math.abs(candidate.pctDiffFromTarget)));

--- a/ui/partner-hub/lib/energy/energy-calc.ts
+++ b/ui/partner-hub/lib/energy/energy-calc.ts
@@ -335,6 +335,7 @@ export function buildNetAppCandidate(
   pue: number,
   price: number,
   overhead: number,
+  extraWatts: number,
   drr: number,
   driveTb: number,
 ): NetAppCandidate {
@@ -351,7 +352,7 @@ export function buildNetAppCandidate(
   const usable = raw * (1 - overhead);
   const eff = usable * drr;
 
-  const w = ctrlWeighted(util) + expansionQty * exp.weightedW(util);
+  const w = ctrlWeighted(util) + expansionQty * exp.weightedW(util) + extraWatts;
   const kwhPue = kwhYear(w) * pue;
   const annual = kwhPue * price;
   const rackUnits =
@@ -381,6 +382,7 @@ export function enumerateNetApp(
   pue: number,
   price: number,
   overhead: number,
+  extraWatts: number,
   drr: number,
   driveTb: number,
   tolFrac = 0.1,
@@ -402,7 +404,7 @@ export function enumerateNetApp(
       const usable = raw * (1 - overhead);
       const eff = usable * drr;
 
-      const w = ctrlWeighted(util) + expQty * exp.weightedW(util);
+      const w = ctrlWeighted(util) + expQty * exp.weightedW(util) + extraWatts;
       const kwhPue = kwhYear(w) * pue;
       const annual = kwhPue * price;
       const pct = targetEffTb > 0 ? ((eff - targetEffTb) / targetEffTb) * 100 : 0;
@@ -445,6 +447,7 @@ export function enumerateVast(
   pue: number,
   price: number,
   overhead: number,
+  extraWatts: number,
   drr: number,
   driveTb: number,
   tolFrac = 0.1,
@@ -488,7 +491,7 @@ export function enumerateVast(
     const usable = raw * (1 - overhead);
     const eff = usable * drr;
 
-    const w = baseWeighted(util) + expQty * expWeighted(util);
+    const w = baseWeighted(util) + expQty * expWeighted(util) + extraWatts;
     const kwhPue = kwhYear(w) * pue;
     const annual = kwhPue * price;
     const pct = targetEffTb > 0 ? ((eff - targetEffTb) / targetEffTb) * 100 : 0;


### PR DESCRIPTION
### Motivation
- Provide an optional, transparent way to add non-modeled competitor overhead watts (networking / other) so competitor kWh/cost comparisons can be adjusted without claiming vendor switch power.

### Description
- Add a new numeric input `competitorExtraWatts` (default 0) to the UI under the competitor baseline with label `Extra overhead (W)` and helper text `Optional: networking / non-modeled hardware` and surface it in the assumptions panel. 
- Thread `competitorExtraWatts` through the model runs and manual-apply flows in `EnergyTool` and pass it into candidate builders/enumerators. 
- Update calculation functions `buildNetAppCandidate`, `enumerateNetApp`, and `enumerateVast` to accept an `extraWatts` parameter and add that value to `weightedW` before computing `kWh`, `annualCost`, and per‑TB derived metrics. 
- Add an optional `helperText` prop to `NumberInput` and update `ui/partner-hub/lib/energy/energy-calc.test.ts` to include the new parameter in test calls.

### Testing
- Ran `npm run build` in `ui/partner-hub` and the production build completed successfully. 
- Unit test file `ui/partner-hub/lib/energy/energy-calc.test.ts` was updated to accommodate the new parameter and the project compiled cleanly as part of the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69706b8bace08330a8ead816525e4867)