### PR TITLE
Improve local TTS quality and robustness

### DIFF
--- a/ui/partner-hub/dev/ai-interview/docker-compose.yml
+++ b/ui/partner-hub/dev/ai-interview/docker-compose.yml
@@ -24,6 +24,10 @@ services:
       - "8000:8000"
     environment:
       PIPER_MODEL_PATH: ${PIPER_MODEL_PATH:-/models/en_US-amy-medium.onnx}
+      PIPER_LENGTH_SCALE: ${PIPER_LENGTH_SCALE:-1.0}
+      PIPER_NOISE_SCALE: ${PIPER_NOISE_SCALE:-0.667}
+      PIPER_NOISE_W: ${PIPER_NOISE_W:-0.8}
+      PIPER_SPEAKER_ID: ${PIPER_SPEAKER_ID:-}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
       interval: 10s

--- a/ui/partner-hub/dev/ai-interview/services/tts/Dockerfile
+++ b/ui/partner-hub/dev/ai-interview/services/tts/Dockerfile
@@ -11,15 +11,21 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ARG PIPER_VERSION=1.2.0
+ARG PIPER_TARBALL_SHA256=
+ARG PIPER_MODEL_SHA256=
+ARG PIPER_MODEL_JSON_SHA256=
 RUN set -eux; \
     curl -L -o /tmp/piper.tar.gz "https://github.com/rhasspy/piper/releases/download/v${PIPER_VERSION}/piper_linux_x86_64.tar.gz"; \
+    if [ -n "$PIPER_TARBALL_SHA256" ]; then echo "$PIPER_TARBALL_SHA256  /tmp/piper.tar.gz" | sha256sum -c -; fi; \
     tar -xzf /tmp/piper.tar.gz -C /tmp; \
     mv /tmp/piper/piper /usr/local/bin/piper; \
     chmod +x /usr/local/bin/piper; \
     rm -rf /tmp/piper /tmp/piper.tar.gz; \
     mkdir -p /models; \
     curl -L -o /models/en_US-amy-medium.onnx "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/amy/medium/en_US-amy-medium.onnx"; \
-    curl -L -o /models/en_US-amy-medium.onnx.json "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/amy/medium/en_US-amy-medium.onnx.json"
+    if [ -n "$PIPER_MODEL_SHA256" ]; then echo "$PIPER_MODEL_SHA256  /models/en_US-amy-medium.onnx" | sha256sum -c -; fi; \
+    curl -L -o /models/en_US-amy-medium.onnx.json "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/amy/medium/en_US-amy-medium.onnx.json"; \
+    if [ -n "$PIPER_MODEL_JSON_SHA256" ]; then echo "$PIPER_MODEL_JSON_SHA256  /models/en_US-amy-medium.onnx.json" | sha256sum -c -; fi
 
 RUN pip install --no-cache-dir --upgrade pip
 COPY requirements.txt /app/requirements.txt

--- a/ui/partner-hub/dev/ai-interview/services/tts/app.py
+++ b/ui/partner-hub/dev/ai-interview/services/tts/app.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 import tempfile
+import time
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import Response
 from pydantic import BaseModel
@@ -16,6 +17,9 @@ logger = logging.getLogger("ai_interview_tts")
 MAX_INPUT_LENGTH = 2000
 MAX_ERROR_DETAIL_LENGTH = 500
 DEFAULT_PIPER_MODEL_PATH = "/models/en_US-amy-medium.onnx"
+DEFAULT_PIPER_LENGTH_SCALE = 1.0
+DEFAULT_PIPER_NOISE_SCALE = 0.667
+DEFAULT_PIPER_NOISE_W = 0.8
 
 
 _NON_PRINTABLE_PATTERN = re.compile(r"[\x00-\x1F\x7F-\x9F]")
@@ -50,6 +54,28 @@ class SpeechRequest(BaseModel):
     response_format: str | None = None
 
 
