### PR TITLE
Add node preflight and clarify WAV generator in smoke script

### DIFF
--- a/ui/partner-hub/scripts/ai-interview-proxy-smoke.sh
+++ b/ui/partner-hub/scripts/ai-interview-proxy-smoke.sh
@@ -5,12 +5,15 @@ set -u
 : "${AI_INTERVIEW_APP_URL:=http://localhost:3000}"
 : "${AI_INTERVIEW_SAMPLE_TEXT:=Hello from AI interview}"
 
+command -v node >/dev/null 2>&1 || { echo "FAIL: node not found (required to generate WAV sample)."; exit 1; }
+
 base_url="${AI_INTERVIEW_APP_URL%/}"
 
 make_audio_sample() {
   local target="$1"
   node -e '
 const fs = require("fs");
+// When using -e, the first argument after the snippet is process.argv[1].
 const path = process.argv[1];
 const sampleRate = 16000;
 const numChannels = 1;


### PR DESCRIPTION
### Motivation
- Ensure the smoke script fails with a clear message when `node` is not installed while preserving existing PASS/FAIL semantics.

### Description
- Add a preflight check `command -v node >/dev/null 2>&1 || { echo "FAIL: node not found (required to generate WAV sample)."; exit 1; }` to `ui/partner-hub/scripts/ai-interview-proxy-smoke.sh`.
- Add a brief comment inside the `node -e` WAV generator noting that the first argument after the snippet is read as `process.argv[1]`, with no change to the generated WAV output.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972a4d5acb88330a53f12354286254f)