### PR TITLE
Persona-based male voice routing and tempo tuning for Coqui TTS

### DIFF
--- a/ui/partner-hub/components/interview/InterviewTool.tsx
+++ b/ui/partner-hub/components/interview/InterviewTool.tsx
@@ -8,6 +8,7 @@ import { logDebug } from "./debug";
 
 type PersonaOption = {
   id: "se-leader" | "peer-engineer" | "sales-exec";
+  voiceAlias: "se_leader" | "peer_engineer" | "sales_exec";
   label: string;
   summary: string;
   systemPrompt: string;
@@ -30,6 +31,7 @@ const WARNING_RECORDING_SECONDS = 50;
 const personaOptions: PersonaOption[] = [
   {
     id: "se-leader",
+    voiceAlias: "se_leader",
     label: "SE Leader",
     summary: "Strategic sales engineer leader focused on discovery and outcomes.",
     systemPrompt:
@@ -37,6 +39,7 @@ const personaOptions: PersonaOption[] = [
   },
   {
     id: "peer-engineer",
+    voiceAlias: "peer_engineer",
     label: "Peer Engineer",
     summary: "Hands-on peer engineer probing technical depth and tradeoffs.",
     systemPrompt:
@@ -44,6 +47,7 @@ const personaOptions: PersonaOption[] = [
   },
   {
     id: "sales-exec",
+    voiceAlias: "sales_exec",
     label: "Sales Exec",
     summary: "Executive sponsor focused on business value and ROI.",
     systemPrompt:
@@ -463,7 +467,7 @@ export function InterviewTool() {
         { role: "assistant", text: responseText },
       ]);
 
-      await sendToTts(responseText, turnId);
+      await sendToTts(responseText, activePersona.voiceAlias, turnId);
     } catch (err) {
       logDebug("error", {
         step: "recording_complete",
@@ -497,7 +501,7 @@ export function InterviewTool() {
 
       setTranscript((prev) => [...prev, { role: "assistant", text: responseText }]);
 
-      await sendToTts(responseText, turnId);
+      await sendToTts(responseText, activePersona.voiceAlias, turnId);
     } catch (err) {
       logDebug("error", {
         step: "start_interview",
@@ -622,7 +626,7 @@ export function InterviewTool() {
     }
   };
 
-  const sendToTts = async (text: string, turnId: string) => {
+  const sendToTts = async (text: string, voiceAlias: PersonaOption["voiceAlias"], turnId: string) => {
     stopAudioPlayback();
     const startedAt = Date.now();
     logDebug("tts_request_start", { turnId });
@@ -635,7 +639,7 @@ export function InterviewTool() {
           "Content-Type": "application/json",
           "x-ai-interview-turn-id": turnId,
         },
-        body: JSON.stringify({ text }),
+        body: JSON.stringify({ text, voice: voiceAlias }),
       });
       const elapsedMs = Date.now() - startedAt;
 

--- a/ui/partner-hub/dev/ai-interview/docker-compose.yml
+++ b/ui/partner-hub/dev/ai-interview/docker-compose.yml
@@ -28,7 +28,8 @@ services:
       COQUI_SPEAKER: ${COQUI_SPEAKER:-}
       TTS_MP3_BITRATE: ${TTS_MP3_BITRATE:-192k}
       TTS_ATEMPO: ${TTS_ATEMPO:-0.94}
-      TTS_VOICE_ATEMPO_JSON: ${TTS_VOICE_ATEMPO_JSON:-}
+      TTS_VOICE_ATEMPO_JSON: '${TTS_VOICE_ATEMPO_JSON:-{"se_leader":0.92,"peer_engineer":0.96,"sales_exec":0.90}}'
+      TTS_VOICE_SPEAKER_JSON: '${TTS_VOICE_SPEAKER_JSON:-{"se_leader":"p287","peer_engineer":"p314","sales_exec":"p259"}}'
     gpus: all  # Requires NVIDIA Container Toolkit and WSL2 GPU support
     volumes:
       - ai-interview-tts-local-share:/root/.local/share/tts

--- a/ui/partner-hub/dev/ai-interview/services/tts/README.md
+++ b/ui/partner-hub/dev/ai-interview/services/tts/README.md
@@ -21,7 +21,8 @@ This service provides a local OpenAI-compatible TTS endpoint for AI Interview de
 - `COQUI_SPEAKER` (optional; only used when model supports multi-speaker)
 - `TTS_MP3_BITRATE` (default: `192k`, valid range `32k..320k`)
 - `TTS_ATEMPO` (default: `0.94`, valid range `0.5..2.0`)
-- `TTS_VOICE_ATEMPO_JSON` (optional JSON object mapping `voice` to tempo, e.g. `{"se_leader":0.92,"peer_engineer":0.96,"sales_exec":0.98}`)
+- `TTS_VOICE_ATEMPO_JSON` (JSON object mapping `voice` alias to tempo, default: `{"se_leader":0.92,"peer_engineer":0.96,"sales_exec":0.90}`)
+- `TTS_VOICE_SPEAKER_JSON` (JSON object mapping `voice` alias to Coqui speaker ID, default: `{"se_leader":"p287","peer_engineer":"p314","sales_exec":"p259"}`)
 
 ## Notes
 
@@ -30,8 +31,10 @@ This service provides a local OpenAI-compatible TTS endpoint for AI Interview de
   - `/root/.cache/tts`
 - `GET /health` stays fast and reports `preflight_ok` / `preflight_detail` without synthesizing audio.
 - If `COQUI_USE_CUDA=true` and CUDA is unavailable, synth requests fail with an explicit actionable error (no silent CPU fallback).
-- Request `voice` is used as a speaker override when the model supports speakers.
-- Tempo is applied with ffmpeg `atempo` for both output formats.
+- Request `voice` is treated as a persona alias (for example `se_leader`, `peer_engineer`, `sales_exec`).
+- Persona alias to speaker resolution is controlled by `TTS_VOICE_SPEAKER_JSON` and validated against the model speaker inventory.
+- Invalid alias speaker configuration fails fast with an actionable 500 error (`Configured speaker "<mapped>" for alias "<alias>" not found.`); there is no silent fallback for bad alias mappings.
+- Tempo is applied with ffmpeg `atempo` for both output formats. Persona-specific tempo can be set via `TTS_VOICE_ATEMPO_JSON`; otherwise `TTS_ATEMPO` is used as default.
   - `0.92` = slower
   - `0.94` = slightly slower
   - `1.0` = normal speed

--- a/ui/partner-hub/dev/ai-interview/services/tts/app.py
+++ b/ui/partner-hub/dev/ai-interview/services/tts/app.py
@@ -27,9 +27,11 @@ MAX_ERROR_DETAIL_LENGTH = 500
 DEFAULT_COQUI_MODEL_NAME = "tts_models/en/vctk/vits"
 DEFAULT_MP3_BITRATE = "192k"
 DEFAULT_TTS_ATEMPO = 0.94
-LAST_SYNTH_METRICS: dict[str, int | str] = {}
+LAST_SYNTH_METRICS: dict[str, int | float | str] = {}
 LAST_ENGINE_LOAD_ERROR: str | None = None
 LAST_EFFECTIVE_SPEAKER: str | None = None
+LAST_EFFECTIVE_VOICE_ALIAS: str | None = None
+LAST_TEMPO_USED: float | None = None
 LAST_SPEAKER_SUPPORTED = False
 LAST_SPEAKERS_COUNT = 0
 
@@ -135,6 +137,35 @@ def get_voice_atempo_overrides() -> dict[str, float]:
             )
         overrides[voice_name.strip()] = tempo
     return overrides
+
+
+
+
+@lru_cache(maxsize=1)
+def get_voice_speaker_map() -> dict[str, str]:
+    raw_value = os.environ.get("TTS_VOICE_SPEAKER_JSON")
+    if raw_value is None or not raw_value.strip():
+        return {}
+    try:
+        parsed = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            "Invalid TTS_VOICE_SPEAKER_JSON. Expected JSON object like {\"se_leader\":\"p287\"}:"
+            f" {exc}"
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise RuntimeError("Invalid TTS_VOICE_SPEAKER_JSON. Expected a JSON object mapping aliases to speakers")
+
+    mapping: dict[str, str] = {}
+    for alias_key, speaker_value in parsed.items():
+        if not isinstance(alias_key, str) or not alias_key.strip():
+            raise RuntimeError("Invalid TTS_VOICE_SPEAKER_JSON key. Alias names must be non-empty strings")
+        if not isinstance(speaker_value, str) or not speaker_value.strip():
+            raise RuntimeError(
+                f"Invalid speaker mapping for alias '{alias_key}'. Speaker values must be non-empty strings"
+            )
+        mapping[alias_key.strip()] = speaker_value.strip()
+    return mapping
 
 
 def get_effective_tempo(request_voice: str | None) -> float:
@@ -282,6 +313,7 @@ def get_speaker_inventory(engine: TTS) -> list[str]:
 def resolve_speaker(engine: TTS, requested_voice: str | None) -> tuple[str | None, bool, int]:
     configured_speaker = (os.environ.get("COQUI_SPEAKER") or "").strip() or None
     requested = (requested_voice or "").strip() or None
+    voice_map = get_voice_speaker_map()
 
     speakers = sorted(get_speaker_inventory(engine))
     speaker_supported = len(speakers) > 0
@@ -299,6 +331,15 @@ def resolve_speaker(engine: TTS, requested_voice: str | None) -> tuple[str | Non
         return None, False, 0
 
     effective_speaker = requested or configured_speaker
+    if requested and requested in voice_map:
+        mapped_speaker = voice_map[requested]
+        effective_speaker = mapped_speaker
+        if mapped_speaker not in speakers:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Configured speaker '{mapped_speaker}' for alias '{requested}' not found.",
+            )
+
     if not effective_speaker:
         effective_speaker = speakers[0]
         logger.info("coqui_default_speaker_selected speaker=%s", effective_speaker)
@@ -332,14 +373,21 @@ def debug_info() -> dict:
     cuda_available = get_cuda_available()
     device_selected = get_selected_device(use_cuda, cuda_available)
     voice_atempo_raw = os.environ.get("TTS_VOICE_ATEMPO_JSON")
+    voice_speaker_raw = os.environ.get("TTS_VOICE_SPEAKER_JSON")
     voice_atempo_preview = None
+    voice_speaker_preview = None
     atempo_config_error = None
+    speaker_config_error = None
     try:
         tts_atempo_default = get_tts_atempo_default()
         voice_atempo_preview = get_voice_atempo_overrides()
     except RuntimeError as exc:
         tts_atempo_default = None
         atempo_config_error = str(exc)
+    try:
+        voice_speaker_preview = get_voice_speaker_map()
+    except RuntimeError as exc:
+        speaker_config_error = str(exc)
 
     return {
         "ok": True,
@@ -349,7 +397,14 @@ def debug_info() -> dict:
         "cuda_available": cuda_available,
         "device_selected": device_selected,
         "configured_speaker": configured_speaker,
+        "voice_speaker_json": voice_speaker_raw,
+        "voice_speaker_preview": voice_speaker_preview,
+        "voice_aliases": sorted(list((voice_speaker_preview or {}).keys())),
+        "voice_speaker_json_configured": bool(voice_speaker_raw and voice_speaker_raw.strip()),
+        "voice_atempo_json_configured": bool(voice_atempo_raw and voice_atempo_raw.strip()),
+        "effective_voice_alias_last": LAST_EFFECTIVE_VOICE_ALIAS,
         "effective_speaker": LAST_EFFECTIVE_SPEAKER,
+        "tempo_used_last": LAST_TEMPO_USED,
         "speaker_supported": LAST_SPEAKER_SUPPORTED,
         "speakers_count": LAST_SPEAKERS_COUNT,
         "last_engine_load_error": LAST_ENGINE_LOAD_ERROR,
@@ -358,6 +413,7 @@ def debug_info() -> dict:
         "voice_atempo_json": voice_atempo_raw,
         "voice_atempo_preview": voice_atempo_preview,
         "atempo_config_error": atempo_config_error,
+        "speaker_config_error": speaker_config_error,
         "ffmpeg_version": get_ffmpeg_version(),
         "last_synth": LAST_SYNTH_METRICS or None,
     }
@@ -366,6 +422,8 @@ def debug_info() -> dict:
 @app.post("/v1/audio/speech")
 def speech(request: SpeechRequest):
     global LAST_EFFECTIVE_SPEAKER
+    global LAST_EFFECTIVE_VOICE_ALIAS
+    global LAST_TEMPO_USED
     global LAST_SPEAKER_SUPPORTED
     global LAST_SPEAKERS_COUNT
 
@@ -403,8 +461,12 @@ def speech(request: SpeechRequest):
         logger.info("coqui_engine_cache_hit model=%s use_cuda=%s", model_name, use_cuda)
 
     sample_rate = get_output_sample_rate(engine)
-    speaker, speaker_supported, speakers_count = resolve_speaker(engine, voice)
+    try:
+        speaker, speaker_supported, speakers_count = resolve_speaker(engine, voice)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=truncate_error_detail(str(exc)))
     LAST_EFFECTIVE_SPEAKER = speaker
+    LAST_EFFECTIVE_VOICE_ALIAS = voice or None
     LAST_SPEAKER_SUPPORTED = speaker_supported
     LAST_SPEAKERS_COUNT = speakers_count
 
@@ -418,6 +480,7 @@ def speech(request: SpeechRequest):
             tempo = get_effective_tempo(voice)
         except RuntimeError as exc:
             raise HTTPException(status_code=500, detail=truncate_error_detail(str(exc)))
+        LAST_TEMPO_USED = tempo
 
         total_start = time.monotonic()
         tts_start = time.monotonic()
@@ -493,6 +556,7 @@ def speech(request: SpeechRequest):
                     "total_ms": total_ms,
                     "response_bytes": wav_bytes,
                     "tempo": tempo,
+                    "tempo_used": tempo,
                 }
             )
             logger.info(
@@ -562,6 +626,7 @@ def speech(request: SpeechRequest):
                 "total_ms": total_ms,
                 "response_bytes": mp3_bytes,
                 "tempo": tempo,
+                "tempo_used": tempo,
             }
         )
         logger.info(


### PR DESCRIPTION
### Motivation
- Provide deterministic, persona-driven male voice selection for AI Interview TTS while preserving the existing API shape.
- Allow per-persona tempo tuning to make personas sound distinct and consistent.
- Surface configuration and failures explicitly so bad mappings do not silently fall back.

### Description
- Frontend now attaches a persona `voice` alias to every TTS request (`se_leader`, `peer_engineer`, `sales_exec`) and keeps the request schema unchanged.
- Backend adds `TTS_VOICE_SPEAKER_JSON` parsing (cached) and maps persona aliases to Coqui speaker IDs in `resolve_speaker()`, returning a 500 actionable error when a configured mapped speaker is not in the model inventory.
- Tempo routing uses `TTS_VOICE_ATEMPO_JSON` with fallback to `TTS_ATEMPO`, validates tempo range `0.5..2.0`, records `tempo_used` in `LAST_SYNTH_METRICS`, and exposes `tempo_used_last` and `effective_voice_alias_last` in `/debug/info`.
- Updated `docker-compose.yml` to include sane defaults for `TTS_VOICE_ATEMPO_JSON` and `TTS_VOICE_SPEAKER_JSON` and updated the TTS `README.md` to document the alias→speaker routing and failure behavior.

### Testing
- Compiled the modified backend file with `python -m py_compile ui/partner-hub/dev/ai-interview/services/tts/app.py` and it succeeded.
- Inspected diffs with `git diff` to verify frontend now sends `voice` alias and backend/compose/readme changes align with routing behavior.
- Changes were committed in a local branch (commit recorded) after the above validations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d061c1e5083309247201a7233d6f2)