### PR TITLE
Harden TTS sanitization and locale handling

### DIFF
--- a/ui/partner-hub/dev/ai-interview/services/tts/Dockerfile
+++ b/ui/partner-hub/dev/ai-interview/services/tts/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends espeak-ng ffmpeg curl \
     && rm -rf /var/lib/apt/lists/*

--- a/ui/partner-hub/dev/ai-interview/services/tts/app.py
+++ b/ui/partner-hub/dev/ai-interview/services/tts/app.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 import tempfile
 from fastapi import FastAPI, HTTPException
@@ -8,6 +9,27 @@ from pydantic import BaseModel
 app = FastAPI()
 
 MAX_INPUT_LENGTH = 2000
+MAX_ERROR_DETAIL_LENGTH = 500
+
+
+_CONTROL_CHAR_PATTERN = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]")
+
+
+def sanitize_tts_text(text: str) -> str:
+    sanitized = text.replace("\r\n", "\n").replace("\r", "\n")
+    sanitized = sanitized.replace("`", "")
+    sanitized = sanitized.replace("**", "").replace("__", "")
+    sanitized = (
+        sanitized.replace("“", '"')
+        .replace("”", '"')
+        .replace("‘", "'")
+        .replace("’", "'")
+        .replace("—", "-")
+        .replace("–", "-")
+    )
+    sanitized = _CONTROL_CHAR_PATTERN.sub("", sanitized)
+    sanitized = re.sub(r"\s+", " ", sanitized).strip()
+    return sanitized
 
 
 class SpeechRequest(BaseModel):
@@ -27,7 +49,10 @@ def speech(request: SpeechRequest) -> Response:
     text = request.input or request.text
     if not text:
         raise HTTPException(status_code=400, detail="Missing input text")
-    if len(text) > MAX_INPUT_LENGTH:
+    sanitized_text = sanitize_tts_text(text)
+    if not sanitized_text:
+        raise HTTPException(status_code=400, detail="Missing input text")
+    if len(sanitized_text) > MAX_INPUT_LENGTH:
         raise HTTPException(
             status_code=400,
             detail=f"Input text exceeds {MAX_INPUT_LENGTH} characters",
@@ -46,16 +71,21 @@ def speech(request: SpeechRequest) -> Response:
         wav_path = wav_file.name
 
     try:
-        command = ["espeak-ng", "-w", wav_path]
+        command = ["espeak-ng", "--stdin", "-w", wav_path]
         if voice:
             command.extend(["-v", voice])
-        command.append(text)
         try:
-            subprocess.run(command, check=True, capture_output=True, text=True)
+            subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+                input=sanitized_text,
+            )
         except subprocess.CalledProcessError as exc:
             stderr = (exc.stderr or "").strip()
-            if len(stderr) > 500:
-                stderr = f"{stderr[:500]}..."
+            if len(stderr) > MAX_ERROR_DETAIL_LENGTH:
+                stderr = f"{stderr[:MAX_ERROR_DETAIL_LENGTH]}..."
             raise HTTPException(status_code=500, detail=f"espeak failed: {stderr}")
 
         if response_format == "wav":
@@ -69,11 +99,14 @@ def speech(request: SpeechRequest) -> Response:
             subprocess.run(
                 ["ffmpeg", "-y", "-i", wav_path, "-codec:a", "libmp3lame", mp3_path],
                 check=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
             )
-        except subprocess.CalledProcessError:
-            raise HTTPException(status_code=500, detail="ffmpeg failed")
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip()
+            if len(stderr) > MAX_ERROR_DETAIL_LENGTH:
+                stderr = f"{stderr[:MAX_ERROR_DETAIL_LENGTH]}..."
+            raise HTTPException(status_code=500, detail=f"ffmpeg failed: {stderr}")
 
         with open(mp3_path, "rb") as mp3_handle:
             return Response(content=mp3_handle.read(), media_type="audio/mpeg")


### PR DESCRIPTION
### Motivation
- Stabilize TTS runtime Unicode behavior by setting locale in the service container to avoid espeak/espeak-ng unicode issues. 
- Prevent espeak failures from LLM-style text (smart quotes, markdown, control chars, excessive whitespace) by sanitizing input and using stdin for more robust invocation.

### Description
- Set `ENV LANG=C.UTF-8` and `ENV LC_ALL=C.UTF-8` in the TTS `Dockerfile` to normalize container locale.
- Add `sanitize_tts_text(text: str) -> str` to `app.py` that normalizes newlines, strips backticks/`**`/`__`, replaces smart quotes and dashes, removes control/non-printable characters, collapses whitespace, and enforces the existing max length.
- Invoke `espeak-ng` with `--stdin` and pass the sanitized text via `subprocess.run(..., input=...)` instead of placing text on the command line, keeping the existing temporary WAV file flow and mp3 conversion via `ffmpeg`.
- Improve error reporting by capturing `stderr` from `espeak` and `ffmpeg`, truncating to 500 characters, and returning detailed 500 responses on failure; preserve existing voice defaulting logic and response format (`mp3`/`wav`).

### Testing
- No automated tests were run on the modified code in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697694c9f1448330a5a936a78c8cefa9)