### PR TITLE
Prevent overlapping audio and hide Start Interview while recording

### DIFF
--- a/ui/partner-hub/components/interview/InterviewTool.tsx
+++ b/ui/partner-hub/components/interview/InterviewTool.tsx
@@ -438,6 +438,7 @@ export function InterviewTool() {
 
     setIsProcessing(true);
     setError(null);
+    stopAudioPlayback();
 
     try {
       const prompt = "Begin the interview now. Ask exactly ONE opening question. No preamble.";
@@ -580,7 +581,7 @@ export function InterviewTool() {
             </div>
 
             <div className="flex flex-wrap items-center gap-3">
-              {transcript.length === 0 ? (
+              {transcript.length === 0 && !isRecording ? (
                 <button
                   type="button"
                   onClick={handleStartInterview}


### PR DESCRIPTION
### Motivation
- Prevent overlapping TTS playback when starting the interview and improve UX by not showing the Start button during an active recording.

### Description
- Call `stopAudioPlayback()` at the start of `handleStartInterview()` to stop any currently playing audio and revoke existing audio URLs before generating/playing the opening question.
- Only render the "Start Interview" button when `transcript.length === 0 && !isRecording`, and keep it disabled while `isProcessing` as before.

### Testing
- Ran `npm run lint`, `npm run typecheck`, and `npm run build` in `ui/partner-hub` and all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69739c0ba3b4833086e448004ad13380)