### PR TITLE
Switch AI interview TTS to Piper with baked model

### DIFF
--- a/ui/partner-hub/dev/ai-interview/docker-compose.yml
+++ b/ui/partner-hub/dev/ai-interview/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       context: ./services/tts
     ports:
       - "8000:8000"
+    environment:
+      PIPER_MODEL_PATH: ${PIPER_MODEL_PATH:-/models/en_US-amy-medium.onnx}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
       interval: 10s

--- a/ui/partner-hub/dev/ai-interview/services/tts/Dockerfile
+++ b/ui/partner-hub/dev/ai-interview/services/tts/Dockerfile
@@ -4,10 +4,22 @@ WORKDIR /app
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
+ENV PIPER_MODEL_PATH=/models/en_US-amy-medium.onnx
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends espeak-ng ffmpeg curl \
+    && apt-get install -y --no-install-recommends ffmpeg curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+
+ARG PIPER_VERSION=1.2.0
+RUN set -eux; \
+    curl -L -o /tmp/piper.tar.gz "https://github.com/rhasspy/piper/releases/download/v${PIPER_VERSION}/piper_linux_x86_64.tar.gz"; \
+    tar -xzf /tmp/piper.tar.gz -C /tmp; \
+    mv /tmp/piper/piper /usr/local/bin/piper; \
+    chmod +x /usr/local/bin/piper; \
+    rm -rf /tmp/piper /tmp/piper.tar.gz; \
+    mkdir -p /models; \
+    curl -L -o /models/en_US-amy-medium.onnx "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/amy/medium/en_US-amy-medium.onnx"; \
+    curl -L -o /models/en_US-amy-medium.onnx.json "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/amy/medium/en_US-amy-medium.onnx.json"
 
 RUN pip install --no-cache-dir --upgrade pip
 COPY requirements.txt /app/requirements.txt

--- a/ui/partner-hub/dev/ai-interview/services/tts/app.py
+++ b/ui/partner-hub/dev/ai-interview/services/tts/app.py
@@ -15,6 +15,7 @@ logger = logging.getLogger("ai_interview_tts")
 
 MAX_INPUT_LENGTH = 2000
 MAX_ERROR_DETAIL_LENGTH = 500
+DEFAULT_PIPER_MODEL_PATH = "/models/en_US-amy-medium.onnx"
 
 
 _NON_PRINTABLE_PATTERN = re.compile(r"[\x00-\x1F\x7F-\x9F]")
@@ -77,19 +78,31 @@ def speech(request: SpeechRequest) -> Response:
     if not voice:
         voice = "en-us"
 
+    model_path = os.environ.get("PIPER_MODEL_PATH", DEFAULT_PIPER_MODEL_PATH)
+    model_config_path = f"{model_path}.json"
+    if not os.path.isfile(model_path):
+        raise HTTPException(
+            status_code=500,
+            detail=f"Piper model not found at {model_path}. Set PIPER_MODEL_PATH or mount /models.",
+        )
+    if not os.path.isfile(model_config_path):
+        raise HTTPException(
+            status_code=500,
+            detail=f"Piper model config not found at {model_config_path}.",
+        )
+
     mp3_path = None
     with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as wav_file:
         wav_path = wav_file.name
 
     try:
-        command = ["espeak-ng", "--stdin", "-w", wav_path]
-        if voice:
-            command.extend(["-v", voice])
+        command = ["piper", "--model", model_path, "--output_file", wav_path]
         logger.info(
-            "tts_espeak_request voice=%r response_format=%s input_len=%s raw_voice=%r raw_input=%r raw_text=%r",
+            "tts_piper_request voice=%r response_format=%s input_len=%s model_path=%r raw_voice=%r raw_input=%r raw_text=%r",
             voice,
             response_format,
             len(sanitized_text),
+            model_path,
             raw_voice,
             request.input,
             request.text,
@@ -102,9 +115,11 @@ def speech(request: SpeechRequest) -> Response:
                 text=True,
                 input=sanitized_text,
             )
+        except FileNotFoundError:
+            raise HTTPException(status_code=500, detail="piper binary not found in PATH")
         except subprocess.CalledProcessError as exc:
             stderr = truncate_error_detail((exc.stderr or "").strip())
-            raise HTTPException(status_code=500, detail=f"espeak failed: {stderr}")
+            raise HTTPException(status_code=500, detail=f"piper failed: {stderr}")
 
         if response_format == "wav":
             with open(wav_path, "rb") as wav_handle:
@@ -120,6 +135,8 @@ def speech(request: SpeechRequest) -> Response:
                 capture_output=True,
                 text=True,
             )
