### PR TITLE
Remove Coastal Moments strip from Office Schedule

### DIFF
--- a/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
+++ b/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
@@ -1420,30 +1420,6 @@ export function OfficeScheduleClient({
           </svg>
         </div>
 
-        <section className="grid gap-4">
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Coastal Moments</h2>
-            <span className="text-xs text-slate-500">A calming backdrop for your planning</span>
-          </div>
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
-            {[
-              "from-sky-100 via-white to-amber-100",
-              "from-slate-100 via-white to-sky-100",
-              "from-amber-100 via-white to-sky-100",
-              "from-sky-50 via-white to-slate-100",
-              "from-slate-100 via-white to-amber-50",
-              "from-sky-100 via-white to-slate-50",
-            ].map((gradient, index) => (
-              <div
-                key={`${gradient}-${index}`}
-                className={`aspect-[4/3] rounded-2xl border border-white/70 bg-gradient-to-br ${gradient} shadow-sm`}
-                aria-hidden
-              />
-            ))}
-          </div>
-          <div className="h-px w-full bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
-        </section>
-
         {/* Top bar */}
         <div className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-white/70 bg-white/80 p-4 shadow-sm backdrop-blur">
           <div className="text-sm font-semibold text-slate-600">Manage your schedule</div>


### PR DESCRIPTION
### Motivation
- Remove the decorative “Coastal Moments” strip so the schedule page keeps the top wave/hero but no longer displays the nonfunctional decorative heading, subtitle and pastel tiles.

### Description
- Deleted the JSX block that rendered the `h2` "Coastal Moments`, the right-aligned subtitle `A calming backdrop for your planning`, the grid of gradient tiles, and the section divider in `ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx`, while leaving the SVG wave header and the subsequent top bar and booking UI unchanged so content flows up beneath the wave.

### Testing
- Ran `npm run build` from `ui/partner-hub` and the Next.js build completed successfully; an attempt to run `npm run build` from the repo root failed due to a missing root `package.json`, which is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970f63dcc1c833085febe2a6d3f2248)