### PR TITLE
Add TTS diagnostics, prosody tuning, and model-selection controls to ai-interview-tts

### DIFF
--- a/ui/partner-hub/dev/ai-interview/README.md
+++ b/ui/partner-hub/dev/ai-interview/README.md
@@ -1,0 +1,91 @@
+# AI Interview (Dev) Diagnostics & TTS Ops
+
+## Diagnostics-first workflow
+
+### TTS debug info
+The TTS service exposes a lightweight diagnostic endpoint:
+
+```
+GET http://localhost:8000/debug/info
+```
+
+The response includes the Piper version, configured model path/basename, effective prosody values, MP3 bitrate, ffmpeg version, and the most recent synth timing metrics.
+
+### A/B output verification (WAV vs MP3)
+Use PowerShell to fetch deterministic outputs for comparison:
+
+```powershell
+# WAV
+Invoke-WebRequest -Uri "http://localhost:8000/v1/audio/speech" `
+  -Method POST `
+  -ContentType "application/json" `
+  -Body '{"input":"Diagnostic sentence for TTS testing.","response_format":"wav"}' `
+  -OutFile "tts_test.wav"
+
+# MP3
+Invoke-WebRequest -Uri "http://localhost:8000/v1/audio/speech" `
+  -Method POST `
+  -ContentType "application/json" `
+  -Body '{"input":"Diagnostic sentence for TTS testing.","response_format":"mp3"}' `
+  -OutFile "tts_test.mp3"
+```
+
+View service logs:
+
+```bash
+docker compose -f ui/partner-hub/dev/ai-interview/docker-compose.yml logs -f ai-interview-tts
+```
+
+## Configuration
+
+### Prosody tuning
+Tuning is fully configurable via env vars (validated in-app with sane bounds):
+
+```
+PIPER_LENGTH_SCALE=1.10
+PIPER_NOISE_SCALE=0.60
+PIPER_NOISE_W=0.80
+```
+
+### Model selection
+The default model is still `/models/en_US-amy-medium.onnx`. You can swap models without editing the Dockerfile by supplying URLs and (optionally) a matching model path:
+
+```
+PIPER_MODEL_URL=https://<your-host>/models/en_US-<voice>.onnx
+PIPER_MODEL_JSON_URL=https://<your-host>/models/en_US-<voice>.onnx.json
+PIPER_MODEL_PATH=/models/en_US-<voice>.onnx
+```
+
+If only the URLs are set, the entrypoint downloads to `/models/<basename>`. Keep `PIPER_MODEL_PATH` aligned with the downloaded filename.
+
+**Recommended (better) voices**
+- Replace `<voice>` above with an alternate Piper voice you want to test.
+- Keep the `.onnx` and `.onnx.json` pair in sync.
+- Use `PIPER_MODEL_PATH` to switch the active model without rebuilding.
+
+### MP3 output
+MP3 bitrate is configurable:
+
+```
+TTS_MP3_BITRATE=192k
+```
+
+## WSL2 troubleshooting (do not auto-edit the system)
+WSL2 backend uses `.wslconfig` at `C:\Users\<user>\.wslconfig`.
+
+Suggested settings for a 16GB RAM / 6C/12T laptop:
+
+```
+[wsl2]
+memory=10GB
+processors=8
+swap=4GB
+```
+
+After changes, run:
+
+```
+wsl --shutdown
+```
+
+Then restart Docker Desktop.

--- a/ui/partner-hub/dev/ai-interview/docker-compose.yml
+++ b/ui/partner-hub/dev/ai-interview/docker-compose.yml
@@ -24,10 +24,13 @@ services:
       - "8000:8000"
     environment:
       PIPER_MODEL_PATH: ${PIPER_MODEL_PATH:-/models/en_US-amy-medium.onnx}
-      PIPER_LENGTH_SCALE: ${PIPER_LENGTH_SCALE:-1.0}
-      PIPER_NOISE_SCALE: ${PIPER_NOISE_SCALE:-0.667}
-      PIPER_NOISE_W: ${PIPER_NOISE_W:-0.8}
+      PIPER_MODEL_URL: ${PIPER_MODEL_URL:-}
+      PIPER_MODEL_JSON_URL: ${PIPER_MODEL_JSON_URL:-}
+      PIPER_LENGTH_SCALE: ${PIPER_LENGTH_SCALE:-1.10}
+      PIPER_NOISE_SCALE: ${PIPER_NOISE_SCALE:-0.60}
+      PIPER_NOISE_W: ${PIPER_NOISE_W:-0.80}
       PIPER_SPEAKER_ID: ${PIPER_SPEAKER_ID:-}
