### PR TITLE
Add Docker preflight checks to ai-interview-services-down.ps1

### DIFF
--- a/ui/partner-hub/scripts/ai-interview-services-down.ps1
+++ b/ui/partner-hub/scripts/ai-interview-services-down.ps1
@@ -1,6 +1,17 @@
 $composeFile = Join-Path $PSScriptRoot "..\dev\ai-interview\docker-compose.yml"
 
 Write-Host "Stopping AI interview services..."
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+  Write-Host "Docker not found. Nothing to stop."
+  exit 0
+}
+
+docker compose version *> $null
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "Docker Desktop not running (compose unavailable). Nothing to stop."
+  exit 0
+}
+
 docker compose -f $composeFile down
 if ($LASTEXITCODE -ne 0) {
   $runningServices = docker compose -f $composeFile ps -q


### PR DESCRIPTION
### Motivation
- Prevent `down` from failing when Docker Desktop isn't running or `docker`/`compose` are unavailable so stopping services becomes a no-op with a friendly message.

### Description
- Added preflight checks that use `Get-Command docker` and `docker compose version` to detect missing `docker` or unavailable compose, print `Docker not found. Nothing to stop.` or `Docker Desktop not running (compose unavailable). Nothing to stop.` and exit 0, while preserving the existing compose file resolution via `$PSScriptRoot`/`Join-Path` and still running `docker compose -f $composeFile down` when available.

### Testing
- No automated tests were run for this script-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976843005908330accd7270bfd30e34)