### PR TITLE
Remove Node dependency from TTS proxy guard

### DIFF
--- a/ui/partner-hub/scripts/ai-interview-tts-proxy-guard.sh
+++ b/ui/partner-hub/scripts/ai-interview-tts-proxy-guard.sh
@@ -50,7 +50,7 @@ check_omitted_voice() {
 check_upstream_400_passthrough() {
   local body_file code long_text
   body_file=$(mktemp)
-  long_text=$(node -e 'console.log("a".repeat(2001))')
+  long_text=$(printf 'a%.0s' {1..2001})
   code=$(curl -sS -o "$body_file" -w "%{http_code}" \
     -H "Content-Type: application/json" \
     -d "{\"text\":\"${long_text}\"}" \


### PR DESCRIPTION
### Motivation
- Remove the remaining Node.js dependency from the AI interview TTS proxy guard so the script is fully portable and does not require Node to generate a long test string.

### Description
- Replace the Node-based string generation in `ui/partner-hub/scripts/ai-interview-tts-proxy-guard.sh` (`long_text=$(node -e 'console.log("a".repeat(2001))')`) with a pure Bash `printf` loop (`long_text=$(printf 'a%.0s' {1..2001})`) while preserving the script's logic and output.

### Testing
- Ran the script with `ui/partner-hub/scripts/ai-interview-tts-proxy-guard.sh`, which attempted to contact the local server and produced connection failures: `curl: (7) Failed to connect to localhost port 3000`, followed by `FAIL: blank voice (HTTP 000)`, `FAIL: omitted voice (HTTP 000)`, and `FAIL: upstream 400 passthrough (HTTP 000)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69790bd2d5ac83309c89f6477bdafbed)