+      TTS_MP3_BITRATE: ${TTS_MP3_BITRATE:-192k}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
       interval: 10s

--- a/ui/partner-hub/dev/ai-interview/services/tts/Dockerfile
+++ b/ui/partner-hub/dev/ai-interview/services/tts/Dockerfile
@@ -32,7 +32,9 @@ COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
 COPY app.py /app/app.py
+COPY entrypoint.sh /app/entrypoint.sh
 
 EXPOSE 8000
 
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/ui/partner-hub/dev/ai-interview/services/tts/app.py
+++ b/ui/partner-hub/dev/ai-interview/services/tts/app.py
@@ -4,6 +4,8 @@ import re
 import subprocess
 import tempfile
 import time
+import uuid
+from functools import lru_cache
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import Response
 from pydantic import BaseModel
@@ -17,12 +19,16 @@ logger = logging.getLogger("ai_interview_tts")
 MAX_INPUT_LENGTH = 2000
 MAX_ERROR_DETAIL_LENGTH = 500
 DEFAULT_PIPER_MODEL_PATH = "/models/en_US-amy-medium.onnx"
-DEFAULT_PIPER_LENGTH_SCALE = 1.0
-DEFAULT_PIPER_NOISE_SCALE = 0.667
-DEFAULT_PIPER_NOISE_W = 0.8
+DEFAULT_PIPER_LENGTH_SCALE = 1.10
+DEFAULT_PIPER_NOISE_SCALE = 0.60
+DEFAULT_PIPER_NOISE_W = 0.80
+DEFAULT_MP3_BITRATE = "192k"
+MIN_PROSODY_VALUE = 0.5
+MAX_PROSODY_VALUE = 2.0
 
 
 _NON_PRINTABLE_PATTERN = re.compile(r"[\x00-\x1F\x7F-\x9F]")
+_BITRATE_PATTERN = re.compile(r"^(?P<rate>\d+)(?P<unit>k)$", re.IGNORECASE)
 
 
 def truncate_error_detail(detail: str) -> str:
@@ -54,6 +60,43 @@ class SpeechRequest(BaseModel):
     response_format: str | None = None
 
 
