### PR TITLE
Update default Peer Engineer TTS speaker to p340

### DIFF
--- a/ui/partner-hub/dev/ai-interview/docker-compose.yml
+++ b/ui/partner-hub/dev/ai-interview/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       TTS_MP3_BITRATE: ${TTS_MP3_BITRATE:-192k}
       TTS_ATEMPO: ${TTS_ATEMPO:-0.94}
       TTS_VOICE_ATEMPO_JSON: '${TTS_VOICE_ATEMPO_JSON:-{"se_leader":0.92,"peer_engineer":0.96,"sales_exec":0.90}}'
-      TTS_VOICE_SPEAKER_JSON: '${TTS_VOICE_SPEAKER_JSON:-{"se_leader":"p287","peer_engineer":"p314","sales_exec":"p259"}}'
+      TTS_VOICE_SPEAKER_JSON: '${TTS_VOICE_SPEAKER_JSON:-{"se_leader":"p287","peer_engineer":"p340","sales_exec":"p259"}}'
       TTS_SENTENCE_PAUSE_MS: ${TTS_SENTENCE_PAUSE_MS:-180}
       TTS_CLAUSE_PAUSE_MS: ${TTS_CLAUSE_PAUSE_MS:-90}
       TTS_VOICE_PAUSE_JSON: '${TTS_VOICE_PAUSE_JSON:-{"se_leader":{"sentence":220,"clause":110},"peer_engineer":{"sentence":170,"clause":90},"sales_exec":{"sentence":200,"clause":100}}}'


### PR DESCRIPTION
### Motivation
- Replace the Peer Engineer's default TTS speaker because `p314` is female and must not be used, while keeping `se_leader` as `p287` and `sales_exec` as `p259`.

### Description
- Update the default `TTS_VOICE_SPEAKER_JSON` in `ui/partner-hub/dev/ai-interview/docker-compose.yml` from `{"se_leader":"p287","peer_engineer":"p314","sales_exec":"p259"}` to `{"se_leader":"p287","peer_engineer":"p340","sales_exec":"p259"}`.

### Testing
- Confirmed the file content and that only the intended mapping changed using `nl -ba ui/partner-hub/dev/ai-interview/docker-compose.yml | sed -n '1,220p'` and a diff check showing the single-line mapping update, both succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d10ae5d30833082db663ef469a899)