### PR TITLE
TTS: add vendor .gitignore, README setup note, and preflight check script

### DIFF
--- a/ui/partner-hub/dev/ai-interview/services/tts/README.md
+++ b/ui/partner-hub/dev/ai-interview/services/tts/README.md
@@ -11,6 +11,14 @@ ui/partner-hub/dev/ai-interview/services/tts/vendor/en_US-amy-medium.onnx.json
 
 The Dockerfile copies these files during build and does **not** download Piper or models from the network.
 
+## Local setup (one-time)
+- Do **not** commit the vendor artifacts; they are gitignored and meant to stay local.
+- Place these files locally:
+  - `vendor/piper_linux_x86_64.tar.gz`
+  - `vendor/en_US-amy-medium.onnx`
+  - `vendor/en_US-amy-medium.onnx.json`
+- Optional: if `PIPER_TARBALL_SHA256`, `PIPER_MODEL_SHA256`, or `PIPER_MODEL_JSON_SHA256` are set, their values must match the local files.
+
 ## Rebuild
 
 ```

--- a/ui/partner-hub/dev/ai-interview/services/tts/scripts/check_vendor.ps1
+++ b/ui/partner-hub/dev/ai-interview/services/tts/scripts/check_vendor.ps1
@@ -1,0 +1,28 @@
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$vendorDir = Join-Path $scriptDir "..\vendor"
+
+$requiredFiles = @(
+  "piper_linux_x86_64.tar.gz",
+  "en_US-amy-medium.onnx",
+  "en_US-amy-medium.onnx.json"
+)
+
+$missing = @()
+
+foreach ($file in $requiredFiles) {
+  $path = Join-Path $vendorDir $file
+  if (-not (Test-Path -LiteralPath $path)) {
+    $missing += $file
+    continue
+  }
+
+  $item = Get-Item -LiteralPath $path
+  Write-Host ("Found {0} ({1} bytes)" -f $file, $item.Length)
+}
+
+if ($missing.Count -gt 0) {
+  Write-Error ("Missing required vendor files in {0}:{1}{2}" -f $vendorDir, [Environment]::NewLine, ($missing | ForEach-Object { " - $_" } | Out-String))
+  exit 1
+}
+
+Write-Host "All required vendor files are present."

--- a/ui/partner-hub/dev/ai-interview/services/tts/vendor/.gitignore
+++ b/ui/partner-hub/dev/ai-interview/services/tts/vendor/.gitignore
@@ -1,0 +1,5 @@
+*.onnx
+*.json
+*.tar.gz
+*.zip
+*.bin


### PR DESCRIPTION
### Motivation
- Prevent accidental commits of large Piper/model artifacts by making the vendor folder explicitly git-ignored while keeping the directory present.
- Make local setup unambiguous so developers know which files belong in `vendor/` and that they should remain local.
- Provide a fast preflight that fails early when required vendor files are missing to avoid long, flaky Docker builds.

### Description
- Add `ui/partner-hub/dev/ai-interview/services/tts/vendor/.gitignore` with patterns for `*.onnx`, `*.json`, `*.tar.gz`, `*.zip`, and `*.bin` to guard against committing artifacts.
- Update `ui/partner-hub/dev/ai-interview/services/tts/README.md` with a `Local setup (one-time)` section that instructs not to commit vendor artifacts, lists the three required files, and notes optional SHA env var verification.
- Add `ui/partner-hub/dev/ai-interview/services/tts/scripts/check_vendor.ps1`, a PowerShell preflight that checks for the three required vendor files, prints their sizes, and exits with code 1 with a clear message if any are missing.
- Preserve existing behavior: no network downloads were reintroduced and Dockerfile logic remains unchanged.

### Testing
- Ran `powershell -ExecutionPolicy Bypass -File ui/partner-hub/dev/ai-interview/services/tts/scripts/check_vendor.ps1`, which failed because `powershell` is not available in the environment.
- Ran `pwsh -ExecutionPolicy Bypass -File ui/partner-hub/dev/ai-interview/services/tts/scripts/check_vendor.ps1`, which failed because `pwsh` is not available in the environment.
- Ran `docker compose -f ui/partner-hub/dev/ai-interview/docker-compose.yml build ai-interview-tts`, which failed because `docker` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aa51e45fc8330a3249ecc176f117c)