### PR TITLE
Restyle Office Schedule UI with coastal theme

### DIFF
--- a/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
+++ b/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
@@ -334,7 +334,7 @@ function computeDaySlots({
 
 function DurationChips({ value, onChange }: { value: number; onChange: (v: number) => void }) {
   return (
-    <div className="inline-flex rounded-xl border border-border/70 bg-muted/30 p-1">
+    <div className="inline-flex rounded-full border border-slate-200/80 bg-slate-100/70 p-1 shadow-sm">
       {DURATIONS_MIN.map((d) => {
         const active = d === value;
         return (
@@ -343,10 +343,10 @@ function DurationChips({ value, onChange }: { value: number; onChange: (v: numbe
             type="button"
             onClick={() => onChange(d)}
             className={
-              "rounded-lg px-3 py-2 text-sm font-semibold transition " +
+              "rounded-full px-3 py-2 text-sm font-semibold transition " +
               (active
-                ? "bg-background text-foreground shadow-sm"
-                : "text-foreground/70 hover:bg-muted/40")
+                ? "bg-white text-slate-700 shadow-sm"
+                : "text-slate-500 hover:bg-white/80")
             }
             aria-pressed={active}
           >
@@ -379,16 +379,16 @@ function Modal({
     >
       <button
         type="button"
-        className="absolute inset-0 bg-black/30"
+        className="absolute inset-0 bg-slate-900/30 backdrop-blur-sm"
         onClick={onClose}
         aria-label="Close modal"
       />
-      <div className="relative w-[92vw] max-w-lg rounded-2xl border border-border/70 bg-background shadow-lg">
-        <div className="flex items-center justify-between border-b border-border/70 p-4">
-          <div className="text-sm font-semibold">{title}</div>
+      <div className="relative w-[92vw] max-w-lg rounded-3xl border border-white/70 bg-white/90 shadow-lg backdrop-blur">
+        <div className="flex items-center justify-between border-b border-slate-200/70 p-4">
+          <div className="text-sm font-semibold text-slate-800">{title}</div>
           <button
             type="button"
-            className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border/70 bg-background/80 transition hover:bg-muted"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200/80 bg-white text-slate-600 transition hover:bg-slate-50"
             onClick={onClose}
             aria-label="Close"
           >
@@ -1382,10 +1382,12 @@ export function OfficeScheduleClient({
 
   if (offices.length === 0) {
     return (
-      <main className="mx-auto max-w-5xl p-6">
-        <div className="rounded-2xl border border-border/70 bg-background p-6">
-          <h1 className="text-xl font-semibold">Office Schedule</h1>
-          <p className="mt-1 text-sm text-foreground/70">No offices found. Seed offices using Prisma Studio.</p>
+      <main className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-sky-50">
+        <div className="mx-auto max-w-5xl px-6 py-16">
+          <div className="rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-sm backdrop-blur">
+            <h1 className="text-xl font-semibold text-slate-900">Office Schedule</h1>
+            <p className="mt-1 text-sm text-slate-600">No offices found. Seed offices using Prisma Studio.</p>
+          </div>
         </div>
       </main>
     );
@@ -1393,47 +1395,96 @@ export function OfficeScheduleClient({
 
   const locked = !unlocked;
   return (
-    <main className="mx-auto max-w-6xl p-6">
-      {/* Top bar */}
-      <div className="mb-4 flex flex-wrap items-center justify-end gap-3">
-        <div className="flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            className="inline-flex h-10 items-center gap-2 rounded-xl border border-border/70 bg-background px-4 text-sm font-semibold transition hover:bg-muted"
-            onClick={() => setUserModalOpen(true)}
-          >
-            <UserRound className="h-4 w-4 text-foreground/60" />
-            User information
-          </button>
+    <main className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-sky-50">
+      <div className="mx-auto flex max-w-6xl flex-col gap-8 px-6 pb-16 pt-10 lg:px-10">
+        <section className="rounded-3xl border border-white/70 bg-white/70 p-8 shadow-sm backdrop-blur">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Office Booking</p>
+          <h1 className="mt-3 text-3xl font-semibold text-slate-900 sm:text-4xl">Office Schedule</h1>
+          <p className="mt-2 max-w-2xl text-base text-slate-600">
+            Pick a day, select an office, book your time.
+          </p>
+          <div className="mt-6 h-px w-full bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
+        </section>
 
-          <button
-            type="button"
-            className={
-              "inline-flex h-10 items-center gap-2 rounded-xl border border-border/70 bg-background px-4 text-sm font-semibold transition hover:bg-muted " +
-              (unlocked ? "" : "opacity-50")
-            }
-            onClick={() => setMyScheduleOpen(true)}
-            disabled={!unlocked}
+        <div className="-mt-10">
+          <svg
+            viewBox="0 0 1200 120"
+            preserveAspectRatio="none"
+            className="h-16 w-full text-sky-100"
+            aria-hidden
           >
-            <CalendarDays className="h-4 w-4 text-foreground/60" />
-            My Office Schedule
-          </button>
+            <path
+              d="M0,96L60,90.7C120,85,240,75,360,69.3C480,64,600,64,720,58.7C840,53,960,43,1080,42.7C1200,43,1320,53,1380,58.7L1440,64L1440,0L1380,0C1320,0,1200,0,1080,0C960,0,840,0,720,0C600,0,480,0,360,0C240,0,120,0,60,0L0,0Z"
+              className="fill-current"
+            />
+          </svg>
         </div>
-      </div>
 
-      <div className="relative rounded-2xl border border-border/70 bg-background shadow-sm">
+        <section className="grid gap-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Coastal Moments</h2>
+            <span className="text-xs text-slate-500">A calming backdrop for your planning</span>
+          </div>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+            {[
+              "from-sky-100 via-white to-amber-100",
+              "from-slate-100 via-white to-sky-100",
+              "from-amber-100 via-white to-sky-100",
+              "from-sky-50 via-white to-slate-100",
+              "from-slate-100 via-white to-amber-50",
+              "from-sky-100 via-white to-slate-50",
+            ].map((gradient, index) => (
+              <div
+                key={`${gradient}-${index}`}
+                className={`aspect-[4/3] rounded-2xl border border-white/70 bg-gradient-to-br ${gradient} shadow-sm`}
+                aria-hidden
+              />
+            ))}
+          </div>
+          <div className="h-px w-full bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
+        </section>
+
+        {/* Top bar */}
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-white/70 bg-white/80 p-4 shadow-sm backdrop-blur">
+          <div className="text-sm font-semibold text-slate-600">Manage your schedule</div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              className="inline-flex h-10 items-center gap-2 rounded-full border border-slate-200/80 bg-white px-4 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50"
+              onClick={() => setUserModalOpen(true)}
+            >
+              <UserRound className="h-4 w-4 text-slate-500" />
+              User information
+            </button>
+
+            <button
+              type="button"
+              className={
+                "inline-flex h-10 items-center gap-2 rounded-full border border-slate-200/80 bg-white px-4 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 " +
+                (unlocked ? "" : "opacity-50")
+              }
+              onClick={() => setMyScheduleOpen(true)}
+              disabled={!unlocked}
+            >
+              <CalendarDays className="h-4 w-4 text-slate-500" />
+              My Office Schedule
+            </button>
+          </div>
+        </div>
+
+        <div className="relative rounded-3xl border border-white/70 bg-white/80 shadow-sm backdrop-blur">
         {/* Lock overlay */}
         {locked ? (
-          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-background/50 backdrop-blur-sm">
-            <div className="mx-auto max-w-md rounded-2xl border border-border/70 bg-background p-5 text-center shadow-sm">
-              <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full border border-border/70 bg-muted/30">
-                <UserRound className="h-5 w-5 text-foreground/70" />
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-3xl bg-white/70 backdrop-blur-sm">
+            <div className="mx-auto max-w-md rounded-3xl border border-slate-200/70 bg-white/90 p-6 text-center shadow-sm">
+              <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full border border-slate-200/70 bg-slate-50">
+                <UserRound className="h-5 w-5 text-slate-500" />
               </div>
-              <div className="mt-3 text-sm font-semibold">Add your user information to schedule</div>
-              <div className="mt-1 text-sm text-foreground/70">Name + email are required (no login yet).</div>
+              <div className="mt-3 text-sm font-semibold text-slate-800">Add your user information to schedule</div>
+              <div className="mt-1 text-sm text-slate-600">Name + email are required (no login yet).</div>
               <button
                 type="button"
-                className="mt-4 inline-flex h-10 items-center justify-center rounded-xl border border-border/70 bg-foreground px-4 text-sm font-semibold text-background transition hover:opacity-90"
+                className="mt-4 inline-flex h-10 items-center justify-center rounded-full border border-sky-200 bg-sky-600 px-4 text-sm font-semibold text-white transition hover:bg-sky-500"
                 onClick={() => setUserModalOpen(true)}
               >
                 Enter user information
@@ -1447,26 +1498,26 @@ export function OfficeScheduleClient({
             {/* Left panel */}
             <section className="p-6">
               <div className="flex flex-wrap items-center justify-between gap-3">
-                <h1 className="text-2xl font-semibold tracking-tight">Schedule a time</h1>
+                <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Schedule a time</h1>
                 <button
                   type="button"
-                  className="inline-flex h-9 items-center gap-2 rounded-xl border border-border/70 bg-background px-3 text-xs font-semibold transition hover:bg-muted"
+                  className="inline-flex h-9 items-center gap-2 rounded-full border border-slate-200/80 bg-white px-3 text-xs font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50"
                   onClick={() => setAiOpen(true)}
                 >
-                  <Sparkles className="h-4 w-4 text-foreground/60" />
+                  <Sparkles className="h-4 w-4 text-slate-500" />
                   Use AI
                 </button>
               </div>
 
               {selectedOffice?.description ? (
-                <p className="mt-3 text-sm text-foreground/70 line-clamp-4">{selectedOffice.description}</p>
+                <p className="mt-3 text-sm text-slate-600 line-clamp-4">{selectedOffice.description}</p>
               ) : (
-                <p className="mt-3 text-sm text-foreground/70">Choose a duration, then pick a day and time.</p>
+                <p className="mt-3 text-sm text-slate-600">Choose a duration, then pick a day and time.</p>
               )}
 
               <div className="mt-6">
-                <div className="flex items-center gap-2 text-sm font-semibold">
-                  <Clock className="h-4 w-4 text-foreground/60" />
+                <div className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+                  <Clock className="h-4 w-4 text-slate-500" />
                   Duration
                 </div>
                 <div className="mt-3">
@@ -1478,20 +1529,20 @@ export function OfficeScheduleClient({
                     }}
                   />
                 </div>
-                <div className="mt-2 text-xs text-foreground/60">Time slots show in {durationMin} minute increments.</div>
+                <div className="mt-2 text-xs text-slate-500">Time slots show in {durationMin} minute increments.</div>
               </div>
 
               <div className="mt-6 grid gap-3">
-                <div className="flex items-center gap-2 text-sm text-foreground/80">
-                  <Building2 className="h-4 w-4 text-foreground/60" />
+                <div className="flex items-center gap-2 text-sm text-slate-600">
+                  <Building2 className="h-4 w-4 text-slate-500" />
                   <div className="min-w-0">
-                    <div className="font-semibold">Office</div>
-                    <div className="text-xs text-foreground/60">Choose an office to book</div>
+                    <div className="font-semibold text-slate-700">Office</div>
+                    <div className="text-xs text-slate-500">Choose an office to book</div>
                   </div>
                 </div>
 
                 <select
-                  className="h-10 w-full rounded-md border border-border/70 bg-background px-3 text-sm"
+                  className="h-11 w-full rounded-xl border border-slate-200/80 bg-white px-3 text-sm text-slate-700 shadow-sm"
                   value={officeId}
                   onChange={(e) => {
                     const next = Number(e.target.value);
@@ -1510,7 +1561,7 @@ export function OfficeScheduleClient({
             </section>
 
             {/* Right panel */}
-            <section className="border-t border-border/70 p-6 md:border-l md:border-t-0">
+            <section className="border-t border-slate-200/70 p-6 md:border-l md:border-t-0">
               {/*
                 Layout note:
                 On large screens, the selected-day header (e.g. "Mon, Jan 19" + availability counts)
@@ -1520,11 +1571,11 @@ export function OfficeScheduleClient({
               */}
               <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1fr_260px] lg:items-start">
                 <div className="flex items-center gap-2">
-                  <div className="text-lg font-semibold">{formatMonthLabel(monthFirst)}</div>
+                  <div className="text-lg font-semibold text-slate-800">{formatMonthLabel(monthFirst)}</div>
                   <div className="flex items-center gap-1">
                     <button
                       type="button"
-                      className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border/70 bg-background/80 transition hover:bg-muted"
+                      className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-slate-200/80 bg-white text-slate-600 transition hover:bg-slate-50"
                       onClick={() => {
                         const prev = new Date(monthFirst);
                         prev.setMonth(prev.getMonth() - 1);
@@ -1539,7 +1590,7 @@ export function OfficeScheduleClient({
                     </button>
                     <button
                       type="button"
-                      className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border/70 bg-background/80 transition hover:bg-muted"
+                      className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-slate-200/80 bg-white text-slate-600 transition hover:bg-slate-50"
                       onClick={() => {
                         const next = new Date(monthFirst);
                         next.setMonth(next.getMonth() + 1);
@@ -1557,8 +1608,8 @@ export function OfficeScheduleClient({
 
                 {/* Desktop-aligned selected-day header */}
                 <div className="hidden lg:block">
-                  <div className="text-sm font-semibold">{formatDayLabel(baseDate)}</div>
-                  <div className="mt-1 text-xs text-foreground/60">
+                  <div className="text-sm font-semibold text-slate-700">{formatDayLabel(baseDate)}</div>
+                  <div className="mt-1 text-xs text-slate-500">
                     {selectedDayAvailableCount === 0
                       ? "No available times. Try another day."
                       : `${selectedDayAvailableCount} available • ${selectedDaySlots.length - selectedDayAvailableCount} unavailable`}
@@ -1568,7 +1619,7 @@ export function OfficeScheduleClient({
 
               <div className="mt-4 grid grid-cols-1 gap-6 lg:grid-cols-[1fr_260px] lg:items-start">
                 <div>
-                  <div className="grid grid-cols-7 gap-2 text-[11px] font-semibold uppercase tracking-wide text-foreground/60">
+                  <div className="grid grid-cols-7 gap-2 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
                     {["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"].map((d) => (
                       <div key={d} className="text-center">
                         {d}
@@ -1593,17 +1644,17 @@ export function OfficeScheduleClient({
                       }
 
                       const baseCls =
-                        "relative flex h-12 w-full items-center justify-center rounded-xl text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-primary/30";
+                        "relative flex h-12 w-full items-center justify-center rounded-2xl text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-sky-200";
 
                       const enabled = !isPastDay && hasAvailability;
                       const cls =
                         baseCls +
                         " " +
                         (selected
-                          ? "bg-foreground text-background"
+                          ? "bg-sky-600 text-white"
                           : enabled
-                            ? "bg-muted/40 text-foreground hover:bg-muted/60"
-                            : "text-foreground/40");
+                            ? "bg-slate-100 text-slate-700 hover:bg-slate-200/70"
+                            : "text-slate-300");
 
                       return (
                         <button
@@ -1628,7 +1679,7 @@ export function OfficeScheduleClient({
                             <span
                               className={
                                 "absolute bottom-1 left-1/2 h-1.5 w-1.5 -translate-x-1/2 rounded-full " +
-                                (selected ? "bg-background" : "bg-foreground/70")
+                                (selected ? "bg-white" : "bg-slate-400")
                               }
                               aria-hidden
                             />
@@ -1637,7 +1688,7 @@ export function OfficeScheduleClient({
                             <span
                               className={
                                 "absolute top-1 left-1/2 h-1 w-6 -translate-x-1/2 rounded-full " +
-                                (selected ? "bg-background/80" : "bg-primary/60")
+                                (selected ? "bg-white/80" : "bg-sky-300")
                               }
                               aria-hidden
                             />
@@ -1647,7 +1698,7 @@ export function OfficeScheduleClient({
                     })}
                   </div>
 
-                  <div className="mt-4 text-xs text-foreground/60">
+                  <div className="mt-4 text-xs text-slate-500">
                     Working hours: {formatTime(new Date(new Date(baseDate).setMinutes(WORK_START_MIN)))} –{" "}
                     {formatTime(new Date(new Date(baseDate).setMinutes(WORK_END_MIN)))}.
                   </div>
@@ -1657,8 +1708,8 @@ export function OfficeScheduleClient({
                 <aside className="flex flex-col">
                   {/* Mobile-only selected-day header (desktop version is aligned with the month header above). */}
                   <div className="lg:hidden">
-                    <div className="text-sm font-semibold">{formatDayLabel(baseDate)}</div>
-                    <div className="mt-1 text-xs text-foreground/60">
+                    <div className="text-sm font-semibold text-slate-700">{formatDayLabel(baseDate)}</div>
+                    <div className="mt-1 text-xs text-slate-500">
                       {selectedDayAvailableCount === 0
                         ? "No available times. Try another day."
                         : `${selectedDayAvailableCount} available • ${selectedDaySlots.length - selectedDayAvailableCount} unavailable`}
@@ -1669,10 +1720,10 @@ export function OfficeScheduleClient({
                     <button
                       type="button"
                       className={
-                        "h-9 rounded-md border border-border/70 px-3 text-xs font-semibold transition " +
+                        "h-9 rounded-full border border-slate-200/80 px-3 text-xs font-semibold text-slate-600 transition " +
                         (bookAllDay
-                          ? "bg-foreground text-background"
-                          : "bg-background hover:bg-muted/40")
+                          ? "bg-sky-600 text-white"
+                          : "bg-white hover:bg-slate-50")
                       }
                       onClick={() => {
                         if (!canAllDay.ok) return;
@@ -1689,7 +1740,7 @@ export function OfficeScheduleClient({
                     {(bookAllDay || selectedSlotStarts.length > 0) ? (
                       <button
                         type="button"
-                        className="h-9 rounded-md border border-border/70 bg-background px-3 text-xs font-semibold transition hover:bg-muted/40"
+                        className="h-9 rounded-full border border-slate-200/80 bg-white px-3 text-xs font-semibold text-slate-600 transition hover:bg-slate-50"
                         onClick={() => {
                           setBookAllDay(false);
                           setSelectedSlotStarts([]);
@@ -1700,11 +1751,11 @@ export function OfficeScheduleClient({
                         Clear
                       </button>
                     ) : (
-                      <div className="text-[11px] text-foreground/60">Select one or more slots</div>
+                      <div className="text-[11px] text-slate-500">Select one or more slots</div>
                     )}
                   </div>
 
-                  <div className="mt-3 max-h-[360px] overflow-auto rounded-lg border border-border/70 bg-background">
+                  <div className="mt-3 max-h-[360px] overflow-auto rounded-2xl border border-slate-200/80 bg-white shadow-sm">
                     <div className="grid gap-1 p-2">
                       {selectedDaySlots.map((slot) => {
                         const iso = slot.start.toISOString();
@@ -1722,12 +1773,12 @@ export function OfficeScheduleClient({
                               : "Past";
 
                         const cls =
-                          "flex h-10 w-full items-center justify-between rounded-md border px-3 text-sm font-semibold transition " +
+                          "flex h-10 w-full items-center justify-between rounded-xl border px-3 text-sm font-semibold transition " +
                           (selected
-                            ? "border-foreground bg-foreground text-background"
+                            ? "border-sky-200 bg-sky-600 text-white"
                             : clickable
-                              ? "border-border/70 bg-background hover:bg-muted/40"
-                              : "border-border/50 bg-muted/20 text-foreground/50");
+                              ? "border-slate-200/80 bg-white text-slate-700 hover:bg-slate-50"
+                              : "border-slate-200/60 bg-slate-50 text-slate-300");
 
                         return (
                           <button
@@ -1745,15 +1796,15 @@ export function OfficeScheduleClient({
                             aria-pressed={selected}
                           >
                             <span>{label}</span>
-                            <span className={selected ? "text-background/80" : "text-foreground/60"}>{right}</span>
+                            <span className={selected ? "text-white/80" : "text-slate-400"}>{right}</span>
                           </button>
                         );
                       })}
                     </div>
                   </div>
 
-                  <div className="mt-3 rounded-lg border border-border/70 bg-background p-3">
-                    <div className="text-xs text-foreground/70">
+                  <div className="mt-3 rounded-2xl border border-slate-200/80 bg-white p-4 shadow-sm">
+                    <div className="text-xs text-slate-600">
                       <span className="font-semibold">Selection:</span>{" "}
                       {selectionSummary.ok ? selectionSummary.label : selectionSummary.error}
                     </div>
@@ -1768,10 +1819,10 @@ export function OfficeScheduleClient({
                     <button
                       type="button"
                       className={
-                        "mt-3 h-10 w-full rounded-md border border-border/70 px-3 text-sm font-semibold transition " +
+                        "mt-3 h-10 w-full rounded-full border border-sky-200 px-3 text-sm font-semibold transition " +
                         (selectionSummary.ok && !bookingSubmitting
-                          ? "bg-foreground text-background hover:opacity-90"
-                          : "bg-muted/30 text-foreground/50")
+                          ? "bg-sky-600 text-white hover:bg-sky-500"
+                          : "bg-slate-100 text-slate-400")
                       }
                       onClick={submitBooking}
                       disabled={!selectionSummary.ok || bookingSubmitting}
@@ -1809,13 +1860,13 @@ export function OfficeScheduleClient({
         onClose={() => setMyScheduleOpen(false)}
       >
         {!unlocked ? (
-          <div className="text-sm text-foreground/70">Add your user information first.</div>
+          <div className="text-sm text-slate-600">Add your user information first.</div>
         ) : myBookingsLoading ? (
-          <div className="text-sm text-foreground/70">Loading…</div>
+          <div className="text-sm text-slate-600">Loading…</div>
         ) : myBookingsError ? (
           <div className="text-sm font-semibold text-red-600">{myBookingsError}</div>
         ) : myBookings.length === 0 ? (
-          <div className="text-sm text-foreground/70">No bookings found for {user?.email}.</div>
+          <div className="text-sm text-slate-600">No bookings found for {user?.email}.</div>
         ) : (
           <div className="grid gap-2">
             {myBookings
@@ -1826,9 +1877,9 @@ export function OfficeScheduleClient({
                 const e = new Date(b.end);
                 const officeName = officeNameById.get(b.officeId) ?? `Office #${b.officeId}`;
                 return (
-                  <div key={b.id} className="rounded-xl border border-border/70 bg-muted/20 p-3">
-                    <div className="text-sm font-semibold">{officeName}</div>
-                    <div className="mt-1 text-xs text-foreground/70">
+                  <div key={b.id} className="rounded-2xl border border-slate-200/80 bg-slate-50 p-3">
+                    <div className="text-sm font-semibold text-slate-800">{officeName}</div>
+                    <div className="mt-1 text-xs text-slate-500">
                       {new Intl.DateTimeFormat(undefined, {
                         weekday: "short",
                         month: "short",
@@ -1836,7 +1887,7 @@ export function OfficeScheduleClient({
                         year: "numeric",
                       }).format(s)}
                     </div>
-                    <div className="mt-1 text-xs text-foreground/70">
+                    <div className="mt-1 text-xs text-slate-500">
                       {formatTime(s)} – {formatTime(e)}
                     </div>
                   </div>
@@ -1853,23 +1904,23 @@ export function OfficeScheduleClient({
               <div
                 key={`${msg.role}-${idx}`}
                 className={
-                  "rounded-lg px-3 py-2 text-sm " +
+                  "rounded-2xl px-3 py-2 text-sm " +
                   (msg.role === "assistant"
-                    ? "bg-muted/40 text-foreground"
-                    : "bg-foreground text-background")
+                    ? "bg-slate-100 text-slate-700"
+                    : "bg-sky-600 text-white")
                 }
               >
                 {msg.content}
               </div>
             ))}
-            {aiLoading ? <div className="text-xs text-foreground/60">Thinking…</div> : null}
+            {aiLoading ? <div className="text-xs text-slate-500">Thinking…</div> : null}
           </div>
 
           {aiError ? <div className="text-xs font-semibold text-red-600">{aiError}</div> : null}
 
           {aiOptions.length > 0 ? (
             <div className="grid gap-2">
-              <div className="text-xs font-semibold text-foreground/70">Suggested options</div>
+              <div className="text-xs font-semibold text-slate-500">Suggested options</div>
               {aiOptions.map((option, idx) => {
                 const selected = aiSelectedOption?.startISO === option.startISO;
                 return (
@@ -1881,10 +1932,10 @@ export function OfficeScheduleClient({
                       setAiStep("confirm");
                     }}
                     className={
-                      "flex w-full items-center gap-2 rounded-lg border border-border/70 px-3 py-2 text-left text-sm transition " +
+                      "flex w-full items-center gap-2 rounded-2xl border border-slate-200/80 px-3 py-2 text-left text-sm transition " +
                       (selected
-                        ? "bg-foreground text-background"
-                        : "bg-background text-foreground hover:bg-muted/30")
+                        ? "bg-sky-600 text-white"
+                        : "bg-white text-slate-700 hover:bg-slate-50")
                     }
                     aria-pressed={selected}
                   >
@@ -1897,9 +1948,9 @@ export function OfficeScheduleClient({
           ) : null}
 
           {aiSelectedOption ? (
-            <div className="rounded-lg border border-border/70 bg-muted/20 p-3">
-              <div className="text-xs text-foreground/70">Selected option</div>
-              <div className="mt-1 text-sm font-semibold">{aiSelectedOption.label}</div>
+            <div className="rounded-2xl border border-slate-200/80 bg-slate-50 p-3">
+              <div className="text-xs text-slate-500">Selected option</div>
+              <div className="mt-1 text-sm font-semibold text-slate-800">{aiSelectedOption.label}</div>
               {aiBookingSuccess ? (
                 <div className="mt-2 text-xs font-semibold text-emerald-700">{aiBookingSuccess}</div>
               ) : null}
@@ -1907,14 +1958,14 @@ export function OfficeScheduleClient({
                 <div className="mt-3 grid gap-2">
                   <button
                     type="button"
-                    className="h-10 w-full rounded-md border border-border/70 bg-foreground px-3 text-sm font-semibold text-background transition hover:opacity-90"
+                    className="h-10 w-full rounded-full border border-sky-200 bg-sky-600 px-3 text-sm font-semibold text-white transition hover:bg-sky-500"
                     onClick={handleAiExit}
                   >
                     Exit
                   </button>
                   <button
                     type="button"
-                    className="text-sm font-semibold text-foreground/70 transition hover:text-foreground"
+                    className="text-sm font-semibold text-slate-500 transition hover:text-slate-700"
                     onClick={() => {
                       // Guardrail: reset the AI booking flow after success so the confirm button never reappears.
                       resetAiFlow();
@@ -1927,10 +1978,10 @@ export function OfficeScheduleClient({
                 <button
                   type="button"
                   className={
-                    "mt-3 h-10 w-full rounded-md border border-border/70 px-3 text-sm font-semibold transition " +
+                    "mt-3 h-10 w-full rounded-full border border-sky-200 px-3 text-sm font-semibold transition " +
                     (aiBookingSubmitting
-                      ? "bg-muted/30 text-foreground/50"
-                      : "bg-foreground text-background hover:opacity-90")
+                      ? "bg-slate-100 text-slate-400"
+                      : "bg-sky-600 text-white hover:bg-sky-500")
                   }
                   onClick={() => submitAiBooking(aiSelectedOption)}
                   disabled={aiBookingSubmitting}
@@ -1943,14 +1994,14 @@ export function OfficeScheduleClient({
 
           {aiNeedsDuration ? (
             <div className="grid gap-2">
-              <div className="text-xs font-semibold text-foreground/70">How long do you need?</div>
+              <div className="text-xs font-semibold text-slate-500">How long do you need?</div>
               <DurationChips value={aiDraft.durationMinutes ?? 0} onChange={handleAiDurationSelect} />
             </div>
           ) : null}
 
           <div className="flex items-center gap-2">
             <input
-              className="h-10 flex-1 rounded-md border border-border/70 bg-background px-3 text-sm"
+              className="h-10 flex-1 rounded-full border border-slate-200/80 bg-white px-4 text-sm text-slate-700 shadow-sm"
               value={aiInput}
               onChange={(e) => setAiInput(e.target.value)}
               placeholder="e.g. Thursday afternoon for 30 minutes at Midtown"
@@ -1964,10 +2015,10 @@ export function OfficeScheduleClient({
             <button
               type="button"
               className={
-                "h-10 rounded-md border border-border/70 px-4 text-sm font-semibold transition " +
+                "h-10 rounded-full border border-sky-200 px-4 text-sm font-semibold transition " +
                 (!aiInput.trim() || aiSending
-                  ? "bg-muted/30 text-foreground/50"
-                  : "bg-foreground text-background hover:opacity-90")
+                  ? "bg-slate-100 text-slate-400"
+                  : "bg-sky-600 text-white hover:bg-sky-500")
               }
               onClick={handleAiSend}
               disabled={!aiInput.trim() || aiSending}
@@ -1976,11 +2027,12 @@ export function OfficeScheduleClient({
             </button>
           </div>
 
-          <div className="text-xs text-foreground/60">
+          <div className="text-xs text-slate-500">
             AI suggestions use your local Ollama model. If it’s unavailable, you can still book manually.
           </div>
         </div>
       </Modal>
+      </div>
     </main>
   );
 }
@@ -2011,18 +2063,18 @@ function UserInfoModal({
     <Modal open={open} title="User information" onClose={onClose}>
       <div className="grid gap-3">
         <div>
-          <label className="text-xs font-semibold text-foreground/70">Name</label>
+          <label className="text-xs font-semibold text-slate-500">Name</label>
           <input
-            className="mt-1 h-10 w-full rounded-md border border-border/70 bg-background px-3 text-sm"
+            className="mt-1 h-10 w-full rounded-full border border-slate-200/80 bg-white px-4 text-sm text-slate-700 shadow-sm"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="Jane Doe"
           />
         </div>
         <div>
-          <label className="text-xs font-semibold text-foreground/70">Email</label>
+          <label className="text-xs font-semibold text-slate-500">Email</label>
           <input
-            className="mt-1 h-10 w-full rounded-md border border-border/70 bg-background px-3 text-sm"
+            className="mt-1 h-10 w-full rounded-full border border-slate-200/80 bg-white px-4 text-sm text-slate-700 shadow-sm"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="jane@company.com"
@@ -2035,14 +2087,14 @@ function UserInfoModal({
         <div className="mt-1 flex items-center justify-end gap-2">
           <button
             type="button"
-            className="h-10 rounded-md border border-border/70 bg-background px-4 text-sm font-semibold transition hover:bg-muted"
+            className="h-10 rounded-full border border-slate-200/80 bg-white px-4 text-sm font-semibold text-slate-600 transition hover:bg-slate-50"
             onClick={onClose}
           >
             Cancel
           </button>
           <button
             type="button"
-            className="h-10 rounded-md border border-border/70 bg-foreground px-4 text-sm font-semibold text-background transition hover:opacity-90"
+            className="h-10 rounded-full border border-sky-200 bg-sky-600 px-4 text-sm font-semibold text-white transition hover:bg-sky-500"
             onClick={() => {
               const n = name.trim();
               const e = email.trim();


### PR DESCRIPTION
### Motivation
- Refresh the Office Schedule route to an airy, coastal look (rounded cards, soft dividers, calm typography) while keeping all scheduling functionality intact.
- Add a lightweight visual hero and photo-strip to improve the page mood without touching backend or booking logic.

### Description
- Restyled the Office Schedule page in `ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx` with a top-to-bottom gradient page shell, an SVG “wave” divider, and a static photo-strip of gradient tiles near the top. 
- Converted major UI containers (hero, top bar, calendar panel, booking panel, modals) to rounded `2xl/3xl` cards with soft borders, subtle shadows, and backdrop blur; updated buttons to pill/`rounded-full` styles and softened hover states. 
- Restyled components including `DurationChips`, the calendar day buttons, time slot cards, AI/chat panels, and modals to match the coastal palette and spacing while preserving existing state and API interactions. 
- Left all booking logic, date/office selection, AI helpers, and API calls unchanged (only classNames/layout modified), so behavior remains the same.

### Testing
- Ran `npm run build` in the `ui/partner-hub` workspace and the Next.js production build completed successfully. 
- Launched the dev server with `npm run dev` and rendered `/partner-hub/offices/schedule` to verify the route compiles and the page displays; a full-page screenshot was produced for visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970f299cd908330b1501754d682ed8d)