### PR TITLE
Add route_out timing logs and truncate AI interview error logs

### DIFF
--- a/ui/partner-hub/app/api/ai-interview/chat/route.ts
+++ b/ui/partner-hub/app/api/ai-interview/chat/route.ts
@@ -28,7 +28,11 @@ export async function POST(req: Request) {
   const responseHeaders: Record<string, string> = turnId ? { "x-ai-interview-turn-id": turnId } : {};
   const routeStart = nowMs();
   serverLog("route_in", { route, method: req.method, turnId });
+  const logRouteOut = (status: number) => {
+    serverLog("route_out", { route, status, ms: nowMs() - routeStart, turnId });
+  };
   if (!aiInterviewEnabled()) {
+    logRouteOut(404);
     return NextResponse.json({ error: "AI interview is disabled." }, { status: 404, headers: responseHeaders });
   }
 
@@ -36,11 +40,13 @@ export async function POST(req: Request) {
   try {
     body = (await req.json()) as ChatRequest;
   } catch {
+    logRouteOut(400);
     return NextResponse.json({ error: "Invalid JSON body." }, { status: 400, headers: responseHeaders });
   }
 
   const prompt = body?.prompt?.trim();
   if (!prompt) {
+    logRouteOut(400);
     return NextResponse.json({ error: "prompt is required." }, { status: 400, headers: responseHeaders });
   }
 
@@ -78,6 +84,7 @@ export async function POST(req: Request) {
 
     if (!resp.ok) {
       const detail = await resp.text().catch(() => "");
+      logRouteOut(502);
       return NextResponse.json(
         {
           error: "Ollama request failed.",
@@ -91,6 +98,7 @@ export async function POST(req: Request) {
     const data = (await resp.json()) as { response?: string };
     const text = String(data?.response ?? "").trim();
 
+    logRouteOut(200);
     return NextResponse.json(
       { text },
       {
@@ -108,12 +116,14 @@ export async function POST(req: Request) {
       message: error instanceof Error ? error.message : String(error),
     });
     if (error instanceof Error && error.name === "AbortError") {
+      logRouteOut(504);
       return NextResponse.json(
         { error: "Ollama request timed out." },
         { status: 504, headers: responseHeaders },
       );
     }
     const message = error instanceof Error ? error.message : String(error);
+    logRouteOut(502);
     return NextResponse.json(
       { error: "Failed to reach Ollama.", detail: message },
       { status: 502, headers: responseHeaders },

--- a/ui/partner-hub/app/api/ai-interview/stt/route.ts
+++ b/ui/partner-hub/app/api/ai-interview/stt/route.ts
@@ -26,7 +26,11 @@ export async function POST(req: Request) {
   const responseHeaders: Record<string, string> = turnId ? { "x-ai-interview-turn-id": turnId } : {};
   const routeStart = nowMs();
   serverLog("route_in", { route, method: req.method, turnId });
+  const logRouteOut = (status: number) => {
+    serverLog("route_out", { route, status, ms: nowMs() - routeStart, turnId });
+  };
   if (!aiInterviewEnabled()) {
+    logRouteOut(404);
     return NextResponse.json({ error: "AI interview is disabled." }, { status: 404, headers: responseHeaders });
   }
 
@@ -34,6 +38,7 @@ export async function POST(req: Request) {
   try {
     formData = await req.formData();
   } catch {
+    logRouteOut(400);
     return NextResponse.json(
       { error: "Invalid multipart/form-data body." },
       { status: 400, headers: responseHeaders },
@@ -42,6 +47,7 @@ export async function POST(req: Request) {
 
   const audioFile = extractAudioFile(formData);
   if (!audioFile) {
+    logRouteOut(400);
     return NextResponse.json({ error: "audio file is required." }, { status: 400, headers: responseHeaders });
   }
 
@@ -73,6 +79,7 @@ export async function POST(req: Request) {
 
     if (!resp.ok) {
       const detail = await resp.text().catch(() => "");
+      logRouteOut(502);
       return NextResponse.json(
         {
           error: "STT request failed.",
@@ -86,6 +93,7 @@ export async function POST(req: Request) {
     const data = (await resp.json()) as { text?: string };
     const text = typeof data?.text === "string" ? data.text : "";
 
+    logRouteOut(200);
     return NextResponse.json(
       { text },
       {
@@ -103,9 +111,11 @@ export async function POST(req: Request) {
       message: error instanceof Error ? error.message : String(error),
     });
     if (error instanceof Error && error.name === "AbortError") {
+      logRouteOut(504);
       return NextResponse.json({ error: "STT request timed out." }, { status: 504, headers: responseHeaders });
     }
     const message = error instanceof Error ? error.message : String(error);
+    logRouteOut(502);
     return NextResponse.json(
       { error: "Failed to reach STT service.", detail: message },
       { status: 502, headers: responseHeaders },

--- a/ui/partner-hub/app/api/ai-interview/tts/route.ts
+++ b/ui/partner-hub/app/api/ai-interview/tts/route.ts
@@ -22,7 +22,11 @@ export async function POST(req: Request) {
   const responseHeaders: Record<string, string> = turnId ? { "x-ai-interview-turn-id": turnId } : {};
   const routeStart = nowMs();
   serverLog("route_in", { route, method: req.method, turnId });
+  const logRouteOut = (status: number) => {
+    serverLog("route_out", { route, status, ms: nowMs() - routeStart, turnId });
+  };
   if (!aiInterviewEnabled()) {
+    logRouteOut(404);
     return NextResponse.json({ error: "AI interview is disabled." }, { status: 404, headers: responseHeaders });
   }
 
@@ -30,11 +34,13 @@ export async function POST(req: Request) {
   try {
     body = (await req.json()) as TtsRequest;
   } catch {
+    logRouteOut(400);
     return NextResponse.json({ error: "Invalid JSON body." }, { status: 400, headers: responseHeaders });
   }
 
   const text = body?.text?.trim();
   if (!text) {
+    logRouteOut(400);
     return NextResponse.json({ error: "text is required." }, { status: 400, headers: responseHeaders });
   }
 
@@ -68,6 +74,7 @@ export async function POST(req: Request) {
 
     if (!resp.ok) {
       const detail = await resp.text().catch(() => "");
+      logRouteOut(502);
       return NextResponse.json(
         {
           error: "TTS request failed.",
@@ -80,6 +87,7 @@ export async function POST(req: Request) {
 
     const audio = await resp.arrayBuffer();
 
+    logRouteOut(200);
     return new Response(audio, {
       status: 200,
       headers: {
@@ -96,9 +104,11 @@ export async function POST(req: Request) {
       message: error instanceof Error ? error.message : String(error),
     });
     if (error instanceof Error && error.name === "AbortError") {
+      logRouteOut(504);
       return NextResponse.json({ error: "TTS request timed out." }, { status: 504, headers: responseHeaders });
     }
     const message = error instanceof Error ? error.message : String(error);
+    logRouteOut(502);
     return NextResponse.json(
       { error: "Failed to reach TTS service.", detail: message },
       { status: 502, headers: responseHeaders },

--- a/ui/partner-hub/components/interview/InterviewTool.tsx
+++ b/ui/partner-hub/components/interview/InterviewTool.tsx
@@ -83,6 +83,13 @@ const parseResponseText = async (response: Response) => {
   return response.text();
 };
 
+const truncateForLog = (value: string, max = 300) => {
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max)}…`;
+};
+
 const createTurnId = () => {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
     return crypto.randomUUID();
@@ -315,7 +322,7 @@ export function InterviewTool() {
       cleanupStream();
       logDebug("error", {
         step: "record_start",
-        message: err instanceof Error ? err.message : String(err),
+        message: truncateForLog(err instanceof Error ? err.message : String(err)),
         turnId: currentTurnIdRef.current,
       });
       setError(
@@ -460,7 +467,7 @@ export function InterviewTool() {
     } catch (err) {
       logDebug("error", {
         step: "recording_complete",
-        message: err instanceof Error ? err.message : String(err),
+        message: truncateForLog(err instanceof Error ? err.message : String(err)),
         turnId: currentTurnIdRef.current,
       });
       setError(err instanceof Error ? err.message : "Unexpected error while processing interview.");
@@ -494,7 +501,7 @@ export function InterviewTool() {
     } catch (err) {
       logDebug("error", {
         step: "start_interview",
-        message: err instanceof Error ? err.message : String(err),
+        message: truncateForLog(err instanceof Error ? err.message : String(err)),
         turnId,
       });
       setError(err instanceof Error ? err.message : "Unexpected error while starting interview.");
@@ -551,7 +558,7 @@ export function InterviewTool() {
       }
       logDebug("error", {
         step: "stt_request",
-        message: err instanceof Error ? err.message : String(err),
+        message: truncateForLog(err instanceof Error ? err.message : String(err)),
         turnId,
       });
       throw err;
@@ -608,7 +615,7 @@ export function InterviewTool() {
       }
       logDebug("error", {
         step: "chat_request",
-        message: err instanceof Error ? err.message : String(err),
+        message: truncateForLog(err instanceof Error ? err.message : String(err)),
         turnId,
       });
       throw err;
@@ -670,7 +677,7 @@ export function InterviewTool() {
         logDebug("audio_play_error", { turnId });
         logDebug("error", {
           step: "audio_playback",
-          message: err instanceof Error ? err.message : String(err),
+          message: truncateForLog(err instanceof Error ? err.message : String(err)),
           turnId,
         });
         throw new Error(
@@ -692,7 +699,7 @@ export function InterviewTool() {
       }
       logDebug("error", {
         step: "tts_request",
-        message: err instanceof Error ? err.message : String(err),
+        message: truncateForLog(err instanceof Error ? err.message : String(err)),
         turnId,
       });
       throw err;


### PR DESCRIPTION
### Motivation
- Improve observability by emitting a `route_out` timing log on every handled return path for AI interview routes so total route durations are visible. 
- Avoid logging giant error bodies from downstream failures on the client by truncating error messages before calling `logDebug`.

### Description
- Added a `logRouteOut(status: number)` helper and invoked it on all handled return paths (disabled, validation errors, upstream `!resp.ok`, success, and handled timeout/other error responses) in `ui/partner-hub/app/api/ai-interview/chat/route.ts`, `ui/partner-hub/app/api/ai-interview/stt/route.ts`, and `ui/partner-hub/app/api/ai-interview/tts/route.ts`, while keeping existing `serverLog("route_error", ...)` for thrown/abort cases. 
- Introduced `truncateForLog(value: string, max = 300)` in `ui/partner-hub/components/interview/InterviewTool.tsx` and replaced direct error message logging in `logDebug("error", ...)` sites to use the truncated message so large response bodies are not dumped to the console. 
- No API contracts or response bodies were changed.

### Testing
- Ran `npm run lint` in `ui/partner-hub` and it completed with no ESLint warnings or errors. 
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed without type errors. 
- Ran `npm run build` (Next.js production build) and it compiled successfully with pages generated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973fe42978c833098173076427a53cb)