### PR TITLE
Harden Job Hunter source settings and sync validation UX

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx
@@ -38,10 +38,16 @@ export default function JobHunterJobsPage() {
 
   const handleSync = async () => {
     setError(null);
+
+    const currentStore = loadJobHunterStore();
+    if (currentStore.sources.length === 0) {
+      setError("Add at least one job source in Settings before syncing.");
+      return;
+    }
+
     setIsSyncing(true);
 
     try {
-      const currentStore = loadJobHunterStore();
       const response = await fetch("/api/job-hunter/sync", {
         method: "POST",
         headers: {

--- a/ui/partner-hub/app/(routes)/job-hunter/settings/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/settings/page.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { loadJobHunterStore, saveJobHunterStore } from "@/lib/job-hunter/storage";
+import { getSourceValidationMessage, truncateBoardToken } from "@/lib/job-hunter/sourceSettings";
 import type { BoardType } from "@/lib/job-hunter/types";
 
 const DEFAULT_FORM = {
@@ -15,11 +16,18 @@ const DEFAULT_FORM = {
 export default function JobHunterSettingsPage() {
   const [store, setStore] = useState(loadJobHunterStore());
   const [form, setForm] = useState(DEFAULT_FORM);
+  const [validationMessage, setValidationMessage] = useState<string | null>(null);
+
 
   const addSource = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (!form.company.trim() || !form.boardToken.trim()) {
+    const company = form.company.trim();
+    const boardToken = form.boardToken.trim();
+
+    const message = getSourceValidationMessage(form, store.sources);
+    if (message) {
+      setValidationMessage(message);
       return;
     }
 
@@ -28,9 +36,9 @@ export default function JobHunterSettingsPage() {
       sources: [
         ...store.sources,
         {
-          company: form.company.trim(),
+          company,
           boardType: form.boardType,
-          boardToken: form.boardToken.trim(),
+          boardToken,
         },
       ],
     };
@@ -38,6 +46,7 @@ export default function JobHunterSettingsPage() {
     saveJobHunterStore(nextStore);
     setStore(nextStore);
     setForm(DEFAULT_FORM);
+    setValidationMessage(null);
   };
 
   const deleteSource = (index: number) => {
@@ -66,7 +75,7 @@ export default function JobHunterSettingsPage() {
             {store.sources.map((source, index) => (
               <li className="flex items-center justify-between rounded-md border border-border/60 p-3" key={`${source.boardType}-${source.boardToken}-${index}`}>
                 <p className="text-sm">
-                  <span className="font-medium">{source.company}</span> · {source.boardType} · {source.boardToken}
+                  <span className="font-medium">{source.company}</span> · {source.boardType} · {truncateBoardToken(source.boardToken)}
                 </p>
                 <Button onClick={() => deleteSource(index)} size="sm" type="button" variant="destructive">
                   Delete
@@ -102,6 +111,7 @@ export default function JobHunterSettingsPage() {
           />
           <div className="md:col-span-3">
             <Button type="submit">Add source</Button>
+            {validationMessage ? <p className="mt-2 text-sm text-red-600">{validationMessage}</p> : null}
           </div>
         </form>
       </section>

--- a/ui/partner-hub/app/api/job-hunter/sync/route.ts
+++ b/ui/partner-hub/app/api/job-hunter/sync/route.ts
@@ -8,7 +8,7 @@ export async function POST(request: Request) {
   const sources = validateJobSources(payload?.sources);
 
   if (!Array.isArray(payload?.sources) || sources.length !== payload.sources.length) {
-    return NextResponse.json({ error: "Invalid sources payload." }, { status: 400 });
+    return NextResponse.json({ error: "Invalid sources payload: one or more source entries are invalid." }, { status: 400 });
   }
 
   const jobs = await runJobSync(sources);

--- a/ui/partner-hub/lib/job-hunter/sourceSettings.ts
+++ b/ui/partner-hub/lib/job-hunter/sourceSettings.ts
@@ -1,0 +1,31 @@
+import type { BoardType, JobSourceConfig } from "./types";
+
+export type SourceForm = {
+  company: string;
+  boardType: BoardType;
+  boardToken: string;
+};
+
+export const truncateBoardToken = (token: string) => {
+  if (token.length <= 10) {
+    return token;
+  }
+
+  return `${token.slice(0, 4)}...${token.slice(-4)}`;
+};
+
+export const getSourceValidationMessage = (form: SourceForm, sources: JobSourceConfig[]) => {
+  const company = form.company.trim();
+  const boardToken = form.boardToken.trim();
+
+  if (!company || !boardToken) {
+    return "Company and board token are required.";
+  }
+
+  const isDuplicate = sources.some((source) => source.boardType === form.boardType && source.boardToken === boardToken);
+  if (isDuplicate) {
+    return "That source already exists.";
+  }
+
+  return null;
+};

--- a/ui/partner-hub/lib/job-hunter/storage.test.ts
+++ b/ui/partner-hub/lib/job-hunter/storage.test.ts
@@ -2,6 +2,7 @@ import * as assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { JOB_HUNTER_STORAGE_KEY, isValidJobSourceConfig, loadJobHunterStore, saveJobHunterStore, validateJobSources } from "./storage";
+import { getSourceValidationMessage, truncateBoardToken } from "./sourceSettings";
 
 class MemoryStorage {
   private store = new Map<string, string>();
@@ -89,5 +90,31 @@ describe("job hunter storage", () => {
       configurable: true,
       writable: true,
     });
+  });
+
+  it("returns an empty source list for non-array payloads", () => {
+    assert.deepEqual(validateJobSources(null), []);
+    assert.deepEqual(validateJobSources({ company: "Acme" }), []);
+  });
+
+  it("supports settings helper validation and token display", () => {
+    assert.equal(truncateBoardToken("abcdefghijklmno"), "abcd...lmno");
+    assert.equal(truncateBoardToken("short"), "short");
+
+    assert.equal(
+      getSourceValidationMessage(
+        { company: " ", boardType: "greenhouse", boardToken: "token" },
+        [{ company: "Acme", boardType: "greenhouse", boardToken: "token" }],
+      ),
+      "Company and board token are required.",
+    );
+
+    assert.equal(
+      getSourceValidationMessage(
+        { company: "Acme", boardType: "greenhouse", boardToken: " token " },
+        [{ company: "Acme", boardType: "greenhouse", boardToken: "token" }],
+      ),
+      "That source already exists.",
+    );
   });
 });


### PR DESCRIPTION
### Motivation
- Improve safety and UX when adding job board sources by validating required fields and preventing duplicate `(boardType, boardToken)` entries.
- Make configured board tokens less sensitive in the UI by showing a truncated form.
- Prevent confusing sync runs when no sources are configured and make API error text clearer when source entries are invalid.

### Description
- Added client-side validation and inline feedback in `settings/page.tsx`, blocking adds when `company` or `boardToken` are blank or when a duplicate `(boardType, boardToken)` exists, and clearing the validation message after a successful add while keeping persistence in `saveJobHunterStore()` only. 
- Display configured board tokens in truncated form via a new helper and use it in the configured source list to shorten long tokens. 
- Extracted reusable helpers to `lib/job-hunter/sourceSettings.ts` including `truncateBoardToken` and `getSourceValidationMessage` and wired the settings page to use them. 
- Added a pre-sync guard in `jobs/page.tsx` to show a friendly error when no sources are configured while preserving existing sync behavior otherwise. 
- Improved the sync API error message in `app/api/job-hunter/sync/route.ts` to `"Invalid sources payload: one or more source entries are invalid."` while preserving validation logic. 
- Extended `lib/job-hunter/storage.test.ts` to cover non-array `validateJobSources` behavior and to test the new settings helpers.

### Testing
- Ran `cd ui/partner-hub && npm run lint` and it completed with no ESLint warnings or errors. 
- Ran `cd ui/partner-hub && npm run typecheck` and it completed successfully with no type errors. 
- Ran `cd ui/partner-hub && npm run test` and all tests passed (`# pass 53`, `# fail 0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aedb4deb088330991eab3fe3fbad2b)