### PR TITLE
Await promised searchParams in bookings page

### DIFF
--- a/ui/partner-hub/app/(routes)/bookings/page.tsx
+++ b/ui/partner-hub/app/(routes)/bookings/page.tsx
@@ -19,8 +19,9 @@ type BookingWithOffice = {
 export default async function BookingsPage({
   searchParams,
 }: {
-  searchParams?: { created?: string };
+  searchParams?: Promise<{ created?: string }>;
 }) {
+  const sp = await searchParams;
   const bookings = (await prisma.booking.findMany({
     orderBy: { start: "desc" },
     take: 200,
@@ -41,7 +42,7 @@ export default async function BookingsPage({
         </Link>
       </div>
 
-      {searchParams?.created ? (
+        {sp?.created ? (
         <div className="mt-6 rounded-xl border p-3 text-sm">
           ✅ Booking created.
         </div>


### PR DESCRIPTION
### Motivation
- Ensure the bookings page properly handles Next.js route `searchParams` when provided as a `Promise`, so the resolved value can be read synchronously in the component.

### Description
- Change the page signature to accept `searchParams?: Promise<{ created?: string }>` and `await` it into `const sp`.
- Replace the `searchParams?.created` usage with `sp?.created` to show the created message based on the resolved params.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a4c77f5a483309a735b05e8838662)