### PR TITLE
Await Promise-based route params in offices availability route

### DIFF
--- a/ui/partner-hub/app/api/offices/[id]/availability/route.ts
+++ b/ui/partner-hub/app/api/offices/[id]/availability/route.ts
@@ -22,9 +22,10 @@ function addDays(d: Date, days: number) {
 
 export async function GET(
   req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
-  const officeId = Number(params.id);
+  const { id } = await params;
+  const officeId = Number(id);
   if (!Number.isFinite(officeId)) {
     return NextResponse.json({ error: "Invalid office id" }, { status: 400 });
   }


### PR DESCRIPTION
### Motivation
- Fix Next.js App Router typecheck failures where route `params` are expected to be Promise-based by updating the offices availability handler to use the Promise-based signature and await the resolved params.

### Description
- Update `ui/partner-hub/app/api/offices/[id]/availability/route.ts` to change the handler signature from `{ params: { id: string } }` to `{ params: Promise<{ id: string }> }` and add `const { id } = await params;` before using `id`.

### Testing
- Ran `cd ui/partner-hub && npm run build` which failed during `prisma generate` with `sh: 1: prisma: not found`, so the build could not complete (change is limited to the single route file).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a789d2c1883309c20b06b3a86d8fd)