### PR TITLE
Initialize response variables in STT smoke script

### DIFF
--- a/ui/partner-hub/scripts/ai-interview-stt-smoke.ps1
+++ b/ui/partner-hub/scripts/ai-interview-stt-smoke.ps1
@@ -44,6 +44,8 @@ try {
 $client = [System.Net.Http.HttpClient]::new()
 $form = [System.Net.Http.MultipartFormDataContent]::new()
 $fileContent = $null
+$response = $null
+$responseBody = $null
 
 $sttEndpoint = $SttUrl.TrimEnd('/') + "/v1/audio/transcriptions"
 


### PR DESCRIPTION
### Motivation
- Ensure the catch block diagnostics always reference defined variables by initializing `$response` and `$responseBody` before the request `try` block.

### Description
- Add explicit initializations ` $response = $null` and `$responseBody = $null` immediately before the STT request endpoint `try` block, preserving the existing `try/catch/finally` flow and behavior.

### Testing
- No automated tests were run for this change since it is a small, initialization-only script modification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976884ef4988330af4f3e435a745bfe)