### PR TITLE
Warm Coqui TTS engine during startup

### DIFF
--- a/ui/partner-hub/dev/ai-interview/services/tts/app.py
+++ b/ui/partner-hub/dev/ai-interview/services/tts/app.py
@@ -118,6 +118,16 @@ def log_startup_config() -> None:
     )
 
 
+@app.on_event("startup")
+def warm_engine() -> None:
+    model_name, use_cuda = get_effective_runtime_config()
+    try:
+        get_tts_engine(model_name, use_cuda)
+        logger.info("coqui_engine_warm_complete model=%s use_cuda=%s", model_name, use_cuda)
+    except Exception as exc:
+        logger.error("coqui_engine_warm_failed: %s", exc)
+
+
 @lru_cache(maxsize=1)
 def get_ffmpeg_version() -> str | None:
     try:


### PR DESCRIPTION
### Motivation

- Reduce first-request latency spikes by deterministically loading the Coqui TTS engine on application startup without changing runtime behavior or API surface.

### Description

- Add a startup hook `warm_engine()` registered with `@app.on_event("startup")` that resolves the runtime config via `get_effective_runtime_config()` and eagerly initializes the engine with `get_tts_engine(model_name, use_cuda)` in `ui/partner-hub/dev/ai-interview/services/tts/app.py`.
- The warmup only loads the engine and model (and logs success or failure) and explicitly does not synthesize any text, preserving existing behavior and endpoints such as `/health`.
- Errors during warmup are logged via `logger.error` and do not alter API surface or introduce fallback behavior.

### Testing

- Verified syntax by running `python -m py_compile ui/partner-hub/dev/ai-interview/services/tts/app.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb1b76228833083eb7466fd5ab503)