### PR TITLE
Make AI interview proxy runtime explicit and use Node for smoke audio

### DIFF
--- a/ui/partner-hub/app/api/ai-interview/chat/route.ts
+++ b/ui/partner-hub/app/api/ai-interview/chat/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
 
 const DEFAULT_TIMEOUT_MS = 20_000;
 

--- a/ui/partner-hub/app/api/ai-interview/stt/route.ts
+++ b/ui/partner-hub/app/api/ai-interview/stt/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
 
 const DEFAULT_TIMEOUT_MS = 20_000;
 

--- a/ui/partner-hub/app/api/ai-interview/tts/route.ts
+++ b/ui/partner-hub/app/api/ai-interview/tts/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
 
 const DEFAULT_TIMEOUT_MS = 20_000;
 

--- a/ui/partner-hub/scripts/ai-interview-proxy-smoke.sh
+++ b/ui/partner-hub/scripts/ai-interview-proxy-smoke.sh
@@ -9,17 +9,46 @@ base_url="${AI_INTERVIEW_APP_URL%/}"
 
 make_audio_sample() {
   local target="$1"
-  python - "$target" <<'PY'
-import sys
-import wave
-
-path = sys.argv[1]
-with wave.open(path, "wb") as wav:
-    wav.setnchannels(1)
-    wav.setsampwidth(2)
-    wav.setframerate(16000)
-    wav.writeframes(b"\x00\x00" * 1600)
-PY
+  node -e '
+const fs = require("fs");
+const path = process.argv[1];
+const sampleRate = 16000;
+const numChannels = 1;
+const bitsPerSample = 16;
+const numSamples = 1600;
+const blockAlign = (numChannels * bitsPerSample) / 8;
+const byteRate = sampleRate * blockAlign;
+const dataSize = numSamples * blockAlign;
+const buffer = Buffer.alloc(44 + dataSize);
+let offset = 0;
+buffer.write("RIFF", offset);
+offset += 4;
+buffer.writeUInt32LE(36 + dataSize, offset);
+offset += 4;
+buffer.write("WAVE", offset);
+offset += 4;
+buffer.write("fmt ", offset);
+offset += 4;
+buffer.writeUInt32LE(16, offset);
+offset += 4;
+buffer.writeUInt16LE(1, offset);
+offset += 2;
+buffer.writeUInt16LE(numChannels, offset);
+offset += 2;
+buffer.writeUInt32LE(sampleRate, offset);
+offset += 4;
+buffer.writeUInt32LE(byteRate, offset);
+offset += 4;
+buffer.writeUInt16LE(blockAlign, offset);
+offset += 2;
+buffer.writeUInt16LE(bitsPerSample, offset);
+offset += 2;
+buffer.write("data", offset);
+offset += 4;
+buffer.writeUInt32LE(dataSize, offset);
+offset += 4;
+fs.writeFileSync(path, buffer);
+' "$target"
 }
 
 check_chat() {


### PR DESCRIPTION
### Motivation
- Ensure the AI interview proxy routes explicitly declare the Node.js runtime for predictable server execution semantics while keeping `dynamic = "force-dynamic"` and feature-flag gating unchanged.  
- Remove the Python dependency from the smoke script so the test is dependency-free and can run in environments without Python while preserving the script behavior and outputs.

### Description
- Added `export const runtime = "nodejs";` to `chat/route.ts`, `stt/route.ts`, and `tts/route.ts` so the routes are runtime-explicit.  
- Replaced the Python `make_audio_sample()` implementation in `scripts/ai-interview-proxy-smoke.sh` with a `node -e` snippet that writes a minimal valid 16kHz mono PCM WAV file (silence) to the target path.  
- Preserved `export const dynamic = "force-dynamic"`, all response shapes, and the feature flag gating; the smoke script still reports `PASS`/`FAIL` and returns the same exit code semantics.

### Testing
- Ran `npm run lint` which completed with no ESLint warnings or errors.  
- Ran `npm run typecheck` (`tsc --noEmit`) which completed without type errors.  
- Ran `npm run build` which completed and produced a successful Next.js production build (compiled successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972a2f861248330bf08c81fc8fbbd9c)