+        except FileNotFoundError:
+            raise HTTPException(status_code=500, detail="ffmpeg binary not found in PATH")
         except subprocess.CalledProcessError as exc:
             stderr = truncate_error_detail((exc.stderr or "").strip())
             raise HTTPException(status_code=500, detail=f"ffmpeg failed: {stderr}")

--- a/ui/partner-hub/docs/ai-interview-local.md
+++ b/ui/partner-hub/docs/ai-interview-local.md
@@ -17,7 +17,7 @@ These containers are intended for **local development only**.
 From `ui/partner-hub/dev/ai-interview`, run:
 
 ```
-docker compose up -d
+docker compose up -d --build
 ```
 
 Ports used:
@@ -50,6 +50,22 @@ Each local service provides a health endpoint that returns JSON:
 - `http://127.0.0.1:9000/health` → `{ "ok": true }`
 - `http://127.0.0.1:8000/health` → `{ "ok": true }`
 
+## TTS model (Piper)
+
+The TTS container uses Piper (neural TTS) with a default English voice baked into the image:
+
+- Default model path: `/models/en_US-amy-medium.onnx`
+- Override with `PIPER_MODEL_PATH` (for a different model in the container)
+
+To use a different model, either rebuild the image with a new model file or mount a local model and set
+`PIPER_MODEL_PATH` to the mounted path.
+
+Example (from `ui/partner-hub/dev/ai-interview`):
+
+```
+PIPER_MODEL_PATH=/models/en_US-amy-medium.onnx docker compose up -d --build
+```
+
 ## Smoke tests (Windows PowerShell)
 
 From `ui/partner-hub`, run:
@@ -71,6 +87,23 @@ AI_INTERVIEW_OLLAMA_URL=http://127.0.0.1:11434
 AI_INTERVIEW_STT_URL=http://127.0.0.1:9000
 AI_INTERVIEW_TTS_URL=http://127.0.0.1:8000
 ```
+
+## Verify TTS (curl)
+
+From `ui/partner-hub/dev/ai-interview`, run:
+
+```
+docker compose build ai-interview-tts
+docker compose up -d
+curl -X POST http://127.0.0.1:8000/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{"input":"Hello from Piper.","response_format":"mp3"}' \
+  --output /tmp/tts-sample.mp3 \
+  --silent --show-error --write-out "\nHTTP %{http_code} content-type=%{content_type}\n"
+ls -lh /tmp/tts-sample.mp3
+```
+
+Confirm the response shows `HTTP 200` and `content-type=audio/mpeg`, and the output file is larger than a few KB.
 
 ## Planned proxy routes
 


### PR DESCRIPTION
### Motivation
- Replace the lightweight, robotic `espeak-ng` TTS with the neural `piper` TTS to produce more natural-sounding local audio while preserving the existing HTTP API contract. 
- Keep the change minimal and Docker-first so the service works when started via `ui/partner-hub/dev/ai-interview/docker-compose.yml` without introducing paid services.

### Description
- Install `piper` binary and a default English voice model into the TTS image by updating `ui/partner-hub/dev/ai-interview/services/tts/Dockerfile` (adds `PIPER_VERSION` arg, downloads `piper` and `en_US-amy-medium.onnx`, and sets `PIPER_MODEL_PATH` env var). 
- Switch runtime TTS execution in `ui/partner-hub/dev/ai-interview/services/tts/app.py` from `espeak-ng` to `piper`, preserve `sanitize_tts_text`, keep the same POST `/v1/audio/speech` behavior and response formats (`mp3` / `wav`), and retain the voice-parameter semantics (blank provided voice -> 400, omitted -> default). 
- Add explicit model presence checks (`PIPER_MODEL_PATH` and `<model>.json`) and clearer errors for missing `piper` or `ffmpeg` binaries, and rename logs to `tts_piper_request` including the model path. 
- Expose `PIPER_MODEL_PATH` in `ui/partner-hub/dev/ai-interview/docker-compose.yml` and document the new TTS model usage and manual verification steps in `ui/partner-hub/docs/ai-interview-local.md` (includes `docker compose build ai-interview-tts` and a `curl` sample to save mp3). 

### Testing
- No automated tests were run as part of this change. 
- Manual verification steps were added to `ui/partner-hub/docs/ai-interview-local.md` including `docker compose build ai-interview-tts`, `docker compose up -d`, and a `curl` POST to `http://127.0.0.1:8000/v1/audio/speech` that saves output to `/tmp/tts-sample.mp3` and checks for `HTTP 200` and `content-type=audio/mpeg`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a37a475508330a1ad22a4cfe7194c)