### PR TITLE
Improve AI interview TTS/STT smoke scripts with error handling and diagnostics

### DIFF
--- a/ui/partner-hub/docs/ai-interview-local.md
+++ b/ui/partner-hub/docs/ai-interview-local.md
@@ -59,7 +59,7 @@ From `ui/partner-hub`, run:
 .\scripts\ai-interview-stt-smoke.ps1
 ```
 
-The TTS command saves output to `ui/partner-hub/tmp/tts-smoke.mp3`. The STT command generates a tiny WAV file in `ui/partner-hub/tmp/stt-smoke.wav` and prints the transcription response.
+The TTS command saves output to `ui/partner-hub/tmp/tts-smoke.mp3`. The STT command generates a tiny WAV file in `ui/partner-hub/tmp/stt-smoke.wav` and prints the transcription response. STT smoke uses a silent WAV; an empty transcript is expected but the request should return 200.
 
 ## Environment variables
 

--- a/ui/partner-hub/scripts/ai-interview-stt-smoke.ps1
+++ b/ui/partner-hub/scripts/ai-interview-stt-smoke.ps1
@@ -43,16 +43,51 @@ try {
 
 $client = [System.Net.Http.HttpClient]::new()
 $form = [System.Net.Http.MultipartFormDataContent]::new()
-$fileBytes = [System.IO.File]::ReadAllBytes($wavPath)
-$fileContent = [System.Net.Http.ByteArrayContent]::new($fileBytes)
-$fileContent.Headers.ContentType = [System.Net.Http.Headers.MediaTypeHeaderValue]::Parse("audio/wav")
-$form.Add($fileContent, "file", "stt-smoke.wav")
+$fileContent = $null
 
-$response = $client.PostAsync(($SttUrl.TrimEnd('/') + "/v1/audio/transcriptions"), $form).Result
-$responseBody = $response.Content.ReadAsStringAsync().Result
+$sttEndpoint = $SttUrl.TrimEnd('/') + "/v1/audio/transcriptions"
 
-if (-not $response.IsSuccessStatusCode) {
-  throw "STT request failed with status $($response.StatusCode): $responseBody"
+try {
+  $fileBytes = [System.IO.File]::ReadAllBytes($wavPath)
+  $fileContent = [System.Net.Http.ByteArrayContent]::new($fileBytes)
+  $fileContent.Headers.ContentType = [System.Net.Http.Headers.MediaTypeHeaderValue]::Parse("audio/wav")
+  $form.Add($fileContent, "file", "stt-smoke.wav")
+
+  $response = $client.PostAsync($sttEndpoint, $form).Result
+  $responseBody = $response.Content.ReadAsStringAsync().Result
+
+  if (-not $response.IsSuccessStatusCode) {
+    throw "STT request failed with status $($response.StatusCode)"
+  }
+
+  Write-Host $responseBody
+  Write-Host "Silence sample may return empty text; success is HTTP 200."
+  exit 0
+} catch {
+  Write-Host "STT request failed."
+  Write-Host "URL called: $sttEndpoint"
+
+  $statusCode = $null
+  $responseBody = $null
+  if ($null -ne $response) {
+    $statusCode = [int]$response.StatusCode
+    $responseBody = $response.Content.ReadAsStringAsync().Result
+  }
+
+  if ($null -ne $statusCode) {
+    Write-Host "HTTP status code: $statusCode"
+  }
+  if ($null -ne $responseBody) {
+    if ($responseBody.Length -gt 500) {
+      $responseBody = $responseBody.Substring(0, 500) + "..."
+    }
+    Write-Host "Response body: $responseBody"
+  }
+  exit 1
+} finally {
+  if ($null -ne $fileContent) {
+    $fileContent.Dispose()
+  }
+  $form.Dispose()
+  $client.Dispose()
 }
-
-Write-Host $responseBody

--- a/ui/partner-hub/scripts/ai-interview-tts-smoke.ps1
+++ b/ui/partner-hub/scripts/ai-interview-tts-smoke.ps1
@@ -10,6 +10,58 @@ $payload = @{
   response_format = "mp3"
 } | ConvertTo-Json
 
-Invoke-WebRequest -Uri ($TtsUrl.TrimEnd('/') + "/v1/audio/speech") -Method Post -ContentType "application/json" -Body $payload -OutFile $outputPath
+$ttsEndpoint = $TtsUrl.TrimEnd('/') + "/v1/audio/speech"
 
-Write-Host "Saved TTS output to $outputPath"
+try {
+  $response = Invoke-WebRequest -Uri $ttsEndpoint -Method Post -ContentType "application/json" -Body $payload -OutFile $outputPath -ErrorAction Stop
+} catch {
+  Write-Host "TTS request failed."
+  Write-Host "URL called: $ttsEndpoint"
+
+  $statusCode = $null
+  $responseBody = $null
+  $exception = $_.Exception
+  if ($exception -and $exception.Response) {
+    if ($exception.Response -is [System.Net.Http.HttpResponseMessage]) {
+      $statusCode = [int]$exception.Response.StatusCode
+      $responseBody = $exception.Response.Content.ReadAsStringAsync().Result
+    } elseif ($exception.Response -is [System.Net.HttpWebResponse]) {
+      $statusCode = [int]$exception.Response.StatusCode
+      $stream = $exception.Response.GetResponseStream()
+      if ($stream) {
+        $reader = [System.IO.StreamReader]::new($stream)
+        try {
+          $responseBody = $reader.ReadToEnd()
+        } finally {
+          $reader.Dispose()
+          $stream.Dispose()
+        }
+      }
+    }
+  }
+
+  if ($null -ne $statusCode) {
+    Write-Host "HTTP status code: $statusCode"
+  }
+  if ($null -ne $responseBody) {
+    if ($responseBody.Length -gt 500) {
+      $responseBody = $responseBody.Substring(0, 500) + "..."
+    }
+    Write-Host "Response body: $responseBody"
+  }
+  exit 1
+}
+
+if (-not (Test-Path $outputPath)) {
+  Write-Host "TTS request succeeded but output file is missing at $outputPath"
+  exit 1
+}
+
+$fileInfo = Get-Item $outputPath
+if ($fileInfo.Length -le 0) {
+  Write-Host "TTS request succeeded but output file is empty at $outputPath"
+  exit 1
+}
+
+Write-Host ("Saved TTS output ({0} bytes) to {1}" -f $fileInfo.Length, $outputPath)
+exit 0


### PR DESCRIPTION
### Motivation
- Make local smoke tests for AI interview TTS and STT more robust and actionable by adding error diagnostics and deterministic exit codes.
- Avoid lingering HTTP/form handles after STT requests by ensuring proper disposal of `HttpClient`/`MultipartFormDataContent`/file content.
- Clarify expected behavior for the silent STT sample in local documentation so users aren't confused by an empty transcript.

### Description
- Wrap the TTS request in `try/catch`, print the called URL and, on failure, print the HTTP status code (when available) and a truncated response body, then `exit 1` on error; on success verify the output file exists and has size > 0, print the saved path and byte size, and `exit 0` (`ui/partner-hub/scripts/ai-interview-tts-smoke.ps1`).
- Wrap the STT request in `try/catch`, print the called URL and diagnostics on failure (HTTP status and truncated response body) and `exit 1` on error, and on success print the raw response body plus the friendly note `Silence sample may return empty text; success is HTTP 200.`; ensure disposal of `HttpClient`, `MultipartFormDataContent`, and the file content in `finally` (`ui/partner-hub/scripts/ai-interview-stt-smoke.ps1`).
- Update `ui/partner-hub/docs/ai-interview-local.md` to note that the STT smoke uses a silent WAV and that an empty transcript is expected while the request should return HTTP 200.

### Testing
- No automated tests were run for these script changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976876c947c83309c35aef81e786c72)