### PR TITLE
Add AI interview proxy routes (chat, STT, TTS) with feature-flag gating and smoke test

### DIFF
--- a/ui/partner-hub/app/api/ai-interview/chat/route.ts
+++ b/ui/partner-hub/app/api/ai-interview/chat/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const DEFAULT_TIMEOUT_MS = 20_000;
+
+type ChatRequest = {
+  prompt: string;
+  system?: string;
+  persona?: string;
+};
+
+function aiInterviewEnabled() {
+  return process.env.NEXT_PUBLIC_ENABLE_AI_INTERVIEW === "true";
+}
+
+function buildSystem(system?: string, persona?: string) {
+  const parts = [system?.trim(), persona?.trim()].filter((value) => value);
+  return parts.join("\n").trim();
+}
+
+export async function POST(req: Request) {
+  if (!aiInterviewEnabled()) {
+    return NextResponse.json({ error: "AI interview is disabled." }, { status: 404 });
+  }
+
+  let body: ChatRequest | null = null;
+  try {
+    body = (await req.json()) as ChatRequest;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const prompt = body?.prompt?.trim();
+  if (!prompt) {
+    return NextResponse.json({ error: "prompt is required." }, { status: 400 });
+  }
+
+  const baseUrl = process.env.AI_INTERVIEW_OLLAMA_URL?.trim() || "http://127.0.0.1:11434";
+  const model =
+    process.env.AI_INTERVIEW_OLLAMA_MODEL?.trim() ||
+    process.env.OLLAMA_MODEL?.trim() ||
+    "llama3.2:3b";
+  const system = buildSystem(body?.system, body?.persona);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+  try {
+    const resp = await fetch(`${baseUrl.replace(/\/$/, "")}/api/generate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model,
+        prompt,
+        stream: false,
+        ...(system ? { system } : {}),
+      }),
+      signal: controller.signal,
+    });
+
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => "");
+      return NextResponse.json(
+        {
+          error: "Ollama request failed.",
+          status: resp.status,
+          detail: detail.slice(0, 500),
+        },
+        { status: 502 },
+      );
+    }
+
+    const data = (await resp.json()) as { response?: string };
+    const text = String(data?.response ?? "").trim();
+
+    return NextResponse.json(
+      { text },
+      {
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      return NextResponse.json({ error: "Ollama request timed out." }, { status: 504 });
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: "Failed to reach Ollama.", detail: message }, { status: 502 });
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/ui/partner-hub/app/api/ai-interview/stt/route.ts
+++ b/ui/partner-hub/app/api/ai-interview/stt/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const DEFAULT_TIMEOUT_MS = 20_000;
+
+function aiInterviewEnabled() {
+  return process.env.NEXT_PUBLIC_ENABLE_AI_INTERVIEW === "true";
+}
+
+function extractAudioFile(formData: FormData): File | null {
+  const file = formData.get("file");
+  if (file instanceof File) {
+    return file;
+  }
+  const audio = formData.get("audio");
+  return audio instanceof File ? audio : null;
+}
+
+export async function POST(req: Request) {
+  if (!aiInterviewEnabled()) {
+    return NextResponse.json({ error: "AI interview is disabled." }, { status: 404 });
+  }
+
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch {
+    return NextResponse.json({ error: "Invalid multipart/form-data body." }, { status: 400 });
+  }
+
+  const audioFile = extractAudioFile(formData);
+  if (!audioFile) {
+    return NextResponse.json({ error: "audio file is required." }, { status: 400 });
+  }
+
+  const baseUrl = process.env.AI_INTERVIEW_STT_URL?.trim() || "http://127.0.0.1:9000";
+  const model = process.env.AI_INTERVIEW_STT_MODEL?.trim() || "whisper-1";
+
+  const upstream = new FormData();
+  upstream.set("file", audioFile, audioFile.name || "audio.webm");
+  upstream.set("model", model);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+  try {
+    const resp = await fetch(`${baseUrl.replace(/\/$/, "")}/v1/audio/transcriptions`, {
+      method: "POST",
+      body: upstream,
+      signal: controller.signal,
+    });
+
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => "");
+      return NextResponse.json(
+        {
+          error: "STT request failed.",
+          status: resp.status,
+          detail: detail.slice(0, 500),
+        },
+        { status: 502 },
+      );
+    }
+
+    const data = (await resp.json()) as { text?: string };
+    const text = typeof data?.text === "string" ? data.text : "";
+
+    return NextResponse.json(
+      { text },
+      {
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      return NextResponse.json({ error: "STT request timed out." }, { status: 504 });
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: "Failed to reach STT service.", detail: message }, { status: 502 });
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/ui/partner-hub/app/api/ai-interview/tts/route.ts
+++ b/ui/partner-hub/app/api/ai-interview/tts/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const DEFAULT_TIMEOUT_MS = 20_000;
+
+type TtsRequest = {
+  text: string;
+  voice?: string;
+};
+
+function aiInterviewEnabled() {
+  return process.env.NEXT_PUBLIC_ENABLE_AI_INTERVIEW === "true";
+}
+
+export async function POST(req: Request) {
+  if (!aiInterviewEnabled()) {
+    return NextResponse.json({ error: "AI interview is disabled." }, { status: 404 });
+  }
+
+  let body: TtsRequest | null = null;
+  try {
+    body = (await req.json()) as TtsRequest;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const text = body?.text?.trim();
+  if (!text) {
+    return NextResponse.json({ error: "text is required." }, { status: 400 });
+  }
+
+  const baseUrl = process.env.AI_INTERVIEW_TTS_URL?.trim() || "http://127.0.0.1:8000";
+  const model = process.env.AI_INTERVIEW_TTS_MODEL?.trim() || "tts-1";
+  const voice = body?.voice?.trim() || "alloy";
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+  try {
+    const resp = await fetch(`${baseUrl.replace(/\/$/, "")}/v1/audio/speech`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model,
+        voice,
+        input: text,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => "");
+      return NextResponse.json(
+        {
+          error: "TTS request failed.",
+          status: resp.status,
+          detail: detail.slice(0, 500),
+        },
+        { status: 502 },
+      );
+    }
+
+    const audio = await resp.arrayBuffer();
+
+    return new Response(audio, {
+      status: 200,
+      headers: {
+        "Content-Type": "audio/mpeg",
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      return NextResponse.json({ error: "TTS request timed out." }, { status: 504 });
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: "Failed to reach TTS service.", detail: message }, { status: 502 });
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/ui/partner-hub/scripts/ai-interview-proxy-smoke.sh
+++ b/ui/partner-hub/scripts/ai-interview-proxy-smoke.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -u
+
+: "${AI_INTERVIEW_APP_URL:=http://localhost:3000}"
+: "${AI_INTERVIEW_SAMPLE_TEXT:=Hello from AI interview}"
+
+base_url="${AI_INTERVIEW_APP_URL%/}"
+
+make_audio_sample() {
+  local target="$1"
+  python - "$target" <<'PY'
+import sys
+import wave
+
+path = sys.argv[1]
+with wave.open(path, "wb") as wav:
+    wav.setnchannels(1)
+    wav.setsampwidth(2)
+    wav.setframerate(16000)
+    wav.writeframes(b"\x00\x00" * 1600)
+PY
+}
+
+check_chat() {
+  local body_file code
+  body_file=$(mktemp)
+  code=$(curl -sS -o "$body_file" -w "%{http_code}" \
+    -H "Content-Type: application/json" \
+    -d "{\"prompt\":\"${AI_INTERVIEW_SAMPLE_TEXT}\"}" \
+    "${base_url}/api/ai-interview/chat" || true)
+
+  if [[ "$code" == "200" ]]; then
+    echo "PASS: chat"
+  else
+    echo "FAIL: chat (HTTP ${code})"
+    cat "$body_file"
+    failed=1
+  fi
+
+  rm -f "$body_file"
+}
+
+check_stt() {
+  local body_file code
+  body_file=$(mktemp)
+  code=$(curl -sS -o "$body_file" -w "%{http_code}" \
+    -F "file=@${audio_file};type=audio/wav" \
+    "${base_url}/api/ai-interview/stt" || true)
+
+  if [[ "$code" == "200" ]]; then
+    echo "PASS: stt"
+  else
+    echo "FAIL: stt (HTTP ${code})"
+    cat "$body_file"
+    failed=1
+  fi
+
+  rm -f "$body_file"
+}
+
+check_tts() {
+  local body_file header_file code
+  body_file=$(mktemp)
+  header_file=$(mktemp)
+  code=$(curl -sS -D "$header_file" -o "$body_file" -w "%{http_code}" \
+    -H "Content-Type: application/json" \
+    -d "{\"text\":\"${AI_INTERVIEW_SAMPLE_TEXT}\"}" \
+    "${base_url}/api/ai-interview/tts" || true)
+
+  if [[ "$code" == "200" ]] && grep -qi "^content-type: audio/mpeg" "$header_file"; then
+    echo "PASS: tts"
+  else
+    echo "FAIL: tts (HTTP ${code})"
+    cat "$body_file"
+    failed=1
+  fi
+
+  rm -f "$body_file" "$header_file"
+}
+
+failed=0
+
+audio_file=$(mktemp --suffix=.wav)
+make_audio_sample "$audio_file"
+
+check_chat
+check_stt
+check_tts
+
+rm -f "$audio_file"
+
+exit "$failed"


### PR DESCRIPTION
### Motivation

- Provide local-only Next.js API proxies so the browser can talk to local AI services without CORS and without calling cloud APIs. 
- Gate the feature behind `NEXT_PUBLIC_ENABLE_AI_INTERVIEW` so the routes are inert when the flag is off and safe for developer machines. 

### Description

- Added new App Router API handlers at `app/api/ai-interview/chat/route.ts`, `app/api/ai-interview/stt/route.ts`, and `app/api/ai-interview/tts/route.ts` that return 404 when `NEXT_PUBLIC_ENABLE_AI_INTERVIEW !== "true"`. 
- The chat route accepts JSON `{ prompt, system?, persona? }` and proxies to `${AI_INTERVIEW_OLLAMA_URL}/api/generate`, returning normalized JSON `{ text }` and using `AI_INTERVIEW_OLLAMA_MODEL` or fallback model envs. 
- The STT route accepts multipart/form-data audio and proxies to `${AI_INTERVIEW_STT_URL}/v1/audio/transcriptions` and returns `{ text }`, and the TTS route accepts JSON `{ text, voice? }`, proxies to `${AI_INTERVIEW_TTS_URL}/v1/audio/speech`, and returns MP3 bytes with `Content-Type: audio/mpeg`. 
- All routes use `AbortController` with a safe timeout (`20_000ms`), surface clear errors (mapping timeouts to 504 and upstream failures to 502), and avoid remote/cloud APIs; environment variables allow URL/model overrides. 
- Added a smoke-test script at `ui/partner-hub/scripts/ai-interview-proxy-smoke.sh` that exercises each `/api/ai-interview/*` endpoint with sample payloads and prints PASS/FAIL. 

### Testing

- Ran `npm run lint` and there were no ESLint warnings or errors. 
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully. 
- Ran `npm run build` and the Next build completed successfully, listing the new proxy routes as server routes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972a12a449083309410428331c6260e)