### PR TITLE
Add local AI-interview STT and TTS services with docker-compose

### DIFF
--- a/ui/partner-hub/dev/ai-interview/docker-compose.yml
+++ b/ui/partner-hub/dev/ai-interview/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+
+services:
+  ai-interview-stt:
+    build:
+      context: ./services/stt
+    ports:
+      - "9000:9000"
+    environment:
+      STT_MODEL: ${STT_MODEL:-base.en}
+    volumes:
+      - ai-interview-stt-cache:/root/.cache
+
+  ai-interview-tts:
+    build:
+      context: ./services/tts
+    ports:
+      - "8000:8000"
+
+volumes:
+  ai-interview-stt-cache:

--- a/ui/partner-hub/dev/ai-interview/services/stt/Dockerfile
+++ b/ui/partner-hub/dev/ai-interview/services/stt/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir --upgrade pip
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY app.py /app/app.py
+
+ENV STT_MODEL=base.en
+
+EXPOSE 9000
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "9000"]

--- a/ui/partner-hub/dev/ai-interview/services/stt/app.py
+++ b/ui/partner-hub/dev/ai-interview/services/stt/app.py
@@ -1,0 +1,28 @@
+import os
+import tempfile
+from fastapi import FastAPI, File, UploadFile
+from faster_whisper import WhisperModel
+
+app = FastAPI()
+
+model_name = os.getenv("STT_MODEL", "base.en")
+model = WhisperModel(model_name, device="cpu", compute_type="int8")
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"ok": True}
+
+
+@app.post("/v1/audio/transcriptions")
+def transcriptions(file: UploadFile = File(...)) -> dict:
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        temp_file.write(file.file.read())
+        temp_path = temp_file.name
+
+    try:
+        segments, _info = model.transcribe(temp_path)
+        text = "".join(segment.text for segment in segments).strip()
+        return {"text": text}
+    finally:
+        os.unlink(temp_path)

--- a/ui/partner-hub/dev/ai-interview/services/stt/requirements.txt
+++ b/ui/partner-hub/dev/ai-interview/services/stt/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+python-multipart==0.0.9
+faster-whisper==1.0.3

--- a/ui/partner-hub/dev/ai-interview/services/tts/Dockerfile
+++ b/ui/partner-hub/dev/ai-interview/services/tts/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends espeak-ng ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir --upgrade pip
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY app.py /app/app.py
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/ui/partner-hub/dev/ai-interview/services/tts/app.py
+++ b/ui/partner-hub/dev/ai-interview/services/tts/app.py
@@ -1,0 +1,69 @@
+import os
+import subprocess
+import tempfile
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import Response
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class SpeechRequest(BaseModel):
+    input: str | None = None
+    text: str | None = None
+    voice: str | None = None
+    response_format: str | None = None
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"ok": True}
+
+
+@app.post("/v1/audio/speech")
+def speech(request: SpeechRequest) -> Response:
+    text = request.input or request.text
+    if not text:
+        raise HTTPException(status_code=400, detail="Missing input text")
+
+    response_format = (request.response_format or "mp3").lower()
+    if response_format not in {"mp3", "wav"}:
+        raise HTTPException(status_code=400, detail="Unsupported response_format")
+
+    mp3_path = None
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as wav_file:
+        wav_path = wav_file.name
+
+    try:
+        command = ["espeak-ng", "-w", wav_path]
+        if request.voice:
+            command.extend(["-v", request.voice])
+        command.append(text)
+        subprocess.run(command, check=True)
+
+        if response_format == "wav":
+            with open(wav_path, "rb") as wav_handle:
+                return Response(content=wav_handle.read(), media_type="audio/wav")
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as mp3_file:
+            mp3_path = mp3_file.name
+
+        subprocess.run(
+            ["ffmpeg", "-y", "-i", wav_path, "-codec:a", "libmp3lame", mp3_path],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        with open(mp3_path, "rb") as mp3_handle:
+            return Response(content=mp3_handle.read(), media_type="audio/mpeg")
+    finally:
+        try:
+            os.remove(wav_path)
+        except FileNotFoundError:
+            pass
+        if mp3_path:
+            try:
+                os.remove(mp3_path)
+            except Exception:
+                pass

--- a/ui/partner-hub/dev/ai-interview/services/tts/requirements.txt
+++ b/ui/partner-hub/dev/ai-interview/services/tts/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.115.0
+uvicorn==0.30.6

--- a/ui/partner-hub/docs/ai-interview-local.md
+++ b/ui/partner-hub/docs/ai-interview-local.md
@@ -10,6 +10,26 @@ Run these services locally (defaults shown):
 - **STT (speech-to-text)**: `http://127.0.0.1:9000`
 - **TTS (text-to-speech)**: `http://127.0.0.1:8000`
 
+## Local Services (Docker compose)
+
+These containers are intended for **local development only**.
+
+From `ui/partner-hub/dev/ai-interview`, run:
+
+```
+docker compose up -d
+```
+
+Ports used:
+
+- `9000` → STT (`/v1/audio/transcriptions`)
+- `8000` → TTS (`/v1/audio/speech`)
+
+Verify health endpoints:
+
+- `http://127.0.0.1:9000/health`
+- `http://127.0.0.1:8000/health`
+
 ## Environment variables
 
 Set these in `.env.local` (see `.env.local.example`):


### PR DESCRIPTION
### Motivation

- Provide a local, repo-owned speech-to-text and text-to-speech bundle for the AI interview feature so the Next.js app can proxy to stable, reproducible local services during development. 
- Expose OpenAI-compatible endpoints for STT and TTS so existing proxy routes and client code can work without browser CORS issues. 
- Keep changes additive and constrained to `ui/partner-hub/**` so no other partner-hub features are broken. 

### Description

- Added `ui/partner-hub/dev/ai-interview/docker-compose.yml` which defines `ai-interview-stt` (port 9000) and `ai-interview-tts` (port 8000) and a model cache volume for the STT service. 
- Implemented STT service at `ui/partner-hub/dev/ai-interview/services/stt/` with `app.py` (FastAPI) exposing `POST /v1/audio/transcriptions` and `GET /health`, a `Dockerfile`, and `requirements.txt` using `faster-whisper` and loading model from `STT_MODEL`. 
- Implemented TTS service at `ui/partner-hub/dev/ai-interview/services/tts/` with `app.py` (FastAPI) exposing `POST /v1/audio/speech` and `GET /health`, a `Dockerfile` that installs `espeak-ng` and `ffmpeg`, and `requirements.txt`; the TTS uses `espeak-ng` to produce WAV and `ffmpeg` to optionally convert to MP3 with correct content-type. 
- Updated `ui/partner-hub/docs/ai-interview-local.md` with a "Local Services (Docker compose)" section describing how to run the compose bundle, the ports used, and health endpoints. 

### Testing

- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69740ce94e788330a50464fb95570a20)