### PR TITLE
Tighten AI interview service checks (PS: tolerate HTTP errors; SH: aggregate results)

### DIFF
--- a/ui/partner-hub/scripts/ai-interview-check.ps1
+++ b/ui/partner-hub/scripts/ai-interview-check.ps1
@@ -8,18 +8,51 @@ function Test-Url {
     [string]$Url
   )
 
+  $supportsSkipHttpErrorCheck = (Get-Command Invoke-WebRequest).Parameters.ContainsKey('SkipHttpErrorCheck')
+  $requestParams = @{
+    Uri = $Url
+    Method = 'Get'
+    TimeoutSec = 2
+    UseBasicParsing = $true
+  }
+  if ($supportsSkipHttpErrorCheck) {
+    $requestParams.SkipHttpErrorCheck = $true
+  }
+
   try {
-    $response = Invoke-WebRequest -Uri $Url -Method Get -TimeoutSec 2 -UseBasicParsing
+    $response = Invoke-WebRequest @requestParams
     if ($response.StatusCode -gt 0) {
       Write-Host "PASS: $Name ($Url) [HTTP $($response.StatusCode)]"
       return $true
     }
   } catch {
+    $statusCode = $null
+    if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+    } elseif ($_.Exception.Response -and $_.Exception.Response.StatusCode.value__) {
+      $statusCode = $_.Exception.Response.StatusCode.value__
+    }
+
+    if ($null -ne $statusCode) {
+      Write-Host "PASS: $Name ($Url) [HTTP $statusCode]"
+      return $true
+    }
+
     Write-Host "FAIL: $Name ($Url)"
     return $false
   }
+
+  Write-Host "FAIL: $Name ($Url)"
+  return $false
 }
 
-Test-Url -Name "Ollama" -Url ($OllamaUrl.TrimEnd('/') + "/api/tags")
-Test-Url -Name "STT" -Url ($SttUrl.TrimEnd('/') + "/")
-Test-Url -Name "TTS" -Url ($TtsUrl.TrimEnd('/') + "/")
+$results = @()
+$results += Test-Url -Name "Ollama" -Url ($OllamaUrl.TrimEnd('/') + "/api/tags")
+$results += Test-Url -Name "STT" -Url ($SttUrl.TrimEnd('/') + "/")
+$results += Test-Url -Name "TTS" -Url ($TtsUrl.TrimEnd('/') + "/")
+
+if ($results -contains $false) {
+  exit 1
+}
+
+exit 0

--- a/ui/partner-hub/scripts/ai-interview-check.sh
+++ b/ui/partner-hub/scripts/ai-interview-check.sh
@@ -20,6 +20,9 @@ check_url() {
   return 1
 }
 
-check_url "Ollama" "${AI_INTERVIEW_OLLAMA_URL%/}/api/tags"
-check_url "STT" "${AI_INTERVIEW_STT_URL%/}/"
-check_url "TTS" "${AI_INTERVIEW_TTS_URL%/}/"
+failed=0
+check_url "Ollama" "${AI_INTERVIEW_OLLAMA_URL%/}/api/tags" || failed=1
+check_url "STT" "${AI_INTERVIEW_STT_URL%/}/" || failed=1
+check_url "TTS" "${AI_INTERVIEW_TTS_URL%/}/" || failed=1
+
+exit "$failed"


### PR DESCRIPTION
### Motivation
- Avoid false negatives when a reachable service returns non-2xx (e.g. 404/405) by treating any reachable HTTP response as a pass. 
- Make the PowerShell check compatible with different PowerShell versions while avoiding spurious failures. 
- Ensure the overall check scripts return a non-zero exit code only when at least one check actually fails.

### Description
- Update `ui/partner-hub/scripts/ai-interview-check.ps1` to detect whether `Invoke-WebRequest` supports `-SkipHttpErrorCheck`, build request parameters via splatting, and use that option when available. 
- In the PowerShell script, catch exceptions from `Invoke-WebRequest` and extract an HTTP status code from `$_ .Exception.Response.StatusCode` (or `value__`) and treat presence of a status code as `PASS` while printing the code. 
- Aggregate PowerShell results into an array and `exit 1` if any check returned `$false`, otherwise `exit 0`. 
- Update `ui/partner-hub/scripts/ai-interview-check.sh` to keep the existing `curl` success condition but aggregate results into a `failed` variable and `exit` with a non-zero code if any check fails.

### Testing
- No automated tests were executed for this change (scripts-only update).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69729f08d2fc8330867f6467ebaf04e9)