### PR TITLE
Add AI interview STT/TTS PowerShell smoke test scripts and docs

### DIFF
--- a/ui/partner-hub/docs/ai-interview-local.md
+++ b/ui/partner-hub/docs/ai-interview-local.md
@@ -50,6 +50,17 @@ Each local service provides a health endpoint that returns JSON:
 - `http://127.0.0.1:9000/health` → `{ "ok": true }`
 - `http://127.0.0.1:8000/health` → `{ "ok": true }`
 
+## Smoke tests (Windows PowerShell)
+
+From `ui/partner-hub`, run:
+
+```
+.\scripts\ai-interview-tts-smoke.ps1
+.\scripts\ai-interview-stt-smoke.ps1
+```
+
+The TTS command saves output to `ui/partner-hub/tmp/tts-smoke.mp3`. The STT command generates a tiny WAV file in `ui/partner-hub/tmp/stt-smoke.wav` and prints the transcription response.
+
 ## Environment variables
 
 Set these in `.env.local` (see `.env.local.example`):

--- a/ui/partner-hub/scripts/ai-interview-stt-smoke.ps1
+++ b/ui/partner-hub/scripts/ai-interview-stt-smoke.ps1
@@ -1,0 +1,58 @@
+$SttUrl = if ($env:AI_INTERVIEW_STT_URL) { $env:AI_INTERVIEW_STT_URL } else { "http://127.0.0.1:9000" }
+
+$scriptRoot = $PSScriptRoot
+$tmpDir = Join-Path $scriptRoot ".." "tmp"
+$null = New-Item -ItemType Directory -Path $tmpDir -Force
+
+$wavPath = Join-Path $tmpDir "stt-smoke.wav"
+
+$sampleRate = 16000
+$channels = 1
+$bitsPerSample = 16
+$durationSeconds = 0.25
+
+$sampleCount = [int]($sampleRate * $durationSeconds)
+$dataSize = $sampleCount * $channels * ($bitsPerSample / 8)
+$riffSize = 36 + $dataSize
+$byteRate = $sampleRate * $channels * ($bitsPerSample / 8)
+$blockAlign = $channels * ($bitsPerSample / 8)
+
+$stream = [System.IO.File]::Open($wavPath, [System.IO.FileMode]::Create)
+$writer = [System.IO.BinaryWriter]::new($stream)
+
+try {
+  $writer.Write([System.Text.Encoding]::ASCII.GetBytes("RIFF"))
+  $writer.Write([int]$riffSize)
+  $writer.Write([System.Text.Encoding]::ASCII.GetBytes("WAVE"))
+  $writer.Write([System.Text.Encoding]::ASCII.GetBytes("fmt "))
+  $writer.Write([int]16)
+  $writer.Write([int16]1)
+  $writer.Write([int16]$channels)
+  $writer.Write([int]$sampleRate)
+  $writer.Write([int]$byteRate)
+  $writer.Write([int16]$blockAlign)
+  $writer.Write([int16]$bitsPerSample)
+  $writer.Write([System.Text.Encoding]::ASCII.GetBytes("data"))
+  $writer.Write([int]$dataSize)
+
+  $writer.Write((New-Object byte[] $dataSize))
+} finally {
+  $writer.Dispose()
+  $stream.Dispose()
+}
+
+$client = [System.Net.Http.HttpClient]::new()
+$form = [System.Net.Http.MultipartFormDataContent]::new()
+$fileBytes = [System.IO.File]::ReadAllBytes($wavPath)
+$fileContent = [System.Net.Http.ByteArrayContent]::new($fileBytes)
+$fileContent.Headers.ContentType = [System.Net.Http.Headers.MediaTypeHeaderValue]::Parse("audio/wav")
+$form.Add($fileContent, "file", "stt-smoke.wav")
+
+$response = $client.PostAsync(($SttUrl.TrimEnd('/') + "/v1/audio/transcriptions"), $form).Result
+$responseBody = $response.Content.ReadAsStringAsync().Result
+
+if (-not $response.IsSuccessStatusCode) {
+  throw "STT request failed with status $($response.StatusCode): $responseBody"
+}
+
+Write-Host $responseBody

--- a/ui/partner-hub/scripts/ai-interview-tts-smoke.ps1
+++ b/ui/partner-hub/scripts/ai-interview-tts-smoke.ps1
@@ -1,0 +1,15 @@
+$TtsUrl = if ($env:AI_INTERVIEW_TTS_URL) { $env:AI_INTERVIEW_TTS_URL } else { "http://127.0.0.1:8000" }
+
+$scriptRoot = $PSScriptRoot
+$tmpDir = Join-Path $scriptRoot ".." "tmp"
+$null = New-Item -ItemType Directory -Path $tmpDir -Force
+
+$outputPath = Join-Path $tmpDir "tts-smoke.mp3"
+$payload = @{
+  input = "hello from tts"
+  response_format = "mp3"
+} | ConvertTo-Json
+
+Invoke-WebRequest -Uri ($TtsUrl.TrimEnd('/') + "/v1/audio/speech") -Method Post -ContentType "application/json" -Body $payload -OutFile $outputPath
+
+Write-Host "Saved TTS output to $outputPath"


### PR DESCRIPTION
### Motivation

- Provide minimal, local smoke tests to validate the STT and TTS endpoints independently for local development and debugging.
- Keep the change limited to scripts and documentation only, without modifying Next app behavior.

### Description

- Add `ui/partner-hub/scripts/ai-interview-tts-smoke.ps1` which POSTs `{"input": "hello from tts", "response_format": "mp3"}` to `http://127.0.0.1:8000/v1/audio/speech` and saves output to `ui/partner-hub/tmp/tts-smoke.mp3`.
- Add `ui/partner-hub/scripts/ai-interview-stt-smoke.ps1` which generates a small WAV file at `ui/partner-hub/tmp/stt-smoke.wav` and POSTs it multipart to `http://127.0.0.1:9000/v1/audio/transcriptions`, then prints the transcription response.
- Update `ui/partner-hub/docs/ai-interview-local.md` to document running both smoke tests from `ui/partner-hub` via `.	ools
t` and the created `tmp` outputs.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697685ed6d84833091376cf620a25dc7)