### PR TITLE
Harden Coqui TTS startup, cache, and cleanup

### DIFF
--- a/ui/partner-hub/dev/ai-interview/docker-compose.yml
+++ b/ui/partner-hub/dev/ai-interview/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       COQUI_USE_CUDA: ${COQUI_USE_CUDA:-true}
       COQUI_SPEAKER: ${COQUI_SPEAKER:-}
       TTS_MP3_BITRATE: ${TTS_MP3_BITRATE:-192k}
-    gpus: all  # Requires NVIDIA Container Toolkit / Docker Desktop GPU support
+    gpus: all  # Requires NVIDIA Container Toolkit and WSL2 GPU support
     volumes:
       - ai-interview-tts-local-share:/root/.local/share/tts
       - ai-interview-tts-cache:/root/.cache/tts

--- a/ui/partner-hub/dev/ai-interview/services/tts/Dockerfile
+++ b/ui/partner-hub/dev/ai-interview/services/tts/Dockerfile
@@ -7,6 +7,7 @@ ENV LC_ALL=C.UTF-8
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ffmpeg libsndfile1 ca-certificates curl \
+    && ffmpeg -version \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /app/requirements.txt

--- a/ui/partner-hub/dev/ai-interview/services/tts/app.py
+++ b/ui/partner-hub/dev/ai-interview/services/tts/app.py
@@ -105,13 +105,17 @@ def get_selected_device(use_cuda: bool, cuda_available: bool) -> str:
 
 
 EFFECTIVE_MP3_BITRATE = get_bitrate_env("TTS_MP3_BITRATE", DEFAULT_MP3_BITRATE)
-_effective_model_name, _effective_use_cuda = get_effective_runtime_config()
-logger.info(
-    "tts_config model=%s use_cuda=%s mp3_bitrate=%s",
-    _effective_model_name,
-    _effective_use_cuda,
-    EFFECTIVE_MP3_BITRATE,
-)
+
+
+@app.on_event("startup")
+def log_startup_config() -> None:
+    model_name, use_cuda = get_effective_runtime_config()
+    logger.info(
+        "tts_config model=%s use_cuda=%s mp3_bitrate=%s",
+        model_name,
+        use_cuda,
+        EFFECTIVE_MP3_BITRATE,
+    )
 
 
 @lru_cache(maxsize=1)
@@ -144,7 +148,7 @@ def engine_preflight() -> tuple[bool, str | None]:
     return True, None
 
 
-@lru_cache(maxsize=8)
+@lru_cache(maxsize=4)
 def get_tts_engine(model_name: str, use_cuda: bool) -> TTS:
     global LAST_ENGINE_LOAD_ERROR
 
@@ -215,6 +219,7 @@ def resolve_speaker(engine: TTS, requested_voice: str | None) -> tuple[str | Non
     speakers_count = len(speakers)
 
     if not speaker_supported:
+        logger.info("single_speaker_model_detected; ignoring voice override")
         if requested:
             logger.info("request_voice_ignored reason=no_multispeaker_support voice=%s", requested)
         if configured_speaker:
@@ -239,10 +244,14 @@ def resolve_speaker(engine: TTS, requested_voice: str | None) -> tuple[str | Non
 @app.get("/health")
 def health() -> dict:
     preflight_ok, preflight_detail = engine_preflight()
+    model_name, use_cuda = get_effective_runtime_config()
+    cuda_available = get_cuda_available()
     return {
         "ok": True,
         "preflight_ok": preflight_ok,
         "preflight_detail": preflight_detail,
+        "cuda_available": cuda_available,
+        "device_selected": get_selected_device(use_cuda, cuda_available),
     }
 
 
@@ -302,10 +311,13 @@ def speech(request: SpeechRequest):
 
     request_id = str(uuid.uuid4())
     model_name, use_cuda = get_effective_runtime_config()
+    cache_hits_before = get_tts_engine.cache_info().hits
     try:
         engine = get_tts_engine(model_name, use_cuda)
     except RuntimeError as exc:
         raise HTTPException(status_code=500, detail=truncate_error_detail(str(exc)))
+    if get_tts_engine.cache_info().hits > cache_hits_before:
+        logger.info("coqui_engine_cache_hit model=%s use_cuda=%s", model_name, use_cuda)
 
     sample_rate = get_output_sample_rate(engine)
     speaker, speaker_supported, speakers_count = resolve_speaker(engine, voice)
@@ -447,7 +459,7 @@ def speech(request: SpeechRequest):
     finally:
         try:
             os.remove(wav_path)
-        except FileNotFoundError:
+        except Exception:
             pass
         if mp3_path:
             try:


### PR DESCRIPTION
### Motivation

- Ensure startup logs reflect runtime environment and make engine reuse, speaker behavior, GPU visibility, and temp-file lifecycle deterministic and observable.
- Improve robustness around engine caching and temporary file cleanup to avoid orphaned artifacts and ambiguous runtime failures.

### Description

- Move the one-shot module-level `tts_config` log into a FastAPI startup event via `@app.on_event("startup")` so logged values come from `get_effective_runtime_config()` at process start.
- Reduce `get_tts_engine` cache size to `@lru_cache(maxsize=4)` and log cache reuse with `logger.info("coqui_engine_cache_hit model=%s use_cuda=%s", ...)` when a cached engine is returned.
- Add explicit logging in `resolve_speaker()` with `logger.info("single_speaker_model_detected; ignoring voice override")` when the model has no speaker inventory, and keep existing voice-ignored logs for clarity.
- Guarantee removal of temporary WAV and MP3 files by ensuring the generation + `ffmpeg` conversion block is wrapped with a `finally` that always attempts to `os.remove(wav_path)` and `os.remove(mp3_path)` with resilient exception guards.
- Make `/health` fully transparent about GPU state by adding `"cuda_available": get_cuda_available()` and `"device_selected": get_selected_device(use_cuda, cuda_available)` to the health response.
- Fail Docker image builds early if `ffmpeg` is missing by adding `&& ffmpeg -version` to the `apt-get` layer in the TTS `Dockerfile`, and clarify the compose GPU comment to note NVIDIA Container Toolkit and WSL2 GPU support.

### Testing

- Ran `python -m py_compile ui/partner-hub/dev/ai-interview/services/tts/app.py` to verify the module compiles cleanly; this succeeded.
- Attempted `docker compose -f ui/partner-hub/dev/ai-interview/docker-compose.yml config` to validate compose output but the `docker` binary is not available in this environment, so the compose validation could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb02686d48330b32edc9b43e186f5)