### PR TITLE
Improve AI interview service scripts reliability

### DIFF
--- a/ui/partner-hub/docs/ai-interview-local.md
+++ b/ui/partner-hub/docs/ai-interview-local.md
@@ -35,6 +35,8 @@ From `ui/partner-hub`, run:
 .\scripts\ai-interview-services-up.ps1
 ```
 
+First run may take a couple minutes while images build.
+
 When you're done:
 
 ```

--- a/ui/partner-hub/scripts/ai-interview-services-down.ps1
+++ b/ui/partner-hub/scripts/ai-interview-services-down.ps1
@@ -3,6 +3,12 @@ $composeFile = Join-Path $PSScriptRoot "..\dev\ai-interview\docker-compose.yml"
 Write-Host "Stopping AI interview services..."
 docker compose -f $composeFile down
 if ($LASTEXITCODE -ne 0) {
+  $runningServices = docker compose -f $composeFile ps -q
+  if ([string]::IsNullOrWhiteSpace($runningServices)) {
+    Write-Host "No AI interview services are running."
+    exit 0
+  }
+
   exit $LASTEXITCODE
 }
 

--- a/ui/partner-hub/scripts/ai-interview-services-up.ps1
+++ b/ui/partner-hub/scripts/ai-interview-services-up.ps1
@@ -1,6 +1,17 @@
 $composeFile = Join-Path $PSScriptRoot "..\dev\ai-interview\docker-compose.yml"
 
 Write-Host "Starting AI interview services..."
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+  Write-Host "Docker Desktop not running"
+  exit 1
+}
+
+docker compose version *> $null
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "Docker Compose is not available. Please install Docker Desktop."
+  exit 1
+}
+
 docker compose -f $composeFile up -d --build
 if ($LASTEXITCODE -ne 0) {
   Write-Host "Failed to start docker compose services."
@@ -44,7 +55,7 @@ function Wait-ForHealth {
   param (
     [string]$Name,
     [string]$Url,
-    [int]$Retries = 10,
+    [int]$Retries = 60,
     [int]$DelaySeconds = 2
   )
 
@@ -66,6 +77,9 @@ $sttHealthy = Wait-ForHealth -Name "STT" -Url "http://127.0.0.1:9000/health"
 $ttsHealthy = Wait-ForHealth -Name "TTS" -Url "http://127.0.0.1:8000/health"
 
 if (-not $sttHealthy -or -not $ttsHealthy) {
+  Write-Host "Service health checks failed. Collecting diagnostics..."
+  docker compose -f $composeFile ps
+  docker compose -f $composeFile logs --tail 150
   exit 1
 }
 


### PR DESCRIPTION
### Motivation

- Increase robustness of the Windows PowerShell helpers that start and stop the local AI interview Docker services.  
- Fail fast with clear messages when Docker or Docker Compose are not available to avoid confusing errors.  
- Provide actionable diagnostics when service healthchecks fail and avoid treating "nothing to stop" during shutdown as an error.

### Description

- Added Docker preflight checks to `ui/partner-hub/scripts/ai-interview-services-up.ps1` to detect missing `docker` or `docker compose` and print clear messages before exiting.  
- Increased the `Wait-ForHealth` default retries to `60` and kept the `DelaySeconds` at `2` to allow longer startup time for images and services.  
- When health checks fail in `ai-interview-services-up.ps1`, the script now prints a short diagnostics summary and runs `docker compose -f $composeFile ps` and `docker compose -f $composeFile logs --tail 150` before exiting with failure.  
- Made `ui/partner-hub/scripts/ai-interview-services-down.ps1` tolerant of the case where no services are running by checking `docker compose -f $composeFile ps -q` and exiting `0` with a friendly message if nothing is running.  
- Small docs tweak in `ui/partner-hub/docs/ai-interview-local.md` adding a note that the first run may take a couple minutes while images build.

### Testing

- No automated tests were run for these script and documentation changes; updates are limited to PowerShell scripts and a documentation note and were validated by static inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697682f37b5483308b29d51ff778aff0)