### PR TITLE
Fix Promise-based params/searchParams in office app pages

### DIFF
--- a/ui/partner-hub/app/(routes)/offices/[id]/bookings/page.tsx
+++ b/ui/partner-hub/app/(routes)/offices/[id]/bookings/page.tsx
@@ -16,9 +16,10 @@ type OfficeBookingRow = {
 export default async function OfficeSchedulePage({
   params,
 }: {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }) {
-  const id = Number(params.id);
+  const { id: rawId } = await params;
+  const id = Number(rawId);
   if (!Number.isFinite(id)) notFound();
 
   const office = await prisma.office.findUnique({

--- a/ui/partner-hub/app/(routes)/offices/[id]/page.tsx
+++ b/ui/partner-hub/app/(routes)/offices/[id]/page.tsx
@@ -17,10 +17,12 @@ export default async function OfficeDetailPage({
   params,
   searchParams,
 }: {
-  params: { id: string };
-  searchParams?: { start?: string; end?: string };
+  params: Promise<{ id: string }>;
+  searchParams?: Promise<{ start?: string; end?: string }>;
 }) {
-  const id = Number(params.id);
+  const p = await params;
+  const sp = await searchParams;
+  const id = Number(p.id);
   if (!Number.isFinite(id)) notFound();
 
   const office = await prisma.office.findUnique({
@@ -87,8 +89,8 @@ export default async function OfficeDetailPage({
 
         <BookingForm
           officeId={id}
-          initialStartIso={searchParams?.start}
-          initialEndIso={searchParams?.end}
+          initialStartIso={sp?.start}
+          initialEndIso={sp?.end}
         />
       </section>
 

--- a/ui/partner-hub/app/(routes)/offices/schedule/page.tsx
+++ b/ui/partner-hub/app/(routes)/offices/schedule/page.tsx
@@ -22,12 +22,13 @@ function toDateKey(d: Date) {
 export default async function OfficeSchedulePage({
   searchParams,
 }: {
-  searchParams?: { date?: string; office?: string; duration?: string };
+  searchParams?: Promise<{ date?: string; office?: string; duration?: string }>;
 }) {
+  const sp = await searchParams;
   const todayKey = toDateKey(new Date());
   const dateKey =
-    searchParams?.date && /^\d{4}-\d{2}-\d{2}$/.test(searchParams.date)
-      ? searchParams.date
+    sp?.date && /^\d{4}-\d{2}-\d{2}$/.test(sp.date)
+      ? sp.date
       : todayKey;
 
   const base = new Date(`${dateKey}T00:00:00`);
@@ -42,14 +43,14 @@ export default async function OfficeSchedulePage({
     orderBy: { name: "asc" },
   })) as OfficeRow[];
 
-  const officeParam = Number(searchParams?.office);
+  const officeParam = Number(sp?.office);
   const defaultOfficeId = offices[0]?.id ?? 0;
   const initialOfficeId =
     Number.isFinite(officeParam) && offices.some((o) => o.id === officeParam)
       ? officeParam
       : defaultOfficeId;
 
-  const durationParam = Number(searchParams?.duration);
+  const durationParam = Number(sp?.duration);
   const initialDurationMin = [15, 30, 45, 60].includes(durationParam)
     ? durationParam
     : 60;


### PR DESCRIPTION
### Motivation
- Resolve Next.js App Router type errors where `PageProps` expects `params`/`searchParams` to be Promise-based, causing `next build` type-check failures.

### Description
- Updated route page signatures to accept Promise-based values and awaited them before use in `ui/partner-hub/app/(routes)/offices/[id]/page.tsx`, `ui/partner-hub/app/(routes)/offices/[id]/bookings/page.tsx`, and `ui/partner-hub/app/(routes)/offices/schedule/page.tsx`.
- Replaced direct `params`/`searchParams` access with resolved values (`p`, `sp`, or destructured `rawId`) and preserved all original behavior and shapes (no logic changes).
- Kept functions `async` where needed to allow `await` and made only minimal, localized edits to usage sites and type annotations.

### Testing
- Ran `npm run build` from the `ui/partner-hub` directory and the build completed successfully with type checks passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a510793d08330a695414ac080c46f)