### PR TITLE
Normalize TTS voice handling and surface espeak stderr

### DIFF
--- a/ui/partner-hub/dev/ai-interview/services/tts/app.py
+++ b/ui/partner-hub/dev/ai-interview/services/tts/app.py
@@ -37,19 +37,26 @@ def speech(request: SpeechRequest) -> Response:
     if response_format not in {"mp3", "wav"}:
         raise HTTPException(status_code=400, detail="Unsupported response_format")
 
+    voice = (request.voice or "").strip()
+    if not voice:
+        voice = "en-us"
+
     mp3_path = None
     with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as wav_file:
         wav_path = wav_file.name
 
     try:
         command = ["espeak-ng", "-w", wav_path]
-        if request.voice:
-            command.extend(["-v", request.voice])
+        if voice:
+            command.extend(["-v", voice])
         command.append(text)
         try:
-            subprocess.run(command, check=True)
-        except subprocess.CalledProcessError:
-            raise HTTPException(status_code=500, detail="espeak failed")
+            subprocess.run(command, check=True, capture_output=True, text=True)
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip()
+            if len(stderr) > 500:
+                stderr = f"{stderr[:500]}..."
+            raise HTTPException(status_code=500, detail=f"espeak failed: {stderr}")
 
         if response_format == "wav":
             with open(wav_path, "rb") as wav_handle:


### PR DESCRIPTION
### Motivation
- Ensure the TTS endpoint does not pass empty voice values to `espeak-ng`, provide a sensible default voice, and give more actionable error details when `espeak-ng` fails while keeping the existing endpoint contract (`POST /v1/audio/speech`).

### Description
- Normalize the incoming `voice` with `voice = (request.voice or "").strip()` and set a default `voice = "en-us"` when empty. 
- Only include the `-v` flag when `voice` is non-empty so empty strings are not passed to `espeak-ng`.
- Capture `espeak-ng` stderr by running `subprocess.run(..., capture_output=True, text=True)` and on failure return `detail: "espeak failed: <stderr truncated to 500 chars>"` in the `HTTPException`.
- Kept the endpoint behavior unchanged: `POST /v1/audio/speech` still returns raw `wav` or `mp3` bytes based on `response_format`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976939065e483308d3a56573e5bcfa3)