### PR TITLE
Make UseBasicParsing conditional in PowerShell checker

### DIFF
--- a/ui/partner-hub/scripts/ai-interview-check.ps1
+++ b/ui/partner-hub/scripts/ai-interview-check.ps1
@@ -9,14 +9,17 @@ function Test-Url {
   )
 
   $supportsSkipHttpErrorCheck = (Get-Command Invoke-WebRequest).Parameters.ContainsKey('SkipHttpErrorCheck')
+  $supportsUseBasicParsing = (Get-Command Invoke-WebRequest).Parameters.ContainsKey('UseBasicParsing')
   $requestParams = @{
     Uri = $Url
     Method = 'Get'
     TimeoutSec = 2
-    UseBasicParsing = $true
   }
   if ($supportsSkipHttpErrorCheck) {
     $requestParams.SkipHttpErrorCheck = $true
+  }
+  if ($supportsUseBasicParsing) {
+    $requestParams.UseBasicParsing = $true
   }
 
   try {


### PR DESCRIPTION
### Motivation
- Ensure `ui/partner-hub/scripts/ai-interview-check.ps1` is compatible across Windows PowerShell 5.1 and PowerShell 7+ by only adding `UseBasicParsing` when `Invoke-WebRequest` actually supports it.

### Description
- Detect support with `(Get-Command Invoke-WebRequest).Parameters.ContainsKey('UseBasicParsing')` and only add `UseBasicParsing = $true` to `$requestParams` when supported, while leaving the existing `SkipHttpErrorCheck` handling and overall behavior unchanged.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972a079a2b4833081f4c2232fd1ff05)