### PR TITLE
Add AI Interview tool skeleton behind feature flag

### DIFF
--- a/ui/partner-hub/app/(routes)/tools/interview/page.tsx
+++ b/ui/partner-hub/app/(routes)/tools/interview/page.tsx
@@ -1,0 +1,22 @@
+import { InterviewTool } from "@/components/interview/InterviewTool";
+
+const aiInterviewEnabled = process.env.NEXT_PUBLIC_ENABLE_AI_INTERVIEW === "true";
+
+export default function InterviewPage() {
+  if (!aiInterviewEnabled) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center px-6 py-16">
+        <div className="max-w-lg rounded-2xl border border-border/60 bg-card p-8 text-center shadow-sm">
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-foreground/40">AI Interview</p>
+          <h1 className="mt-3 text-2xl font-semibold text-foreground">AI Interview is disabled</h1>
+          <p className="mt-3 text-sm text-foreground/60">
+            Set the <span className="font-semibold">NEXT_PUBLIC_ENABLE_AI_INTERVIEW</span> flag to &quot;true&quot; to enable
+            this tool.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return <InterviewTool />;
+}

--- a/ui/partner-hub/components/interview/InterviewTool.tsx
+++ b/ui/partner-hub/components/interview/InterviewTool.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const services = [
+  { name: "Ollama", url: "http://127.0.0.1:11434" },
+  { name: "STT", url: "http://127.0.0.1:9000" },
+  { name: "TTS", url: "http://127.0.0.1:8000" },
+];
+
+export function InterviewTool() {
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <header className="space-y-2">
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-foreground/40">Tools</p>
+        <h1 className="text-3xl font-semibold text-foreground">AI Interview</h1>
+        <p className="max-w-2xl text-sm text-foreground/60">
+          This is a placeholder for the AI Interview workflow. Enable the required services locally to begin wiring up
+          the next steps.
+        </p>
+      </header>
+
+      <Card className="border-border/60 shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-lg">Local Services</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <ul className="space-y-2 text-sm text-foreground/70">
+            {services.map((service) => (
+              <li key={service.name} className="flex flex-col gap-1 rounded-lg border border-border/50 px-4 py-3">
+                <span className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground/40">
+                  {service.name}
+                </span>
+                <span className="font-mono text-sm text-foreground/80">{service.url}</span>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/ui/partner-hub/components/left-nav.tsx
+++ b/ui/partner-hub/components/left-nav.tsx
@@ -6,12 +6,17 @@ import { Menu, ChevronLeft } from "lucide-react";
 import { useState } from "react";
 import { clsx } from "clsx";
 
+const aiInterviewEnabled = process.env.NEXT_PUBLIC_ENABLE_AI_INTERVIEW === "true";
+const toolLinks = [
+  { name: "Energy Tool", href: "/tools/energy" },
+  { name: "CHIP-8", href: "/tools/chip8" },
+  ...(aiInterviewEnabled ? [{ name: "AI Interview", href: "/tools/interview" }] : []),
+];
 const links = [
   { name: "Home", href: "/" },
   { name: "Case Studies", href: "/case-studies" },
   { name: "Account Mapping", href: "/accountmap" },
-  { name: "Energy Tool", href: "/tools/energy" },
-  { name: "CHIP-8", href: "/tools/chip8" },
+  ...toolLinks,
   { name: "Office Schedule", href: "/offices/schedule" },
   { name: "About / Contact", href: "/about" },
 ];


### PR DESCRIPTION
### Motivation
- Introduce an additive, sandboxed AI Interview tool scaffold to begin wiring the feature without affecting existing behavior.
- Gate the entire experience behind `NEXT_PUBLIC_ENABLE_AI_INTERVIEW` so the UI and APIs remain inert unless explicitly enabled.

### Description
- Add a new route page at `app/(routes)/tools/interview/page.tsx` that renders a friendly "AI Interview is disabled" message when `NEXT_PUBLIC_ENABLE_AI_INTERVIEW !== "true"`, and otherwise renders `<InterviewTool />`.
- Add a client component `components/interview/InterviewTool.tsx` that provides a minimal placeholder UI and a "Local Services" card listing Ollama, STT, and TTS endpoints.
- Update `components/left-nav.tsx` to include the "AI Interview" link under Tools only when `NEXT_PUBLIC_ENABLE_AI_INTERVIEW === "true"`.

### Testing
- Ran `npm run lint` and received no ESLint errors (success).
- Ran `npm run typecheck` (`tsc --noEmit`) with no type errors (success).
- Ran `npm run build` (`next build`) and completed a successful production build that included the new route (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972915897048330849f2c7093526ac3)