### PR TITLE
Vendor Piper artifacts for deterministic ai-interview-tts Docker builds

### DIFF
--- a/ui/partner-hub/dev/ai-interview/services/tts/Dockerfile
+++ b/ui/partner-hub/dev/ai-interview/services/tts/Dockerfile
@@ -14,18 +14,30 @@ ARG PIPER_VERSION=1.2.0
 ARG PIPER_TARBALL_SHA256=
 ARG PIPER_MODEL_SHA256=
 ARG PIPER_MODEL_JSON_SHA256=
+
+COPY vendor/ /tmp/vendor/
+
 RUN set -eux; \
-    curl -L -o /tmp/piper.tar.gz "https://github.com/rhasspy/piper/releases/download/v${PIPER_VERSION}/piper_linux_x86_64.tar.gz"; \
+    if [ ! -f /tmp/vendor/piper_linux_x86_64.tar.gz ]; then \
+      echo "Missing vendor/piper_linux_x86_64.tar.gz. Place the Piper tarball in services/tts/vendor/."; \
+      exit 1; \
+    fi; \
+    if [ ! -f /tmp/vendor/en_US-amy-medium.onnx ] || [ ! -f /tmp/vendor/en_US-amy-medium.onnx.json ]; then \
+      echo "Missing default Piper model files in services/tts/vendor (en_US-amy-medium.onnx + .json)."; \
+      exit 1; \
+    fi; \
+    cp /tmp/vendor/piper_linux_x86_64.tar.gz /tmp/piper.tar.gz; \
     if [ -n "$PIPER_TARBALL_SHA256" ]; then echo "$PIPER_TARBALL_SHA256  /tmp/piper.tar.gz" | sha256sum -c -; fi; \
     tar -xzf /tmp/piper.tar.gz -C /tmp; \
     mv /tmp/piper/piper /usr/local/bin/piper; \
     chmod +x /usr/local/bin/piper; \
     rm -rf /tmp/piper /tmp/piper.tar.gz; \
     mkdir -p /models; \
-    curl -L -o /models/en_US-amy-medium.onnx "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/amy/medium/en_US-amy-medium.onnx"; \
+    cp /tmp/vendor/en_US-amy-medium.onnx /models/en_US-amy-medium.onnx; \
     if [ -n "$PIPER_MODEL_SHA256" ]; then echo "$PIPER_MODEL_SHA256  /models/en_US-amy-medium.onnx" | sha256sum -c -; fi; \
-    curl -L -o /models/en_US-amy-medium.onnx.json "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/amy/medium/en_US-amy-medium.onnx.json"; \
-    if [ -n "$PIPER_MODEL_JSON_SHA256" ]; then echo "$PIPER_MODEL_JSON_SHA256  /models/en_US-amy-medium.onnx.json" | sha256sum -c -; fi
+    cp /tmp/vendor/en_US-amy-medium.onnx.json /models/en_US-amy-medium.onnx.json; \
+    if [ -n "$PIPER_MODEL_JSON_SHA256" ]; then echo "$PIPER_MODEL_JSON_SHA256  /models/en_US-amy-medium.onnx.json" | sha256sum -c -; fi; \
+    rm -rf /tmp/vendor
 
 RUN pip install --no-cache-dir --upgrade pip
 COPY requirements.txt /app/requirements.txt

--- a/ui/partner-hub/dev/ai-interview/services/tts/README.md
+++ b/ui/partner-hub/dev/ai-interview/services/tts/README.md
@@ -1,0 +1,18 @@
+# AI Interview TTS (Dev)
+
+## Vendored Piper artifacts
+To keep Docker builds deterministic, place the Piper release tarball and default model files in the vendor folder before building:
+
+```
+ui/partner-hub/dev/ai-interview/services/tts/vendor/piper_linux_x86_64.tar.gz
+ui/partner-hub/dev/ai-interview/services/tts/vendor/en_US-amy-medium.onnx
+ui/partner-hub/dev/ai-interview/services/tts/vendor/en_US-amy-medium.onnx.json
+```
+
+The Dockerfile copies these files during build and does **not** download Piper or models from the network.
+
+## Rebuild
+
+```
+docker compose -f ui/partner-hub/dev/ai-interview/docker-compose.yml up -d --build ai-interview-tts
+```


### PR DESCRIPTION
### Motivation
- Make `ai-interview-tts` Docker builds deterministic by eliminating build-time network downloads of Piper and its default model, which occasionally return invalid payloads and break `tar`/`gzip` during image builds.

### Description
- Add a vendor directory placeholder at `ui/partner-hub/dev/ai-interview/services/tts/vendor/.gitkeep` to allow local placement of `piper_linux_x86_64.tar.gz` and model files.
- Update `ui/partner-hub/dev/ai-interview/services/tts/Dockerfile` to `COPY vendor/ /tmp/vendor/`, fail fast with clear error messages if vendored artifacts are missing, extract the Piper tarball to `/usr/local/bin/piper`, and copy the default model files into `/models` while preserving optional SHA256 verification.
- Remove all `curl` downloads for the Piper tarball and default model from the Dockerfile so no network calls occur at build time.
- Add `ui/partner-hub/dev/ai-interview/services/tts/README.md` documenting where to place the Piper tarball and model files and how to rebuild with `docker compose -f ui/partner-hub/dev/ai-interview/docker-compose.yml up -d --build ai-interview-tts`.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aa3fee5e88330b519d426c9ab7faa)