### PR TITLE
Increase healthcheck retries and add start_period for ai-interview services

### DIFF
--- a/ui/partner-hub/dev/ai-interview/docker-compose.yml
+++ b/ui/partner-hub/dev/ai-interview/docker-compose.yml
@@ -14,7 +14,8 @@ services:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/health"]
       interval: 10s
       timeout: 5s
-      retries: 5
+      retries: 15
+      start_period: 60s
 
   ai-interview-tts:
     build:
@@ -25,7 +26,8 @@ services:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
       interval: 10s
       timeout: 5s
-      retries: 5
+      retries: 15
+      start_period: 60s
 
 volumes:
   ai-interview-stt-cache:


### PR DESCRIPTION
### Motivation
- Give the STT and TTS services more startup time and resilience by increasing healthcheck retry attempts and adding a 60s start period.

### Description
- Updated `ui/partner-hub/dev/ai-interview/docker-compose.yml` to set `retries: 15` and add `start_period: 60s` under the `healthcheck` for `ai-interview-stt` and `ai-interview-tts`, leaving all other configuration unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697413f9cf54833091a982ede8e56cae)