### PR TITLE
feat(job-hunter): add Job Hunter shell routes + local storage

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/applications/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/applications/page.tsx
@@ -1,0 +1,17 @@
+import { EmptyState } from "@/components/job-hunter/EmptyState";
+
+export default function JobHunterApplicationsPage() {
+  return (
+    <main className="mx-auto max-w-5xl space-y-6 p-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Applications</h1>
+        <p className="text-sm text-foreground/70">Track your application pipeline.</p>
+      </header>
+
+      <EmptyState
+        title="No applications tracked yet"
+        description="Once jobs are saved and applications are created, this page will show status, timelines, and follow-ups."
+      />
+    </main>
+  );
+}

--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+
+import { EmptyState } from "@/components/job-hunter/EmptyState";
+import { JobList } from "@/components/job-hunter/JobList";
+import { Button } from "@/components/ui/button";
+import { loadJobHunterStore, saveJobHunterStore } from "@/lib/job-hunter/storage";
+import type { JobPosting } from "@/lib/job-hunter/types";
+
+const createManualJob = (): JobPosting => {
+  const timestamp = new Date().toISOString();
+
+  return {
+    id: crypto.randomUUID(),
+    title: "New saved job",
+    company: "Add company",
+    source: "manual",
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+};
+
+export default function JobHunterJobsPage() {
+  const [jobs, setJobs] = useState<JobPosting[]>(() => loadJobHunterStore().jobs);
+
+  const handleAddManualJob = () => {
+    const newJob = createManualJob();
+    const nextJobs = [newJob, ...jobs];
+
+    setJobs(nextJobs);
+    saveJobHunterStore({
+      ...loadJobHunterStore(),
+      jobs: nextJobs,
+    });
+  };
+
+  return (
+    <main className="mx-auto max-w-5xl space-y-6 p-6">
+      <header className="flex flex-wrap items-end justify-between gap-4">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold">Jobs</h1>
+          <p className="text-sm text-foreground/70">Saved jobs are stored locally in your browser.</p>
+        </div>
+        <Button onClick={handleAddManualJob} type="button">
+          Add job manually
+        </Button>
+      </header>
+
+      {jobs.length > 0 ? (
+        <JobList jobs={jobs} />
+      ) : (
+        <EmptyState
+          title="No saved jobs yet"
+          description="Start by adding a job manually. In the next phase, this page will support richer job details and import flows."
+          actionLabel="Add job manually"
+          onAction={handleAddManualJob}
+        />
+      )}
+    </main>
+  );
+}

--- a/ui/partner-hub/app/(routes)/job-hunter/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/page.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const sections = [
+  {
+    title: "Jobs",
+    description: "Track saved roles and opportunities in one place.",
+    href: "/job-hunter/jobs",
+  },
+  {
+    title: "Applications",
+    description: "Review application progress and next steps.",
+    href: "/job-hunter/applications",
+  },
+];
+
+export default function JobHunterPage() {
+  return (
+    <main className="mx-auto max-w-5xl space-y-6 p-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Job Hunter</h1>
+        <p className="text-sm text-foreground/70">Manage saved jobs and applications.</p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        {sections.map((section) => (
+          <Link key={section.href} href={section.href}>
+            <Card className="h-full hover:border-primary/40 hover:bg-muted/30">
+              <CardHeader>
+                <CardTitle>{section.title}</CardTitle>
+              </CardHeader>
+              <CardContent>{section.description}</CardContent>
+            </Card>
+          </Link>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/ui/partner-hub/components/job-hunter/EmptyState.tsx
+++ b/ui/partner-hub/components/job-hunter/EmptyState.tsx
@@ -1,0 +1,27 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type EmptyStateProps = {
+  title: string;
+  description: string;
+  actionLabel?: string;
+  onAction?: () => void;
+};
+
+export function EmptyState({ title, description, actionLabel, onAction }: EmptyStateProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p>{description}</p>
+        {actionLabel ? (
+          <Button onClick={onAction} type="button">
+            {actionLabel}
+          </Button>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui/partner-hub/components/job-hunter/JobList.tsx
+++ b/ui/partner-hub/components/job-hunter/JobList.tsx
@@ -1,0 +1,29 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { JobPosting } from "@/lib/job-hunter/types";
+
+type JobListProps = {
+  jobs: JobPosting[];
+};
+
+export function JobList({ jobs }: JobListProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Saved jobs</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="divide-y divide-border/60 rounded-lg border border-border/60">
+          {jobs.map((job) => (
+            <li key={job.id} className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="font-medium text-foreground">{job.title}</p>
+                <p className="text-xs text-foreground/70">{job.company}</p>
+              </div>
+              <div className="text-xs text-foreground/70">{job.location ?? "Remote / TBD"}</div>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui/partner-hub/components/left-nav.tsx
+++ b/ui/partner-hub/components/left-nav.tsx
@@ -19,6 +19,7 @@ export function LeftNav() {
     { name: "Home", href: "/" },
     { name: "Case Studies", href: "/case-studies" },
     { name: "Account Mapping", href: "/accountmap" },
+    { name: "Job Hunter", href: "/job-hunter" },
     ...toolLinks,
     { name: "Office Schedule", href: "/offices/schedule" },
     { name: "About / Contact", href: "/about" },

--- a/ui/partner-hub/lib/job-hunter/storage.ts
+++ b/ui/partner-hub/lib/job-hunter/storage.ts
@@ -1,0 +1,37 @@
+import type { JobHunterStore } from "./types";
+
+export const JOB_HUNTER_STORAGE_KEY = "partner-hub:job-hunter:v1";
+
+const DEFAULT_STORE: JobHunterStore = {
+  jobs: [],
+  applications: [],
+};
+
+export const loadJobHunterStore = (): JobHunterStore => {
+  if (typeof window === "undefined") {
+    return DEFAULT_STORE;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(JOB_HUNTER_STORAGE_KEY);
+    if (!raw) {
+      return DEFAULT_STORE;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<JobHunterStore>;
+    return {
+      jobs: Array.isArray(parsed.jobs) ? parsed.jobs : [],
+      applications: Array.isArray(parsed.applications) ? parsed.applications : [],
+    };
+  } catch {
+    return DEFAULT_STORE;
+  }
+};
+
+export const saveJobHunterStore = (store: JobHunterStore) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(JOB_HUNTER_STORAGE_KEY, JSON.stringify(store));
+};

--- a/ui/partner-hub/lib/job-hunter/types.ts
+++ b/ui/partner-hub/lib/job-hunter/types.ts
@@ -1,0 +1,38 @@
+export type JobSource = "manual" | "linkedin" | "company-site" | "referral" | "other";
+
+export type ApplicationStatus =
+  | "saved"
+  | "applied"
+  | "interviewing"
+  | "offer"
+  | "rejected"
+  | "withdrawn";
+
+export type JobPosting = {
+  id: string;
+  title: string;
+  company: string;
+  location?: string;
+  salaryRange?: string;
+  source: JobSource;
+  sourceUrl?: string;
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type Application = {
+  id: string;
+  jobId: string;
+  status: ApplicationStatus;
+  appliedAt?: string;
+  nextStepAt?: string;
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type JobHunterStore = {
+  jobs: JobPosting[];
+  applications: Application[];
+};


### PR DESCRIPTION
### Motivation

- Provide a lightweight "Job Hunter" area in the Partner Hub for saving jobs and tracking applications without external dependencies. 
- Enable local persistence so users can save jobs in-browser until richer import/sync flows are implemented.

### Description

- Added a new left-nav entry `Job Hunter` that links to `/job-hunter` while preserving existing navigation items in `ui/partner-hub/components/left-nav.tsx`.
- Introduced a new route group under `ui/partner-hub/app/(routes)/job-hunter/` with a dashboard page (`page.tsx`) linking to subpages, a `jobs` page (`jobs/page.tsx`) with a saved-jobs list and add button, and an `applications` page (`applications/page.tsx`) with an empty-state placeholder.
- Implemented a small Job Hunter data model in `ui/partner-hub/lib/job-hunter/types.ts` and local persistence helpers in `ui/partner-hub/lib/job-hunter/storage.ts` using the `partner-hub:job-hunter:v1` localStorage key.
- Added minimal, reusable UI components `EmptyState.tsx` and `JobList.tsx` under `ui/partner-hub/components/job-hunter/`, reusing the app's existing `Card` and `Button` patterns for consistent styling.

### Testing

- Ran `cd ui/partner-hub && npm install`, which completed successfully.
- Ran `cd ui/partner-hub && npm run lint`, which reported no ESLint warnings or errors.
- Ran `cd ui/partner-hub && npm run typecheck`, which completed with no TypeScript errors.
- Ran `cd ui/partner-hub && npm run test`, which executed the test suite and reported all tests passing (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9d1585114833096ebd92f44c0f2e8)