### PR TITLE
Add Windows PowerShell up/down scripts and docs for AI-interview services

### DIFF
--- a/ui/partner-hub/docs/ai-interview-local.md
+++ b/ui/partner-hub/docs/ai-interview-local.md
@@ -27,6 +27,20 @@ Ports used:
 
 Note: the first STT request may download the model and take a bit longer.
 
+## Quick Start (Windows PowerShell)
+
+From `ui/partner-hub`, run:
+
+```
+.\scripts\ai-interview-services-up.ps1
+```
+
+When you're done:
+
+```
+.\scripts\ai-interview-services-down.ps1
+```
+
 ## Healthchecks
 
 Each local service provides a health endpoint that returns JSON:

--- a/ui/partner-hub/scripts/ai-interview-services-down.ps1
+++ b/ui/partner-hub/scripts/ai-interview-services-down.ps1
@@ -1,0 +1,9 @@
+$composeFile = Join-Path $PSScriptRoot "..\dev\ai-interview\docker-compose.yml"
+
+Write-Host "Stopping AI interview services..."
+docker compose -f $composeFile down
+if ($LASTEXITCODE -ne 0) {
+  exit $LASTEXITCODE
+}
+
+exit 0

--- a/ui/partner-hub/scripts/ai-interview-services-up.ps1
+++ b/ui/partner-hub/scripts/ai-interview-services-up.ps1
@@ -1,0 +1,78 @@
+$composeFile = Join-Path $PSScriptRoot "..\dev\ai-interview\docker-compose.yml"
+
+Write-Host "Starting AI interview services..."
+docker compose -f $composeFile up -d --build
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "Failed to start docker compose services."
+  exit $LASTEXITCODE
+}
+
+function Test-Health {
+  param (
+    [string]$Name,
+    [string]$Url
+  )
+
+  $supportsSkipHttpErrorCheck = (Get-Command Invoke-WebRequest).Parameters.ContainsKey('SkipHttpErrorCheck')
+  $supportsUseBasicParsing = (Get-Command Invoke-WebRequest).Parameters.ContainsKey('UseBasicParsing')
+  $requestParams = @{
+    Uri = $Url
+    Method = 'Get'
+    TimeoutSec = 2
+  }
+  if ($supportsSkipHttpErrorCheck) {
+    $requestParams.SkipHttpErrorCheck = $true
+  }
+  if ($supportsUseBasicParsing) {
+    $requestParams.UseBasicParsing = $true
+  }
+
+  try {
+    $response = Invoke-WebRequest @requestParams
+    return ($response.StatusCode -ge 200 -and $response.StatusCode -lt 400)
+  } catch {
+    if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+      return ($statusCode -ge 200 -and $statusCode -lt 400)
+    }
+  }
+
+  return $false
+}
+
+function Wait-ForHealth {
+  param (
+    [string]$Name,
+    [string]$Url,
+    [int]$Retries = 10,
+    [int]$DelaySeconds = 2
+  )
+
+  for ($attempt = 1; $attempt -le $Retries; $attempt++) {
+    if (Test-Health -Name $Name -Url $Url) {
+      Write-Host "PASS: $Name ($Url)"
+      return $true
+    }
+
+    Write-Host "Waiting for $Name ($Url)... attempt $attempt/$Retries"
+    Start-Sleep -Seconds $DelaySeconds
+  }
+
+  Write-Host "FAIL: $Name ($Url)"
+  return $false
+}
+
+$sttHealthy = Wait-ForHealth -Name "STT" -Url "http://127.0.0.1:9000/health"
+$ttsHealthy = Wait-ForHealth -Name "TTS" -Url "http://127.0.0.1:8000/health"
+
+if (-not $sttHealthy -or -not $ttsHealthy) {
+  exit 1
+}
+
+Write-Host "Running AI interview checks..."
+& (Join-Path $PSScriptRoot "ai-interview-check.ps1")
+if ($LASTEXITCODE -ne 0) {
+  exit $LASTEXITCODE
+}
+
+exit 0


### PR DESCRIPTION
### Motivation

- Provide a Windows PowerShell-first, one-command workflow to start/stop the local AI-interview docker services and to verify they are healthy before running follow-up checks.

### Description

- Add `ui/partner-hub/scripts/ai-interview-services-up.ps1` which runs `docker compose -f ui/partner-hub/dev/ai-interview/docker-compose.yml up -d --build`, waits with a retry loop for `http://127.0.0.1:9000/health` and `http://127.0.0.1:8000/health`, then invokes the existing `ai-interview-check.ps1` and exits non-zero on failure.
- Add `ui/partner-hub/scripts/ai-interview-services-down.ps1` which runs `docker compose -f ui/partner-hub/dev/ai-interview/docker-compose.yml down` and returns the compose exit code.
- Update `ui/partner-hub/docs/ai-interview-local.md` to add a `Quick Start (Windows PowerShell)` section showing `.\iles\scripts\ai-interview-services-up.ps1` and `.\iles\scripts\ai-interview-services-down.ps1` usage from `ui/partner-hub`.

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697414dab24c8330b132278f904c9e59)