+def get_float_env(name: str, default: float, minimum: float, maximum: float) -> float:
+    raw_value = os.environ.get(name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    try:
+        parsed = float(raw_value)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using default %s", name, raw_value, default)
+        return default
+    if parsed < minimum or parsed > maximum:
+        logger.warning(
+            "Out of bounds %s=%r; expected %s-%s. Using default %s",
+            name,
+            parsed,
+            minimum,
+            maximum,
+            default,
+        )
+        return default
+    return parsed
+
+
+def get_bitrate_env(name: str, default: str) -> str:
+    raw_value = os.environ.get(name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    match = _BITRATE_PATTERN.match(raw_value.strip())
+    if not match:
+        logger.warning("Invalid %s=%r; using default %s", name, raw_value, default)
+        return default
+    rate = int(match.group("rate"))
+    if rate < 32 or rate > 320:
+        logger.warning("Out of bounds %s=%r; using default %s", name, raw_value, default)
+        return default
+    return f"{rate}k"
+
+
 def get_piper_supported_flags() -> set[str]:
     try:
         result = subprocess.run(
@@ -74,11 +117,81 @@ def get_piper_supported_flags() -> set[str]:
 
 
 PIPER_SUPPORTED_FLAGS = get_piper_supported_flags()
+EFFECTIVE_LENGTH_SCALE = get_float_env(
+    "PIPER_LENGTH_SCALE", DEFAULT_PIPER_LENGTH_SCALE, MIN_PROSODY_VALUE, MAX_PROSODY_VALUE
+)
+EFFECTIVE_NOISE_SCALE = get_float_env(
+    "PIPER_NOISE_SCALE", DEFAULT_PIPER_NOISE_SCALE, MIN_PROSODY_VALUE, MAX_PROSODY_VALUE
+)
+EFFECTIVE_NOISE_W = get_float_env(
+    "PIPER_NOISE_W", DEFAULT_PIPER_NOISE_W, MIN_PROSODY_VALUE, MAX_PROSODY_VALUE
+)
+EFFECTIVE_MP3_BITRATE = get_bitrate_env("TTS_MP3_BITRATE", DEFAULT_MP3_BITRATE)
+LAST_SYNTH_METRICS: dict[str, int | str] = {}
+
+logger.info(
+    "tts_config length_scale=%s noise_scale=%s noise_w=%s mp3_bitrate=%s",
+    EFFECTIVE_LENGTH_SCALE,
+    EFFECTIVE_NOISE_SCALE,
+    EFFECTIVE_NOISE_W,
+    EFFECTIVE_MP3_BITRATE,
+)
+
+
+@lru_cache(maxsize=1)
+def get_piper_version() -> str | None:
+    try:
+        result = subprocess.run(
+            ["piper", "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except Exception as exc:
+        logger.warning("Unable to read piper version: %s", exc)
+        return None
+    version_line = (result.stdout or result.stderr or "").strip()
+    return version_line or None
+
+
+@lru_cache(maxsize=1)
+def get_ffmpeg_version() -> str | None:
+    try:
+        result = subprocess.run(
+            ["ffmpeg", "-version"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except Exception as exc:
+        logger.warning("Unable to read ffmpeg version: %s", exc)
+        return None
+    first_line = (result.stdout or "").splitlines()[:1]
+    return first_line[0].strip() if first_line else None
 
 
 @app.get("/health")
 def health() -> dict:
     return {"ok": True}
+
+
+@app.get("/debug/info")
+def debug_info() -> dict:
+    model_path = os.environ.get("PIPER_MODEL_PATH", DEFAULT_PIPER_MODEL_PATH)
+    return {
+        "ok": True,
+        "piper_version": get_piper_version(),
+        "model_path": model_path,
+        "model_basename": os.path.basename(model_path),
+        "prosody": {
+            "length_scale": EFFECTIVE_LENGTH_SCALE,
+            "noise_scale": EFFECTIVE_NOISE_SCALE,
+            "noise_w": EFFECTIVE_NOISE_W,
+        },
+        "mp3_bitrate": EFFECTIVE_MP3_BITRATE,
+        "ffmpeg_version": get_ffmpeg_version(),
+        "last_synth": LAST_SYNTH_METRICS or None,
+    }
 
 
 @app.post("/v1/audio/speech")
@@ -126,10 +239,8 @@ def speech(request: SpeechRequest) -> Response:
             ),
         )
 
-    length_scale = os.environ.get("PIPER_LENGTH_SCALE", str(DEFAULT_PIPER_LENGTH_SCALE))
-    noise_scale = os.environ.get("PIPER_NOISE_SCALE", str(DEFAULT_PIPER_NOISE_SCALE))
-    noise_w = os.environ.get("PIPER_NOISE_W", str(DEFAULT_PIPER_NOISE_W))
     speaker_id = os.environ.get("PIPER_SPEAKER_ID")
+    request_id = str(uuid.uuid4())
 
     mp3_path = None
     with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as wav_file:
@@ -138,25 +249,22 @@ def speech(request: SpeechRequest) -> Response:
     try:
         command = ["piper", "--model", model_path, "--output_file", wav_path]
         if "--length_scale" in PIPER_SUPPORTED_FLAGS:
-            command += ["--length_scale", length_scale]
+            command += ["--length_scale", str(EFFECTIVE_LENGTH_SCALE)]
         if "--noise_scale" in PIPER_SUPPORTED_FLAGS:
-            command += ["--noise_scale", noise_scale]
+            command += ["--noise_scale", str(EFFECTIVE_NOISE_SCALE)]
         if "--noise_w" in PIPER_SUPPORTED_FLAGS:
-            command += ["--noise_w", noise_w]
+            command += ["--noise_w", str(EFFECTIVE_NOISE_W)]
         if speaker_id and "--speaker" in PIPER_SUPPORTED_FLAGS:
             command += ["--speaker", speaker_id]
 
         total_start = time.monotonic()
         piper_start = time.monotonic()
         logger.info(
-            "tts_piper_request voice=%r response_format=%s input_len=%s model_path=%r raw_voice=%r raw_input=%r raw_text=%r",
-            voice,
-            response_format,
+            "tts_request id=%s input_len=%s response_format=%s model_basename=%s",
+            request_id,
             len(sanitized_text),
-            model_path,
-            raw_voice,
-            request.input,
-            request.text,
+            response_format,
+            os.path.basename(model_path),
         )
         try:
             subprocess.run(
@@ -173,16 +281,31 @@ def speech(request: SpeechRequest) -> Response:
             raise HTTPException(status_code=500, detail=f"piper failed: {stderr}")
         piper_ms = int((time.monotonic() - piper_start) * 1000)
 
+        if not os.path.isfile(wav_path) or os.path.getsize(wav_path) == 0:
+            raise HTTPException(status_code=500, detail="piper output WAV was empty")
+
         if response_format == "wav":
             with open(wav_path, "rb") as wav_handle:
                 wav_content = wav_handle.read()
             total_ms = int((time.monotonic() - total_start) * 1000)
+            wav_bytes = len(wav_content)
+            LAST_SYNTH_METRICS.update(
+                {
+                    "request_id": request_id,
+                    "format": "wav",
+                    "piper_ms": piper_ms,
+                    "ffmpeg_ms": 0,
+                    "total_ms": total_ms,
+                    "response_bytes": wav_bytes,
+                }
+            )
             logger.info(
-                "tts_timing piper_ms=%s ffmpeg_ms=0 total_ms=%s input_len=%s response_bytes=%s",
+                "tts_timing id=%s format=wav piper_ms=%s ffmpeg_ms=0 total_ms=%s input_len=%s response_bytes=%s",
+                request_id,
                 piper_ms,
                 total_ms,
                 len(sanitized_text),
-                len(wav_content),
+                wav_bytes,
             )
             return Response(
                 content=wav_content,
@@ -190,6 +313,7 @@ def speech(request: SpeechRequest) -> Response:
                 headers={
                     "X-TTS-Engine": "piper",
                     "X-TTS-Model": os.path.basename(model_path),
+                    "X-Request-Id": request_id,
                 },
             )
 
@@ -205,12 +329,8 @@ def speech(request: SpeechRequest) -> Response:
                     "-i",
                     wav_path,
                     "-vn",
-                    "-ar",
-                    "44100",
                     "-b:a",
-                    "128k",
-                    "-ac",
-                    "1",
+                    EFFECTIVE_MP3_BITRATE,
                     "-codec:a",
                     "libmp3lame",
                     mp3_path,
@@ -226,16 +346,31 @@ def speech(request: SpeechRequest) -> Response:
             raise HTTPException(status_code=500, detail=f"ffmpeg failed: {stderr}")
         ffmpeg_ms = int((time.monotonic() - ffmpeg_start) * 1000)
 
+        if not os.path.isfile(mp3_path) or os.path.getsize(mp3_path) == 0:
+            raise HTTPException(status_code=500, detail="ffmpeg output MP3 was empty")
+
         with open(mp3_path, "rb") as mp3_handle:
             mp3_content = mp3_handle.read()
         total_ms = int((time.monotonic() - total_start) * 1000)
+        mp3_bytes = len(mp3_content)
+        LAST_SYNTH_METRICS.update(
+            {
+                "request_id": request_id,
+                "format": "mp3",
+                "piper_ms": piper_ms,
+                "ffmpeg_ms": ffmpeg_ms,
+                "total_ms": total_ms,
+                "response_bytes": mp3_bytes,
+            }
+        )
         logger.info(
-            "tts_timing piper_ms=%s ffmpeg_ms=%s total_ms=%s input_len=%s response_bytes=%s",
+            "tts_timing id=%s format=mp3 piper_ms=%s ffmpeg_ms=%s total_ms=%s input_len=%s response_bytes=%s",
+            request_id,
             piper_ms,
             ffmpeg_ms,
             total_ms,
             len(sanitized_text),
-            len(mp3_content),
+            mp3_bytes,
         )
         return Response(
             content=mp3_content,
@@ -243,6 +378,7 @@ def speech(request: SpeechRequest) -> Response:
             headers={
                 "X-TTS-Engine": "piper",
                 "X-TTS-Model": os.path.basename(model_path),
+                "X-Request-Id": request_id,
             },
         )
     finally:

--- a/ui/partner-hub/dev/ai-interview/services/tts/entrypoint.sh
+++ b/ui/partner-hub/dev/ai-interview/services/tts/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+set -eu
+
+mkdir -p /models
+
+if [ -n "${PIPER_MODEL_URL:-}" ]; then
+  model_filename=$(basename "$PIPER_MODEL_URL")
+  model_path="/models/$model_filename"
+  echo "Downloading Piper model from $PIPER_MODEL_URL"
+  curl -fsSL -o "$model_path" "$PIPER_MODEL_URL"
+  if [ ! -s "$model_path" ]; then
+    echo "Downloaded Piper model is empty: $model_path" >&2
+    exit 1
+  fi
+  if [ -z "${PIPER_MODEL_PATH:-}" ]; then
+    export PIPER_MODEL_PATH="$model_path"
+  fi
+fi
+
+if [ -n "${PIPER_MODEL_JSON_URL:-}" ]; then
+  json_filename=$(basename "$PIPER_MODEL_JSON_URL")
+  json_path="/models/$json_filename"
+  echo "Downloading Piper model config from $PIPER_MODEL_JSON_URL"
+  curl -fsSL -o "$json_path" "$PIPER_MODEL_JSON_URL"
+  if [ ! -s "$json_path" ]; then
+    echo "Downloaded Piper model config is empty: $json_path" >&2
+    exit 1
+  fi
+fi
+
+exec "$@"


### PR DESCRIPTION
### Motivation
- Provide a diagnostics-first workflow and clearer logs to root-cause choppy/staccato Piper output without guessing. 
- Make prosody tuning (length/noise parameters) first-class, validated and configurable via environment variables to allow safe experimentation. 
- Allow swapping Piper models at container start and stabilize MP3 encoding to avoid resampling/encoding artifacts. 

### Description
- Added validated prosody and MP3 bitrate configuration in `services/tts/app.py`, with defaults `PIPER_LENGTH_SCALE=1.10`, `PIPER_NOISE_SCALE=0.60`, `PIPER_NOISE_W=0.80`, and `TTS_MP3_BITRATE=192k`, plus bounds checking and warnings for invalid values. 
- Added deterministic request-level logging and diagnostics: UUID `X-Request-Id` headers, timing logs (`piper_ms`, `ffmpeg_ms`, `total_ms`), response byte counts, and a lightweight endpoint `GET /debug/info` that returns `piper_version`, `model_path`/`model_basename`, effective prosody values, `mp3_bitrate`, `ffmpeg_version`, and the last synth metrics. 
- Hardening around audio files: validate Piper WAV output and ffmpeg MP3 outputs are non-empty and return clear 500 errors on failures; use WAV as source of truth and avoid unnecessary resampling in ffmpeg invocation. 
- Added an optional entrypoint `services/tts/entrypoint.sh` that downloads `PIPER_MODEL_URL` and `PIPER_MODEL_JSON_URL` into `/models` (fail-fast if empty) and wired it into the container by copying the script and setting `ENTRYPOINT` in the `Dockerfile`. 
- Exposed new environment variables and new defaults in `dev/ai-interview/docker-compose.yml` (`PIPER_MODEL_URL`, `PIPER_MODEL_JSON_URL`, `PIPER_LENGTH_SCALE`, `PIPER_NOISE_SCALE`, `PIPER_NOISE_W`, `TTS_MP3_BITRATE`) while preserving the existing default `PIPER_MODEL_PATH`. 
- Added `dev/ai-interview/README.md` with diagnostics commands (A/B WAV vs MP3), guidance for model swapping via env vars, and WSL2 troubleshooting tips (do not modify the host automatically). 

### Testing
- No automated tests were run against these changes in this rollout; changes were limited to the TTS service, compose, Dockerfile and docs and committed for review. 
- Basic safety checks added in code (file existence/size, validated env parsing, and `piper`/`ffmpeg` probing) will produce deterministic failures during container start or request time if misconfigured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a85fff9e883309bc2781929bf3c79)