### PR TITLE
Preserve upstream TTS errors, add single proxy log, and ensure backend logging

### DIFF
--- a/ui/partner-hub/app/api/ai-interview/tts/route.ts
+++ b/ui/partner-hub/app/api/ai-interview/tts/route.ts
@@ -60,7 +60,19 @@ export async function POST(req: Request) {
 
   try {
     const upstreamUrl = `${baseUrl.replace(/\/$/, "")}/v1/audio/speech`;
-    serverLog("upstream_request", { route, upstreamUrl, turnId });
+    const requestId = req.headers.get("x-request-id");
+    const rawVoicePresent = body?.voice !== undefined;
+    const trimmedVoice = voice ?? null;
+    const forwardVoice = Boolean(voice);
+    serverLog("upstream_request", {
+      route,
+      upstreamUrl,
+      turnId,
+      requestId,
+      rawVoicePresent,
+      trimmedVoice,
+      forwardVoice,
+    });
     const upstreamStart = nowMs();
     const resp = await fetch(upstreamUrl, {
       method: "POST",
@@ -80,15 +92,42 @@ export async function POST(req: Request) {
     });
 
     if (!resp.ok) {
-      const detail = await resp.text().catch(() => "");
-      logRouteOut(502);
+      let rawBody = "";
+      try {
+        rawBody = await resp.text();
+      } catch (readError) {
+        serverLog("upstream_error", {
+          route,
+          status: resp.status,
+          turnId,
+          message: readError instanceof Error ? readError.message : String(readError),
+        });
+        logRouteOut(502);
+        return NextResponse.json(
+          { error: "TTS upstream response could not be read." },
+          { status: 502, headers: responseHeaders },
+        );
+      }
+      const contentType = resp.headers.get("content-type") || "";
+      let parsedJson: unknown = null;
+      if (contentType.includes("application/json") || rawBody.trim().startsWith("{") || rawBody.trim().startsWith("[")) {
+        try {
+          parsedJson = JSON.parse(rawBody);
+        } catch {
+          parsedJson = null;
+        }
+      }
+      logRouteOut(resp.status);
+      if (parsedJson) {
+        return NextResponse.json(parsedJson, { status: resp.status, headers: responseHeaders });
+      }
+      const detail = rawBody.trim();
       return NextResponse.json(
         {
           error: "TTS request failed.",
-          status: resp.status,
-          detail: detail.slice(0, 500),
+          detail: detail ? detail.slice(0, 500) : "Upstream error without a response body.",
         },
-        { status: 502, headers: responseHeaders },
+        { status: resp.status, headers: responseHeaders },
       );
     }
 

--- a/ui/partner-hub/dev/ai-interview/services/tts/app.py
+++ b/ui/partner-hub/dev/ai-interview/services/tts/app.py
@@ -7,6 +7,9 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import Response
 from pydantic import BaseModel
 
+if not logging.getLogger().handlers:
+    logging.basicConfig(level=logging.INFO)
+
 app = FastAPI()
 logger = logging.getLogger("ai_interview_tts")
 

--- a/ui/partner-hub/scripts/ai-interview-tts-proxy-guard.sh
+++ b/ui/partner-hub/scripts/ai-interview-tts-proxy-guard.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -u
+
+: "${AI_INTERVIEW_APP_URL:=http://localhost:3000}"
+: "${AI_INTERVIEW_SAMPLE_TEXT:=Hello from AI interview}"
+
+base_url="${AI_INTERVIEW_APP_URL%/}"
+failed=0
+
+check_blank_voice() {
+  local body_file code
+  body_file=$(mktemp)
+  code=$(curl -sS -o "$body_file" -w "%{http_code}" \
+    -H "Content-Type: application/json" \
+    -d "{\"text\":\"${AI_INTERVIEW_SAMPLE_TEXT}\",\"voice\":\"\"}" \
+    "${base_url}/api/ai-interview/tts" || true)
+
+  if [[ "$code" == "400" ]]; then
+    echo "PASS: blank voice returns 400"
+  else
+    echo "FAIL: blank voice (HTTP ${code})"
+    cat "$body_file"
+    failed=1
+  fi
+
+  rm -f "$body_file"
+}
+
+check_omitted_voice() {
+  local body_file header_file code
+  body_file=$(mktemp)
+  header_file=$(mktemp)
+  code=$(curl -sS -D "$header_file" -o "$body_file" -w "%{http_code}" \
+    -H "Content-Type: application/json" \
+    -d "{\"text\":\"${AI_INTERVIEW_SAMPLE_TEXT}\"}" \
+    "${base_url}/api/ai-interview/tts" || true)
+
+  if [[ "$code" == "200" ]] && grep -qi "^content-type: audio/mpeg" "$header_file"; then
+    echo "PASS: omitted voice returns audio"
+  else
+    echo "FAIL: omitted voice (HTTP ${code})"
+    cat "$body_file"
+    failed=1
+  fi
+
+  rm -f "$body_file" "$header_file"
+}
+
+check_upstream_400_passthrough() {
+  local body_file code long_text
+  body_file=$(mktemp)
+  long_text=$(node -e 'console.log("a".repeat(2001))')
+  code=$(curl -sS -o "$body_file" -w "%{http_code}" \
+    -H "Content-Type: application/json" \
+    -d "{\"text\":\"${long_text}\"}" \
+    "${base_url}/api/ai-interview/tts" || true)
+
+  if [[ "$code" == "400" ]]; then
+    echo "PASS: upstream 400 passes through"
+  else
+    echo "FAIL: upstream 400 passthrough (HTTP ${code})"
+    cat "$body_file"
+    failed=1
+  fi
+
+  rm -f "$body_file"
+}
+
+check_blank_voice
+check_omitted_voice
+check_upstream_400_passthrough
+
+exit "$failed"


### PR DESCRIPTION
### Motivation
- Prevent the proxy from mapping all upstream TTS failures to 502 and instead preserve meaningful 4xx responses and JSON bodies for clients.
- Add one concise proxy-side log with voice forwarding context right before forwarding to upstream to aid debugging without log spam.
- Ensure the local TTS service emits its pre-espeak INFO log during normal dev runs by adding a minimal safe logging setup.

### Description
- Proxy error handling: update `ui/partner-hub/app/api/ai-interview/tts/route.ts` to read the upstream body, parse JSON when present, and return the upstream status + body for 4xx/other non-2xx cases, using 502 only when upstream is unreachable or its response cannot be read.
- Single upstream request log: add one decisive log right before the fetch that includes `requestId` (from `x-request-id`), `turnId`, `rawVoicePresent`, `trimmedVoice`, and `forwardVoice` to indicate whether `voice` will be forwarded.
- Backend logging hardening: add a minimal, production-safe logging bootstrap in `ui/partner-hub/dev/ai-interview/services/tts/app.py` so the `logger.info("tts_espeak_request ...")` message is emitted when no logging handlers are configured.
- Regression guard script: add `ui/partner-hub/scripts/ai-interview-tts-proxy-guard.sh` which exercises three scenarios against a running app: blank `voice` -> expect 400, omitted `voice` -> expect audio (200 + audio Content-Type), and long input that triggers upstream 400 -> expect 400 passthrough.
- Files changed/added: `app/api/ai-interview/tts/route.ts` (modified), `dev/ai-interview/services/tts/app.py` (modified), `scripts/ai-interview-tts-proxy-guard.sh` (new).

### Testing
- Ran `npm test` in `ui/partner-hub`; test runner executed and reported `37 passed, 1 failed` with a failing `matchAccounts` subtest (expected "weak" but got "exact").
- Ran `npm run lint` in `ui/partner-hub` and received `✔ No ESLint warnings or errors`.
- Ran `npm run build` in `ui/partner-hub` and the Next.js production build completed successfully (`Compiled successfully`).
- The included `scripts/ai-interview-tts-proxy-guard.sh` is provided to validate the proxy behaviors against a live app/TTS stack (not executed in CI here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978fe7a55d48330852fc4192cd9779a)