### PR TITLE
Set Office Schedule page background color to #71646D

### DIFF
--- a/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
+++ b/ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx
@@ -1382,7 +1382,7 @@ export function OfficeScheduleClient({
 
   if (offices.length === 0) {
     return (
-      <main className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-sky-50">
+      <main className="min-h-screen bg-[#71646D]">
         <div className="mx-auto max-w-5xl px-6 py-16">
           <div className="rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-sm backdrop-blur">
             <h1 className="text-xl font-semibold text-slate-900">Office Schedule</h1>
@@ -1395,7 +1395,7 @@ export function OfficeScheduleClient({
 
   const locked = !unlocked;
   return (
-    <main className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-sky-50">
+    <main className="min-h-screen bg-[#71646D]">
       <div className="mx-auto flex max-w-6xl flex-col gap-8 px-6 pb-16 pt-10 lg:px-10">
         <section className="rounded-3xl border border-white/70 bg-white/70 p-8 shadow-sm backdrop-blur">
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Office Booking</p>


### PR DESCRIPTION
### Motivation
- Apply the specified background color RGB(113,100,109) / `#71646D` to the Office Schedule route only while preserving the wave header and existing white card surfaces.

### Description
- Replaced the route wrapper background on the empty-state and main view in `ui/partner-hub/app/(routes)/offices/schedule/OfficeScheduleClient.tsx` from the gradient to `className="min-h-screen bg-[#71646D]"` so the background covers the full viewport without changing global theme or card styles.

### Testing
- Ran `npm run build` in `ui/partner-hub` (which runs `prisma generate` and `next build`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970fa6f394c83308779e66f094ce530)