### PR TITLE
Align generateMetadata params typing for case study page

### DIFF
--- a/ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx
+++ b/ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx
@@ -24,12 +24,6 @@ type CaseStudyPageProps = {
   }>;
 };
 
-type CaseStudyMetadataProps = {
-  params: {
-    slug: string;
-  };
-};
-
 const beforeAfterCards = [
   {
     title: "Before",
@@ -146,10 +140,11 @@ const AdjacentCaseStudyCard = ({
   );
 };
 
-export function generateMetadata({
+export async function generateMetadata({
   params,
-}: CaseStudyMetadataProps): Metadata {
-  const caseStudy = getCaseStudyBySlug(params.slug);
+}: CaseStudyPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const caseStudy = getCaseStudyBySlug(slug);
 
   if (!caseStudy) {
     notFound();


### PR DESCRIPTION
### Motivation
- Fix a type-check failure caused by Next 15 App Router using promise-based `params` for page props by aligning `generateMetadata` to the same signature.

### Description
- Remove the now-unused `CaseStudyMetadataProps` type and stop using it in `generateMetadata` in `ui/partner-hub/app/(routes)/case-studies/[slug]/page.tsx`.
- Make `generateMetadata` `async`, accept `CaseStudyPageProps`, and return `Promise<Metadata>`.
- Await the promise-based `params` inside `generateMetadata` and extract `slug` with `const { slug } = await params;` while keeping all metadata logic unchanged.
- No routes, behavior, or other files were modified.

### Testing
- Ran `npm run build` from `ui/partner-hub` and the Next build completed successfully with type checking and static page generation passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a4f73173c8330bc8d4b789a06d611)