### PR TITLE
Improve local STT/TTS reliability and healthchecks

### DIFF
--- a/ui/partner-hub/dev/ai-interview/docker-compose.yml
+++ b/ui/partner-hub/dev/ai-interview/docker-compose.yml
@@ -10,12 +10,22 @@ services:
       STT_MODEL: ${STT_MODEL:-base.en}
     volumes:
       - ai-interview-stt-cache:/root/.cache
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   ai-interview-tts:
     build:
       context: ./services/tts
     ports:
       - "8000:8000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   ai-interview-stt-cache:

--- a/ui/partner-hub/dev/ai-interview/services/stt/Dockerfile
+++ b/ui/partner-hub/dev/ai-interview/services/stt/Dockerfile
@@ -2,6 +2,10 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libgomp1 curl \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN pip install --no-cache-dir --upgrade pip
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt

--- a/ui/partner-hub/dev/ai-interview/services/stt/app.py
+++ b/ui/partner-hub/dev/ai-interview/services/stt/app.py
@@ -1,11 +1,12 @@
 import os
 import tempfile
-from fastapi import FastAPI, File, UploadFile
+from fastapi import FastAPI, File, HTTPException, UploadFile
 from faster_whisper import WhisperModel
 
 app = FastAPI()
 
 model_name = os.getenv("STT_MODEL", "base.en")
+print(f"Loading STT model: {model_name}. First run may download the model.")
 model = WhisperModel(model_name, device="cpu", compute_type="int8")
 
 
@@ -17,11 +18,24 @@ def health() -> dict:
 @app.post("/v1/audio/transcriptions")
 def transcriptions(file: UploadFile = File(...)) -> dict:
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-        temp_file.write(file.file.read())
+        bytes_written = 0
+        while True:
+            chunk = file.file.read(1024 * 1024)
+            if not chunk:
+                break
+            bytes_written += len(chunk)
+            temp_file.write(chunk)
         temp_path = temp_file.name
 
+    if bytes_written == 0:
+        os.unlink(temp_path)
+        raise HTTPException(status_code=400, detail="Empty audio file")
+
     try:
-        segments, _info = model.transcribe(temp_path)
+        try:
+            segments, _info = model.transcribe(temp_path)
+        except Exception:
+            raise HTTPException(status_code=500, detail="Transcription failed")
         text = "".join(segment.text for segment in segments).strip()
         return {"text": text}
     finally:

--- a/ui/partner-hub/dev/ai-interview/services/tts/Dockerfile
+++ b/ui/partner-hub/dev/ai-interview/services/tts/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends espeak-ng ffmpeg \
+    && apt-get install -y --no-install-recommends espeak-ng ffmpeg curl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir --upgrade pip

--- a/ui/partner-hub/dev/ai-interview/services/tts/app.py
+++ b/ui/partner-hub/dev/ai-interview/services/tts/app.py
@@ -7,6 +7,8 @@ from pydantic import BaseModel
 
 app = FastAPI()
 
+MAX_INPUT_LENGTH = 2000
+
 
 class SpeechRequest(BaseModel):
     input: str | None = None
@@ -25,6 +27,11 @@ def speech(request: SpeechRequest) -> Response:
     text = request.input or request.text
     if not text:
         raise HTTPException(status_code=400, detail="Missing input text")
+    if len(text) > MAX_INPUT_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Input text exceeds {MAX_INPUT_LENGTH} characters",
+        )
 
     response_format = (request.response_format or "mp3").lower()
     if response_format not in {"mp3", "wav"}:
@@ -39,7 +46,10 @@ def speech(request: SpeechRequest) -> Response:
         if request.voice:
             command.extend(["-v", request.voice])
         command.append(text)
-        subprocess.run(command, check=True)
+        try:
+            subprocess.run(command, check=True)
+        except subprocess.CalledProcessError:
+            raise HTTPException(status_code=500, detail="espeak failed")
 
         if response_format == "wav":
             with open(wav_path, "rb") as wav_handle:
@@ -48,12 +58,15 @@ def speech(request: SpeechRequest) -> Response:
         with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as mp3_file:
             mp3_path = mp3_file.name
 
-        subprocess.run(
-            ["ffmpeg", "-y", "-i", wav_path, "-codec:a", "libmp3lame", mp3_path],
-            check=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
+        try:
+            subprocess.run(
+                ["ffmpeg", "-y", "-i", wav_path, "-codec:a", "libmp3lame", mp3_path],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except subprocess.CalledProcessError:
+            raise HTTPException(status_code=500, detail="ffmpeg failed")
 
         with open(mp3_path, "rb") as mp3_handle:
             return Response(content=mp3_handle.read(), media_type="audio/mpeg")

--- a/ui/partner-hub/docs/ai-interview-local.md
+++ b/ui/partner-hub/docs/ai-interview-local.md
@@ -25,10 +25,14 @@ Ports used:
 - `9000` → STT (`/v1/audio/transcriptions`)
 - `8000` → TTS (`/v1/audio/speech`)
 
-Verify health endpoints:
+Note: the first STT request may download the model and take a bit longer.
 
-- `http://127.0.0.1:9000/health`
-- `http://127.0.0.1:8000/health`
+## Healthchecks
+
+Each local service provides a health endpoint that returns JSON:
+
+- `http://127.0.0.1:9000/health` → `{ "ok": true }`
+- `http://127.0.0.1:8000/health` → `{ "ok": true }`
 
 ## Environment variables
 


### PR DESCRIPTION
### Motivation
- Ensure local STT/TTS containers are observable and restart-safe by adding Docker healthchecks. 
- Reduce runtime surprises and large memory usage by streaming uploads and adding basic validations. 
- Provide clearer failures for operators by catching subprocess/transcription errors and documenting first-run behavior.

### Description
- Add Docker Compose healthchecks for STT (`http://127.0.0.1:9000/health`) and TTS (`http://127.0.0.1:8000/health`) in `ui/partner-hub/dev/ai-interview/docker-compose.yml`.
- Update STT container (`services/stt/Dockerfile`) to install `libgomp1` (and `curl` for healthchecks) without recommended packages to keep the image slim.
- Harden STT API (`services/stt/app.py`) by printing a startup message about the model, reading uploaded audio in chunks to avoid loading into memory, rejecting empty uploads with `400`, and wrapping `model.transcribe` to return a `500` with a concise error on failure.
- Update TTS container (`services/tts/Dockerfile`) to install `curl` for healthchecks.
- Harden TTS API (`services/tts/app.py`) by adding a `MAX_INPUT_LENGTH` (2000 chars) with a `400` response when exceeded and wrapping `espeak-ng` and `ffmpeg` subprocess calls to return `500` with clear error messages on failures.
- Update docs (`ui/partner-hub/docs/ai-interview-local.md`) to note that the first STT run may download a model and to document the healthcheck endpoints and expected JSON.

### Testing
- No automated tests were run for these changes (no CI/test steps executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697410979da48330a4b4dd0792d3f9a5)