### PR TITLE
Improve TTS sanitization and truncate espeak/ffmpeg error details

### DIFF
--- a/ui/partner-hub/dev/ai-interview/services/tts/app.py
+++ b/ui/partner-hub/dev/ai-interview/services/tts/app.py
@@ -12,7 +12,11 @@ MAX_INPUT_LENGTH = 2000
 MAX_ERROR_DETAIL_LENGTH = 500
 
 
-_CONTROL_CHAR_PATTERN = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]")
+_CONTROL_CHAR_PATTERN = re.compile(r"[\x00-\x1F\x7F]")
+
+
+def truncate_error_detail(detail: str) -> str:
+    return detail[:MAX_ERROR_DETAIL_LENGTH]
 
 
 def sanitize_tts_text(text: str) -> str:
@@ -83,9 +87,7 @@ def speech(request: SpeechRequest) -> Response:
                 input=sanitized_text,
             )
         except subprocess.CalledProcessError as exc:
-            stderr = (exc.stderr or "").strip()
-            if len(stderr) > MAX_ERROR_DETAIL_LENGTH:
-                stderr = f"{stderr[:MAX_ERROR_DETAIL_LENGTH]}..."
+            stderr = truncate_error_detail((exc.stderr or "").strip())
             raise HTTPException(status_code=500, detail=f"espeak failed: {stderr}")
 
         if response_format == "wav":
@@ -103,9 +105,7 @@ def speech(request: SpeechRequest) -> Response:
                 text=True,
             )
         except subprocess.CalledProcessError as exc:
-            stderr = (exc.stderr or "").strip()
-            if len(stderr) > MAX_ERROR_DETAIL_LENGTH:
-                stderr = f"{stderr[:MAX_ERROR_DETAIL_LENGTH]}..."
+            stderr = truncate_error_detail((exc.stderr or "").strip())
             raise HTTPException(status_code=500, detail=f"ffmpeg failed: {stderr}")
 
         with open(mp3_path, "rb") as mp3_handle:


### PR DESCRIPTION
### Motivation
- Ensure TTS input is sanitized more robustly by removing the full range of ASCII control characters before whitespace normalization to avoid passing non-printable characters to the TTS engine.
- Provide consistent, bounded error detail in 500-char form when `espeak-ng` or `ffmpeg` fail to make server errors easier to inspect and safer to return.

### Description
- Broadened the control-character removal regex to `[_CONTROL_CHAR_PATTERN = re.compile(r"[\x00-\x1F\x7F]")]` in `ui/partner-hub/dev/ai-interview/services/tts/app.py` so all ASCII control characters are stripped during `sanitize_tts_text`.
- Added helper `truncate_error_detail(detail: str) -> str` and applied it to `espeak-ng` and `ffmpeg` exception handling so stderr returned in HTTP 500 responses is truncated to `MAX_ERROR_DETAIL_LENGTH`.
- Kept existing `sanitize_tts_text` behavior for newline normalization, markdown token stripping, smart-quote/dash replacement, whitespace collapsing, and the existing `espeak-ng --stdin -w` invocation that feeds sanitized text via `subprocess.run(..., input=...)`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697695cd85e0833088213d0598e9dfcd)