### PR TITLE
Fix PowerShell smoke scripts for PS 5.1 compatibility

### DIFF
--- a/ui/partner-hub/scripts/ai-interview-stt-smoke.ps1
+++ b/ui/partner-hub/scripts/ai-interview-stt-smoke.ps1
@@ -1,8 +1,9 @@
 $SttUrl = if ($env:AI_INTERVIEW_STT_URL) { $env:AI_INTERVIEW_STT_URL } else { "http://127.0.0.1:9000" }
 
 $scriptRoot = $PSScriptRoot
-$tmpDir = Join-Path $scriptRoot ".." "tmp"
-$null = New-Item -ItemType Directory -Path $tmpDir -Force
+$repoRoot = Resolve-Path (Join-Path $scriptRoot "..")
+$tmpDir = Join-Path $repoRoot "tmp"
+New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
 
 $wavPath = Join-Path $tmpDir "stt-smoke.wav"
 

--- a/ui/partner-hub/scripts/ai-interview-tts-smoke.ps1
+++ b/ui/partner-hub/scripts/ai-interview-tts-smoke.ps1
@@ -1,8 +1,9 @@
 $TtsUrl = if ($env:AI_INTERVIEW_TTS_URL) { $env:AI_INTERVIEW_TTS_URL } else { "http://127.0.0.1:8000" }
 
 $scriptRoot = $PSScriptRoot
-$tmpDir = Join-Path $scriptRoot ".." "tmp"
-$null = New-Item -ItemType Directory -Path $tmpDir -Force
+$repoRoot = Resolve-Path (Join-Path $scriptRoot "..")
+$tmpDir = Join-Path $repoRoot "tmp"
+New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
 
 $outputPath = Join-Path $tmpDir "tts-smoke.mp3"
 $payload = @{
@@ -13,7 +14,19 @@ $payload = @{
 $ttsEndpoint = $TtsUrl.TrimEnd('/') + "/v1/audio/speech"
 
 try {
-  $response = Invoke-WebRequest -Uri $ttsEndpoint -Method Post -ContentType "application/json" -Body $payload -OutFile $outputPath -ErrorAction Stop
+  $iwrParams = @{
+    Method = "Post"
+    Uri = $ttsEndpoint
+    ContentType = "application/json"
+    Body = $payload
+    OutFile = $outputPath
+    ErrorAction = "Stop"
+    TimeoutSec = 60
+  }
+  if ((Get-Command Invoke-WebRequest).Parameters.ContainsKey("UseBasicParsing")) {
+    $iwrParams.UseBasicParsing = $true
+  }
+  $response = Invoke-WebRequest @iwrParams
 } catch {
   Write-Host "TTS request failed."
   Write-Host "URL called: $ttsEndpoint"


### PR DESCRIPTION
### Motivation
- Ensure the partner-hub smoke PowerShell scripts run on PowerShell 5.1 by fixing path construction and removing the interactive "Security Warning" prompt from `Invoke-WebRequest` usage.
- Preserve existing behavior including the TTS output location `ui/partner-hub/tmp/tts-smoke.mp3` and existing exit codes and PASS/FAIL semantics.

### Description
- Replace 3-argument `Join-Path` calls with a PS 5.1-compatible pattern using `Resolve-Path (Join-Path $scriptRoot "..")` and `Join-Path $repoRoot "tmp"` and create the directory via `New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null` in both `ai-interview-tts-smoke.ps1` and `ai-interview-stt-smoke.ps1`.
- Change the TTS script to call `Invoke-WebRequest` with a splatted parameter hashtable including `ErrorAction = "Stop"` and `TimeoutSec = 60`, and only add `UseBasicParsing = $true` to the hashtable when the parameter exists to avoid the security prompt on older PowerShell.
- Keep the TTS output saved to the same path (`tmp/tts-smoke.mp3`) and retain existing error handling and exit codes when requests fail or files are missing/empty.
- Modified files: `ui/partner-hub/scripts/ai-interview-tts-smoke.ps1` and `ui/partner-hub/scripts/ai-interview-stt-smoke.ps1`.

### Testing
- No automated tests were run against these changes.
- Basic repository checks (file diffs and commits) were performed to verify the changes were applied and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69768cec501c8330a46d04cbe2ce12b6)