### PR TITLE
Add Start Interview kickoff to Interview tool

### DIFF
--- a/ui/partner-hub/components/interview/InterviewTool.tsx
+++ b/ui/partner-hub/components/interview/InterviewTool.tsx
@@ -431,6 +431,31 @@ export function InterviewTool() {
     }
   };
 
+  const handleStartInterview = async () => {
+    if (isProcessing || isRecording) {
+      return;
+    }
+
+    setIsProcessing(true);
+    setError(null);
+
+    try {
+      const prompt = "Begin the interview now. Ask exactly ONE opening question. No preamble.";
+      const responseText = await sendToChat(prompt, activePersona);
+      if (!responseText) {
+        throw new Error("Chat response was empty.");
+      }
+
+      setTranscript((prev) => [...prev, { role: "assistant", text: responseText }]);
+
+      await sendToTts(responseText);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unexpected error while starting interview.");
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
   const sendToStt = async (blob: Blob) => {
     const formData = new FormData();
     formData.append("file", blob, "recording.webm");
@@ -555,6 +580,20 @@ export function InterviewTool() {
             </div>
 
             <div className="flex flex-wrap items-center gap-3">
+              {transcript.length === 0 ? (
+                <button
+                  type="button"
+                  onClick={handleStartInterview}
+                  disabled={isProcessing || isRecording}
+                  className={`rounded-full px-6 py-3 text-sm font-semibold transition ${
+                    isProcessing || isRecording
+                      ? "cursor-not-allowed bg-primary/40 text-primary-foreground/80"
+                      : "bg-primary text-primary-foreground hover:bg-primary/90"
+                  }`}
+                >
+                  Start Interview
+                </button>
+              ) : null}
               <button
                 type="button"
                 onClick={isRecording ? handleStopRecording : handleStartRecording}


### PR DESCRIPTION
### Motivation
- Provide a way for the AI persona to ask the first interview question automatically so users can begin an interview without speaking first.
- Show a clear entry point when there is no transcript and ensure controls are disabled during recording/processing to avoid race conditions.
- Keep the change scoped to the Interview tool and preserve existing push-to-talk and reset behavior.

### Description
- Added a `handleStartInterview` function that posts the prompt `Begin the interview now. Ask exactly ONE opening question. No preamble.` to the chat proxy and uses the response to append a single `assistant` entry to the transcript and trigger `sendToTts` for playback.
- Renders a `Start Interview` button when `transcript.length === 0`, and disables it while `isProcessing` or `isRecording`; styling matches existing controls.
- The new flow appends only the interviewer message (no `You:` entry) and reuses the existing `sendToChat` and `sendToTts` helpers so proxy routes/contracts remain unchanged.
- Changes confined to `ui/partner-hub/components/interview/InterviewTool.tsx` and do not alter push-to-talk, reset, or other flows.

### Testing
- Ran `npm run lint` and there were no ESLint warnings or errors (passed).
- Ran `npm run typecheck` (`tsc --noEmit`) and type checking completed successfully (passed).
- Ran `npm run build` and the Next.js build completed successfully (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972b426a0048330ab7f0bb67b3be826)