### PR TITLE
Add Job Hunter source settings and source-driven sync; remove server in-memory store

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx
@@ -41,8 +41,15 @@ export default function JobHunterJobsPage() {
     setIsSyncing(true);
 
     try {
+      const currentStore = loadJobHunterStore();
       const response = await fetch("/api/job-hunter/sync", {
         method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          sources: currentStore.sources,
+        }),
       });
       const payload = (await response.json()) as {
         error?: string;
@@ -58,7 +65,7 @@ export default function JobHunterJobsPage() {
       setLastSyncedAt(payload.lastSyncedAt);
 
       saveJobHunterStore({
-        ...loadJobHunterStore(),
+        ...currentStore,
         jobs: Object.values(payload.jobsById),
         jobsById: payload.jobsById,
         lastSyncedAt: payload.lastSyncedAt,

--- a/ui/partner-hub/app/(routes)/job-hunter/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/page.tsx
@@ -13,6 +13,11 @@ const sections = [
     description: "Review application progress and next steps.",
     href: "/job-hunter/applications",
   },
+  {
+    title: "Settings",
+    description: "Manage source boards for job syncing.",
+    href: "/job-hunter/settings",
+  },
 ];
 
 export default function JobHunterPage() {
@@ -23,7 +28,7 @@ export default function JobHunterPage() {
         <p className="text-sm text-foreground/70">Manage saved jobs and applications.</p>
       </header>
 
-      <section className="grid gap-4 md:grid-cols-2">
+      <section className="grid gap-4 md:grid-cols-3">
         {sections.map((section) => (
           <Link key={section.href} href={section.href}>
             <Card className="h-full hover:border-primary/40 hover:bg-muted/30">

--- a/ui/partner-hub/app/(routes)/job-hunter/settings/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/settings/page.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { loadJobHunterStore, saveJobHunterStore } from "@/lib/job-hunter/storage";
+import type { BoardType } from "@/lib/job-hunter/types";
+
+const DEFAULT_FORM = {
+  company: "",
+  boardType: "greenhouse" as BoardType,
+  boardToken: "",
+};
+
+export default function JobHunterSettingsPage() {
+  const [store, setStore] = useState(loadJobHunterStore());
+  const [form, setForm] = useState(DEFAULT_FORM);
+
+  const addSource = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!form.company.trim() || !form.boardToken.trim()) {
+      return;
+    }
+
+    const nextStore = {
+      ...store,
+      sources: [
+        ...store.sources,
+        {
+          company: form.company.trim(),
+          boardType: form.boardType,
+          boardToken: form.boardToken.trim(),
+        },
+      ],
+    };
+
+    saveJobHunterStore(nextStore);
+    setStore(nextStore);
+    setForm(DEFAULT_FORM);
+  };
+
+  const deleteSource = (index: number) => {
+    const nextStore = {
+      ...store,
+      sources: store.sources.filter((_, sourceIndex) => sourceIndex !== index),
+    };
+
+    saveJobHunterStore(nextStore);
+    setStore(nextStore);
+  };
+
+  return (
+    <main className="mx-auto max-w-5xl space-y-6 p-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Job Source Settings</h1>
+        <p className="text-sm text-foreground/70">Manage Greenhouse and Lever boards used by Sync Jobs.</p>
+      </header>
+
+      <section className="space-y-3 rounded-lg border border-border/60 p-4">
+        <h2 className="text-sm font-semibold">Configured Sources</h2>
+        {store.sources.length === 0 ? (
+          <p className="text-sm text-foreground/70">No sources configured yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {store.sources.map((source, index) => (
+              <li className="flex items-center justify-between rounded-md border border-border/60 p-3" key={`${source.boardType}-${source.boardToken}-${index}`}>
+                <p className="text-sm">
+                  <span className="font-medium">{source.company}</span> · {source.boardType} · {source.boardToken}
+                </p>
+                <Button onClick={() => deleteSource(index)} size="sm" type="button" variant="destructive">
+                  Delete
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="space-y-3 rounded-lg border border-border/60 p-4">
+        <h2 className="text-sm font-semibold">Add Source</h2>
+        <form className="grid gap-3 md:grid-cols-3" onSubmit={addSource}>
+          <input
+            className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
+            onChange={(event) => setForm((prev) => ({ ...prev, company: event.target.value }))}
+            placeholder="Company"
+            value={form.company}
+          />
+          <select
+            className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
+            onChange={(event) => setForm((prev) => ({ ...prev, boardType: event.target.value as BoardType }))}
+            value={form.boardType}
+          >
+            <option value="greenhouse">greenhouse</option>
+            <option value="lever">lever</option>
+          </select>
+          <input
+            className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
+            onChange={(event) => setForm((prev) => ({ ...prev, boardToken: event.target.value }))}
+            placeholder="Board token"
+            value={form.boardToken}
+          />
+          <div className="md:col-span-3">
+            <Button type="submit">Add source</Button>
+          </div>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/ui/partner-hub/app/api/job-hunter/sync/route.ts
+++ b/ui/partner-hub/app/api/job-hunter/sync/route.ts
@@ -1,23 +1,23 @@
 import { NextResponse } from "next/server";
 
+import { validateJobSources } from "@/lib/job-hunter/storage";
 import { runJobSync } from "@/lib/job-hunter/syncEngine";
-import { loadJobHunterStore, setServerJobHunterStore } from "@/lib/job-hunter/storage";
 
-export async function POST() {
-  const jobs = await runJobSync();
-  const store = loadJobHunterStore();
-  const nextStore = {
-    ...store,
-    jobs,
-    jobsById: Object.fromEntries(jobs.map((job) => [job.id, job])),
-    lastSyncedAt: new Date().toISOString(),
-  };
+export async function POST(request: Request) {
+  const payload = (await request.json().catch(() => null)) as { sources?: unknown } | null;
+  const sources = validateJobSources(payload?.sources);
 
-  setServerJobHunterStore(nextStore);
+  if (!Array.isArray(payload?.sources) || sources.length !== payload.sources.length) {
+    return NextResponse.json({ error: "Invalid sources payload." }, { status: 400 });
+  }
+
+  const jobs = await runJobSync(sources);
+  const jobsById = Object.fromEntries(jobs.map((job) => [job.id, job]));
+  const lastSyncedAt = new Date().toISOString();
 
   return NextResponse.json({
-    jobs: nextStore.jobs,
-    jobsById: nextStore.jobsById,
-    lastSyncedAt: nextStore.lastSyncedAt,
+    jobs,
+    jobsById,
+    lastSyncedAt,
   });
 }

--- a/ui/partner-hub/lib/job-hunter/storage.test.ts
+++ b/ui/partner-hub/lib/job-hunter/storage.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { JOB_HUNTER_STORAGE_KEY, loadJobHunterStore } from "./storage";
+import { JOB_HUNTER_STORAGE_KEY, isValidJobSourceConfig, loadJobHunterStore, saveJobHunterStore, validateJobSources } from "./storage";
 
 class MemoryStorage {
   private store = new Map<string, string>();
@@ -46,6 +46,43 @@ describe("job hunter storage", () => {
 
     assert.ok(loaded.applicationsById["job-1"]);
     assert.equal(loaded.applications.length, 1);
+
+    Object.defineProperty(globalThis, "window", {
+      value: previousWindow,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it("validates source payloads", () => {
+    assert.equal(isValidJobSourceConfig({ company: "Acme", boardType: "greenhouse", boardToken: "acme" }), true);
+    assert.equal(isValidJobSourceConfig({ company: "", boardType: "greenhouse", boardToken: "acme" }), false);
+    assert.equal(isValidJobSourceConfig({ company: "Acme", boardType: "invalid", boardToken: "acme" }), false);
+    assert.deepEqual(validateJobSources([{ company: " Acme ", boardType: "lever", boardToken: " acme " }, { nope: true }]), [
+      { company: "Acme", boardType: "lever", boardToken: "acme" },
+    ]);
+  });
+
+  it("round-trips sources through local storage", () => {
+    const storage = new MemoryStorage();
+    const previousWindow = globalThis.window;
+    Object.defineProperty(globalThis, "window", {
+      value: { localStorage: storage },
+      configurable: true,
+      writable: true,
+    });
+
+    saveJobHunterStore({
+      jobs: [],
+      jobsById: {},
+      applications: [],
+      applicationsById: {},
+      sources: [{ company: "Acme", boardType: "greenhouse", boardToken: "acme" }],
+    });
+
+    const loaded = loadJobHunterStore();
+    assert.equal(loaded.sources.length, 1);
+    assert.deepEqual(loaded.sources[0], { company: "Acme", boardType: "greenhouse", boardToken: "acme" });
 
     Object.defineProperty(globalThis, "window", {
       value: previousWindow,

--- a/ui/partner-hub/lib/job-hunter/storage.ts
+++ b/ui/partner-hub/lib/job-hunter/storage.ts
@@ -1,4 +1,4 @@
-import type { Application, JobHunterStore } from "./types";
+import type { Application, BoardType, JobHunterStore, JobSourceConfig } from "./types";
 
 export const JOB_HUNTER_STORAGE_KEY = "partner-hub:job-hunter:v1";
 
@@ -10,7 +10,7 @@ const DEFAULT_STORE: JobHunterStore = {
   applicationsById: {},
 };
 
-let serverStore: JobHunterStore = DEFAULT_STORE;
+const BOARD_TYPES: BoardType[] = ["greenhouse", "lever"];
 
 const toApplicationsById = (applications: Application[]) =>
   applications.reduce<Record<string, Application>>((acc, application) => {
@@ -18,9 +18,39 @@ const toApplicationsById = (applications: Application[]) =>
     return acc;
   }, {});
 
+export const isValidJobSourceConfig = (value: unknown): value is JobSourceConfig => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const source = value as Partial<JobSourceConfig>;
+  return (
+    typeof source.company === "string" &&
+    source.company.trim().length > 0 &&
+    typeof source.boardToken === "string" &&
+    source.boardToken.trim().length > 0 &&
+    typeof source.boardType === "string" &&
+    BOARD_TYPES.includes(source.boardType as BoardType)
+  );
+};
+
+export const validateJobSources = (value: unknown): JobSourceConfig[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((source): source is JobSourceConfig => isValidJobSourceConfig(source))
+    .map((source) => ({
+      company: source.company.trim(),
+      boardType: source.boardType,
+      boardToken: source.boardToken.trim(),
+    }));
+};
+
 export const loadJobHunterStore = (): JobHunterStore => {
   if (typeof window === "undefined") {
-    return serverStore;
+    return DEFAULT_STORE;
   }
 
   try {
@@ -47,7 +77,7 @@ export const loadJobHunterStore = (): JobHunterStore => {
     return {
       jobs,
       jobsById,
-      sources: Array.isArray(parsed.sources) ? parsed.sources : [],
+      sources: validateJobSources(parsed.sources),
       lastSyncedAt: typeof parsed.lastSyncedAt === "string" ? parsed.lastSyncedAt : undefined,
       applications,
       applicationsById,
@@ -55,10 +85,6 @@ export const loadJobHunterStore = (): JobHunterStore => {
   } catch {
     return DEFAULT_STORE;
   }
-};
-
-export const setServerJobHunterStore = (store: JobHunterStore) => {
-  serverStore = store;
 };
 
 export const saveJobHunterStore = (store: JobHunterStore) => {

--- a/ui/partner-hub/lib/job-hunter/syncEngine.test.ts
+++ b/ui/partner-hub/lib/job-hunter/syncEngine.test.ts
@@ -1,42 +1,11 @@
 import * as assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { JOB_HUNTER_STORAGE_KEY } from "./storage";
 import { __private__, runJobSync } from "./syncEngine";
-
-class MemoryStorage {
-  private store = new Map<string, string>();
-
-  getItem(key: string) {
-    return this.store.get(key) ?? null;
-  }
-
-  setItem(key: string, value: string) {
-    this.store.set(key, value);
-  }
-}
 
 describe("job hunter sync engine", () => {
   it("runs board adapters and syncs jobs", async () => {
-    const storage = new MemoryStorage();
-    storage.setItem(
-      JOB_HUNTER_STORAGE_KEY,
-      JSON.stringify({
-        sources: [
-          { company: "Acme", boardType: "greenhouse", boardToken: "acme-gh" },
-          { company: "Acme", boardType: "lever", boardToken: "acme-lever" },
-        ],
-      }),
-    );
-
-    const previousWindow = globalThis.window;
     const previousFetch = globalThis.fetch;
-
-    Object.defineProperty(globalThis, "window", {
-      value: { localStorage: storage },
-      configurable: true,
-      writable: true,
-    });
 
     const called: string[] = [];
     globalThis.fetch = (async (input: URL | RequestInfo) => {
@@ -54,24 +23,20 @@ describe("job hunter sync engine", () => {
 
       return {
         ok: true,
-        json: async () => [
-          { id: "abc", text: " PM ", hostedUrl: "https://lever/job/abc", categories: { location: "NYC" } },
-        ],
+        json: async () => [{ id: "abc", text: " PM ", hostedUrl: "https://lever/job/abc", categories: { location: "NYC" } }],
       } as Response;
     }) as typeof fetch;
 
-    const jobs = await runJobSync();
+    const jobs = await runJobSync([
+      { company: "Acme", boardType: "greenhouse", boardToken: "acme-gh" },
+      { company: "Acme", boardType: "lever", boardToken: "acme-lever" },
+    ]);
 
     assert.equal(called.length, 2);
     assert.ok(called.some((url) => url.includes("boards-api.greenhouse.io/v1/boards/acme-gh/jobs")));
     assert.ok(called.some((url) => url.includes("api.lever.co/v0/postings/acme-lever")));
     assert.equal(jobs.length, 2);
 
-    Object.defineProperty(globalThis, "window", {
-      value: previousWindow,
-      configurable: true,
-      writable: true,
-    });
     globalThis.fetch = previousFetch;
   });
 

--- a/ui/partner-hub/lib/job-hunter/syncEngine.ts
+++ b/ui/partner-hub/lib/job-hunter/syncEngine.ts
@@ -1,8 +1,7 @@
 import { normalizeJobPosting } from "./normalize";
-import { loadJobHunterStore } from "./storage";
 import { fetchGreenhouseJobs } from "./sources/greenhouse";
 import { fetchLeverJobs } from "./sources/lever";
-import type { JobPosting } from "./types";
+import type { JobPosting, JobSourceConfig } from "./types";
 
 const normalizeJobs = (jobs: JobPosting[]) => {
   const merged = new Map<string, JobPosting>();
@@ -40,12 +39,10 @@ const normalizeJobs = (jobs: JobPosting[]) => {
   });
 };
 
-export const runJobSync = async () => {
-  const store = loadJobHunterStore();
-
+export const runJobSync = async (sources: JobSourceConfig[]) => {
   const jobs: JobPosting[] = [];
 
-  for (const source of store.sources) {
+  for (const source of sources) {
     if (source.boardType === "greenhouse") {
       const results = await fetchGreenhouseJobs(source);
       jobs.push(...results);


### PR DESCRIPTION
### Motivation
- Provide a proper UI flow to manage Job Hunter sources (list/add/delete) persisted in client localStorage instead of relying on a server in-memory store.
- Make the sync engine reusable and driven by explicit source configs so syncing can run with arbitrary source sets.
- Validate incoming source payloads at hydration and API boundaries to avoid malformed sync requests.

### Description
- Added a new settings page `ui/partner-hub/app/(routes)/job-hunter/settings/page.tsx` with UI to list configured sources, add new sources (`company`, `boardType`, `boardToken`), and delete sources, persisting via `saveJobHunterStore()`.
- Updated Job Hunter hub to include a `Settings` card at `ui/partner-hub/app/(routes)/job-hunter/page.tsx` for discoverability.
- Modified Jobs page (`ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx`) to POST the saved local `sources` to the sync API when `Sync Jobs` is clicked.
- Removed server in-memory `serverStore` and `setServerJobHunterStore()` from `ui/partner-hub/lib/job-hunter/storage.ts` and made server-side `load` return `DEFAULT_STORE` when `window` is undefined.
- Added source validation helpers `isValidJobSourceConfig` and `validateJobSources` in `ui/partner-hub/lib/job-hunter/storage.ts` and used them to sanitize stored/hydrated sources.
- Refactored the sync engine to `runJobSync(sources: JobSourceConfig[])` (from reading store internally) while preserving existing normalization, dedupe, and sorting via the existing `normalizeJobs` pipeline in `ui/partner-hub/lib/job-hunter/syncEngine.ts`.
- Updated the API route `ui/partner-hub/app/api/job-hunter/sync/route.ts` to accept a POST body of shape `{ sources: JobSourceConfig[] }`, validate the payload with `validateJobSources`, and run `runJobSync(sources)` returning `{ jobs, jobsById, lastSyncedAt }` or a 400 on invalid payload.
- Added/updated tests: `ui/partner-hub/lib/job-hunter/storage.test.ts` (source validation and storage round-trip) and `ui/partner-hub/lib/job-hunter/syncEngine.test.ts` (sync engine behavior when passed sources), and adjusted tests to call the new `runJobSync` signature.

### Testing
- Ran `cd ui/partner-hub && npm run lint`, which completed with no ESLint errors.
- Ran `cd ui/partner-hub && npm run typecheck`, which completed with no TypeScript errors.
- Ran `cd ui/partner-hub && npm run test`, which executed the test suite and completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aed822306c8330917d17a3d19df093)