### PR TITLE
Silence docker compose down output in AI interview stop script

### DIFF
--- a/ui/partner-hub/scripts/ai-interview-services-down.ps1
+++ b/ui/partner-hub/scripts/ai-interview-services-down.ps1
@@ -12,7 +12,7 @@ if ($LASTEXITCODE -ne 0) {
   exit 0
 }
 
-docker compose -f $composeFile down
+docker compose -f $composeFile down *> $null
 if ($LASTEXITCODE -ne 0) {
   $runningServices = docker compose -f $composeFile ps -q
   if ([string]::IsNullOrWhiteSpace($runningServices)) {


### PR DESCRIPTION
### Motivation
- Reduce noisy console output when stopping the AI interview services while preserving the existing Docker preflight checks and exit semantics.

### Description
- In `ui/partner-hub/scripts/ai-interview-services-down.ps1` redirect both stdout and stderr for `docker compose -f $composeFile down` to `$null` by changing it to `docker compose -f $composeFile down *> $null`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976850a8f1c83308f57c76cd001d5c9)