### PR TITLE
Harden interview tool recorder cleanup

### DIFF
--- a/ui/partner-hub/components/interview/InterviewTool.tsx
+++ b/ui/partner-hub/components/interview/InterviewTool.tsx
@@ -92,17 +92,24 @@ export function InterviewTool() {
   );
 
   const cleanupStream = () => {
-    streamRef.current?.getTracks().forEach((track) => track.stop());
+    streamRef.current?.getTracks().forEach((track) => {
+      if (track.readyState !== "ended") {
+        track.stop();
+      }
+    });
     streamRef.current = null;
     recorderRef.current = null;
     chunksRef.current = [];
   };
 
   const stopAudioPlayback = () => {
-    if (audioRef.current) {
-      audioRef.current.pause();
-      audioRef.current = null;
+    const audio = audioRef.current;
+    if (audio) {
+      audio.pause();
+      audio.src = "";
+      audio.currentTime = 0;
     }
+    audioRef.current = null;
     if (audioUrlRef.current) {
       URL.revokeObjectURL(audioUrlRef.current);
       audioUrlRef.current = null;
@@ -179,13 +186,7 @@ export function InterviewTool() {
   };
 
   const handleStopRecording = () => {
-    if (!recorderRef.current || !isRecording) {
-      return;
-    }
-    if (recorderRef.current.state !== "recording") {
-      return;
-    }
-    recorderRef.current.stop();
+    stopRecorderIfActive();
   };
 
   const handleRecordingComplete = async (blob: Blob) => {
@@ -294,9 +295,7 @@ export function InterviewTool() {
   };
 
   const handleReset = () => {
-    if (isRecording) {
-      stopRecorderIfActive({ skipOnStop: true });
-    }
+    stopRecorderIfActive({ skipOnStop: true });
     stopAudioPlayback();
     cleanupStream();
     setTranscript([]);


### PR DESCRIPTION
### Motivation
- Make the media cleanup and reset flow more robust and idempotent to avoid leakage and race conditions when stopping recording, resetting, or unmounting.
- Ensure audio playback is fully torn down and recorder stop handlers can be skipped during forced teardown to avoid triggering the async onstop pipeline.

### Description
- Stop media tracks only when not already ended and clear `streamRef`/`recorderRef`/`chunksRef` to make stream cleanup safe to call multiple times.
- Fully reset playback by pausing the audio, clearing `src`, resetting `currentTime`, revoking any object URL, and nulling audio refs.
- Centralize and guard recorder stopping in `stopRecorderIfActive` (with a `skipOnStop` option that nulls event handlers) and route `handleStopRecording` and `handleReset` through it to avoid double-stop or triggering completion handlers during reset.
- Preserve existing browser support checks and UX (persona buttons disabled while recording/processing, Reset disabled while processing) while only adding cleanup and guardrails.

### Testing
- Ran `npm run lint` and there were no ESLint warnings or errors; the command succeeded.
- Ran `npm run typecheck` (`tsc --noEmit`) and the typecheck completed successfully.
- Ran `npm run build` (`next build`) and the application compiled and built successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972ab0761808330bed06bcdcdaabd96)