### PR TITLE
Fix deterministic default speaker selection for Coqui multi-speaker models

### DIFF
--- a/ui/partner-hub/dev/ai-interview/services/tts/app.py
+++ b/ui/partner-hub/dev/ai-interview/services/tts/app.py
@@ -224,7 +224,7 @@ def resolve_speaker(engine: TTS, requested_voice: str | None) -> tuple[str | Non
     configured_speaker = (os.environ.get("COQUI_SPEAKER") or "").strip() or None
     requested = (requested_voice or "").strip() or None
 
-    speakers = get_speaker_inventory(engine)
+    speakers = sorted(get_speaker_inventory(engine))
     speaker_supported = len(speakers) > 0
     speakers_count = len(speakers)
 
@@ -241,7 +241,8 @@ def resolve_speaker(engine: TTS, requested_voice: str | None) -> tuple[str | Non
 
     effective_speaker = requested or configured_speaker
     if not effective_speaker:
-        return None, True, speakers_count
+        effective_speaker = speakers[0]
+        logger.info("coqui_default_speaker_selected speaker=%s", effective_speaker)
 
     if effective_speaker not in speakers:
         raise HTTPException(


### PR DESCRIPTION
### Motivation
- Multi-speaker Coqui TTS models were failing when no speaker was provided, causing errors like "Model is multi-speaker but no speaker is provided.".
- The goal is to ensure the TTS service always supplies a speaker for multi-speaker models in a deterministic way without requiring UI changes.

### Description
- Sort the model's speaker inventory by calling `sorted(get_speaker_inventory(engine))` to make speaker ordering deterministic.
- When the model supports multiple speakers and neither `request.voice` nor `COQUI_SPEAKER` is provided, automatically select the first entry from the sorted speakers as the effective speaker and log `"coqui_default_speaker_selected speaker=%s"` with the chosen name.
- Preserve existing behavior: if a `request.voice` (or configured speaker) is provided but not in the speakers list, raise HTTP 400 with the existing error message; request-provided voice continues to override the default.
- Keep existing endpoints and response formats unchanged and ensure `LAST_EFFECTIVE_SPEAKER` continues to be set from the `resolve_speaker` result so `/debug/info` reflects the actual used speaker.

### Testing
- Ran `python -m py_compile ui/partner-hub/dev/ai-interview/services/tts/app.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d016f8e3883309fd52a18c34327b8)