+def get_piper_supported_flags() -> set[str]:
+    try:
+        result = subprocess.run(
+            ["piper", "--help"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except Exception as exc:
+        logger.warning("Unable to probe piper flags: %s", exc)
+        return set()
+    help_text = f"{result.stdout}\n{result.stderr}"
+    supported = set()
+    for flag in ("--length_scale", "--noise_scale", "--noise_w", "--speaker"):
+        if flag in help_text:
+            supported.add(flag)
+    return supported
+
+
+PIPER_SUPPORTED_FLAGS = get_piper_supported_flags()
+
+
 @app.get("/health")
 def health() -> dict:
     return {"ok": True}
@@ -66,6 +92,8 @@ def speech(request: SpeechRequest) -> Response:
         raise HTTPException(status_code=400, detail=str(exc))
     if not sanitized_text:
         raise HTTPException(status_code=400, detail="Missing input text")
+    if len(sanitized_text) < 2:
+        raise HTTPException(status_code=400, detail="Input text is too short")
 
     response_format = (request.response_format or "mp3").lower()
     if response_format not in {"mp3", "wav"}:
@@ -83,13 +111,25 @@ def speech(request: SpeechRequest) -> Response:
     if not os.path.isfile(model_path):
         raise HTTPException(
             status_code=500,
-            detail=f"Piper model not found at {model_path}. Set PIPER_MODEL_PATH or mount /models.",
+            detail=(
+                "Piper model not found. "
+                f"model_path={model_path} expected_config={model_config_path}. "
+                "Set PIPER_MODEL_PATH or mount /models."
+            ),
         )
     if not os.path.isfile(model_config_path):
         raise HTTPException(
             status_code=500,
-            detail=f"Piper model config not found at {model_config_path}.",
+            detail=(
+                "Piper model config not found. "
+                f"model_path={model_path} expected_config={model_config_path}."
+            ),
         )
+
+    length_scale = os.environ.get("PIPER_LENGTH_SCALE", str(DEFAULT_PIPER_LENGTH_SCALE))
+    noise_scale = os.environ.get("PIPER_NOISE_SCALE", str(DEFAULT_PIPER_NOISE_SCALE))
+    noise_w = os.environ.get("PIPER_NOISE_W", str(DEFAULT_PIPER_NOISE_W))
+    speaker_id = os.environ.get("PIPER_SPEAKER_ID")
 
     mp3_path = None
     with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as wav_file:
@@ -97,6 +137,17 @@ def speech(request: SpeechRequest) -> Response:
 
     try:
         command = ["piper", "--model", model_path, "--output_file", wav_path]
+        if "--length_scale" in PIPER_SUPPORTED_FLAGS:
+            command += ["--length_scale", length_scale]
+        if "--noise_scale" in PIPER_SUPPORTED_FLAGS:
+            command += ["--noise_scale", noise_scale]
+        if "--noise_w" in PIPER_SUPPORTED_FLAGS:
+            command += ["--noise_w", noise_w]
+        if speaker_id and "--speaker" in PIPER_SUPPORTED_FLAGS:
+            command += ["--speaker", speaker_id]
+
+        total_start = time.monotonic()
+        piper_start = time.monotonic()
         logger.info(
             "tts_piper_request voice=%r response_format=%s input_len=%s model_path=%r raw_voice=%r raw_input=%r raw_text=%r",
             voice,
@@ -120,17 +171,50 @@ def speech(request: SpeechRequest) -> Response:
         except subprocess.CalledProcessError as exc:
             stderr = truncate_error_detail((exc.stderr or "").strip())
             raise HTTPException(status_code=500, detail=f"piper failed: {stderr}")
+        piper_ms = int((time.monotonic() - piper_start) * 1000)
 
         if response_format == "wav":
             with open(wav_path, "rb") as wav_handle:
-                return Response(content=wav_handle.read(), media_type="audio/wav")
+                wav_content = wav_handle.read()
+            total_ms = int((time.monotonic() - total_start) * 1000)
+            logger.info(
+                "tts_timing piper_ms=%s ffmpeg_ms=0 total_ms=%s input_len=%s response_bytes=%s",
+                piper_ms,
+                total_ms,
+                len(sanitized_text),
+                len(wav_content),
+            )
+            return Response(
+                content=wav_content,
+                media_type="audio/wav",
+                headers={
+                    "X-TTS-Engine": "piper",
+                    "X-TTS-Model": os.path.basename(model_path),
+                },
+            )
 
         with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as mp3_file:
             mp3_path = mp3_file.name
 
         try:
+            ffmpeg_start = time.monotonic()
             subprocess.run(
-                ["ffmpeg", "-y", "-i", wav_path, "-codec:a", "libmp3lame", mp3_path],
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-i",
+                    wav_path,
+                    "-vn",
+                    "-ar",
+                    "44100",
+                    "-b:a",
+                    "128k",
+                    "-ac",
+                    "1",
+                    "-codec:a",
+                    "libmp3lame",
+                    mp3_path,
+                ],
                 check=True,
                 capture_output=True,
                 text=True,
@@ -140,9 +224,27 @@ def speech(request: SpeechRequest) -> Response:
         except subprocess.CalledProcessError as exc:
             stderr = truncate_error_detail((exc.stderr or "").strip())
             raise HTTPException(status_code=500, detail=f"ffmpeg failed: {stderr}")
+        ffmpeg_ms = int((time.monotonic() - ffmpeg_start) * 1000)
 
         with open(mp3_path, "rb") as mp3_handle:
-            return Response(content=mp3_handle.read(), media_type="audio/mpeg")
+            mp3_content = mp3_handle.read()
+        total_ms = int((time.monotonic() - total_start) * 1000)
+        logger.info(
+            "tts_timing piper_ms=%s ffmpeg_ms=%s total_ms=%s input_len=%s response_bytes=%s",
+            piper_ms,
+            ffmpeg_ms,
+            total_ms,
+            len(sanitized_text),
+            len(mp3_content),
+        )
+        return Response(
+            content=mp3_content,
+            media_type="audio/mpeg",
+            headers={
+                "X-TTS-Engine": "piper",
+                "X-TTS-Model": os.path.basename(model_path),
+            },
+        )
     finally:
         try:
             os.remove(wav_path)

--- a/ui/partner-hub/docs/ai-interview-local.md
+++ b/ui/partner-hub/docs/ai-interview-local.md
@@ -66,6 +66,23 @@ Example (from `ui/partner-hub/dev/ai-interview`):
 PIPER_MODEL_PATH=/models/en_US-amy-medium.onnx docker compose up -d --build
 ```
 
+### Prosody tuning (optional)
+
+You can tune Piper prosody with environment variables (defaults shown):
+
+```
+PIPER_LENGTH_SCALE=1.0   # speaking rate (lower = faster)
+PIPER_NOISE_SCALE=0.667  # expressiveness
+PIPER_NOISE_W=0.8        # variation
+PIPER_SPEAKER_ID=        # optional speaker id (if the model supports it)
+```
+
+Example (from `ui/partner-hub/dev/ai-interview`):
+
+```
+PIPER_LENGTH_SCALE=0.95 PIPER_NOISE_SCALE=0.75 PIPER_NOISE_W=0.9 docker compose up -d --build
+```
+
 ## Smoke tests (Windows PowerShell)
 
 From `ui/partner-hub`, run:

--- a/ui/partner-hub/scripts/ai-interview-tts-smoke.ps1
+++ b/ui/partner-hub/scripts/ai-interview-tts-smoke.ps1
@@ -6,6 +6,7 @@ $tmpDir = Join-Path $repoRoot "tmp"
 New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
 
 $outputPath = Join-Path $tmpDir "tts-smoke.mp3"
+$headersPath = Join-Path $tmpDir "tts-smoke.headers.txt"
 $payload = @{
   input = "hello from tts"
   response_format = "mp3"
@@ -14,19 +15,19 @@ $payload = @{
 $ttsEndpoint = $TtsUrl.TrimEnd('/') + "/v1/audio/speech"
 
 try {
-  $iwrParams = @{
-    Method = "Post"
-    Uri = $ttsEndpoint
-    ContentType = "application/json"
-    Body = $payload
-    OutFile = $outputPath
-    ErrorAction = "Stop"
-    TimeoutSec = 60
+  $curlArgs = @(
+    "-sS",
+    "-D", $headersPath,
+    "-o", $outputPath,
+    "-H", "Content-Type: application/json",
+    "-X", "POST",
+    $ttsEndpoint,
+    "-d", $payload
+  )
+  & curl.exe @curlArgs | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    throw "curl.exe failed with exit code $LASTEXITCODE"
   }
-  if ((Get-Command Invoke-WebRequest).Parameters.ContainsKey("UseBasicParsing")) {
-    $iwrParams.UseBasicParsing = $true
-  }
-  $response = Invoke-WebRequest @iwrParams
 } catch {
   Write-Host "TTS request failed."
   Write-Host "URL called: $ttsEndpoint"
@@ -71,9 +72,25 @@ if (-not (Test-Path $outputPath)) {
 }
 
 $fileInfo = Get-Item $outputPath
-if ($fileInfo.Length -le 0) {
-  Write-Host "TTS request succeeded but output file is empty at $outputPath"
+if ($fileInfo.Length -lt 3072) {
+  Write-Host "TTS request succeeded but output file is too small ($($fileInfo.Length) bytes) at $outputPath"
   exit 1
+}
+
+if (Test-Path $headersPath) {
+  $headers = Get-Content $headersPath
+  $statusLine = $headers | Select-Object -First 1
+  if ($null -eq $statusLine -or $statusLine -notmatch "\s200\s") {
+    Write-Host "Unexpected HTTP status line: $statusLine"
+    exit 1
+  }
+  $contentTypeLine = $headers | Where-Object { $_ -match "^(?i)Content-Type:" } | Select-Object -First 1
+  if ($null -eq $contentTypeLine -or $contentTypeLine -notmatch "(?i)audio/mpeg") {
+    Write-Host "Unexpected content-type header: $contentTypeLine"
+    exit 1
+  }
+  Write-Host "Response headers:"
+  $headers | ForEach-Object { Write-Host $_ }
 }
 
 Write-Host ("Saved TTS output ({0} bytes) to {1}" -f $fileInfo.Length, $outputPath)


### PR DESCRIPTION
### Motivation

- Reduce perceived roboticness and choppiness of local Piper TTS while keeping everything local/free and preserving the existing API contract. 
- Improve reliability and observability of the TTS service (clearer errors, timing logs, and model checks). 

### Description

- Add env-driven Piper prosody controls (`PIPER_LENGTH_SCALE`, `PIPER_NOISE_SCALE`, `PIPER_NOISE_W`, `PIPER_SPEAKER_ID`) and probe the bundled `piper --help` to only pass supported flags. 
- Improve MP3 encoding by invoking `ffmpeg` with `-vn -ar 44100 -b:a 128k -ac 1 -codec:a libmp3lame` and keep fast, deterministic encoding. 
- Add short-input guard (reject inputs < 2 chars), timing logs (`piper_ms`, `ffmpeg_ms`, `total_ms`, `input_len`, `response_bytes`), and response headers `X-TTS-Engine: piper` and `X-TTS-Model: <basename>` for safe debugging. 
- Dockerfile: add optional build args for SHA256 verification (`PIPER_TARBALL_SHA256`, `PIPER_MODEL_SHA256`, `PIPER_MODEL_JSON_SHA256`) and validate when provided; docker-compose: expose prosody env defaults; docs: document prosody tuning examples; smoke test: update PowerShell smoke test to use `curl.exe`, save headers, assert status 200, `content-type=audio/mpeg`, and output size > 3KB.

### Testing

- Attempted `docker compose build ai-interview-tts`, but it failed in this environment because `docker` is not available (error: `bash: command not found: docker`).
- Attempted to download Piper and model files to compute checksums during verification, but the network download failed in this environment with `curl: (56) CONNECT tunnel failed, response 403` so checksum verification could not be exercised here. 
- Updated and sanity-checked modified files locally (added/committed changes) and updated the PowerShell smoke test to validate headers and size; the smoke script was not executed against a running container due to the environment limitations above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a3986ff4883309b7da4b6664a2d42)