### PR TITLE
Use applyPacket content when rendering Job Hunter Apply tab

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
@@ -169,16 +169,9 @@ export default function JobDetailPage({ params }: PageProps) {
               <Button onClick={() => copyText(applyPacket.screenerAnswersText)} size="sm" type="button" variant="secondary">Copy Screener Answers</Button>
             </div>
             <p className="font-medium">Cover-letter draft</p>
-            <pre className="whitespace-pre-wrap rounded-md bg-muted/50 p-3">{tailoringPacket.coverLetterDraft}</pre>
+            <pre className="whitespace-pre-wrap rounded-md bg-muted/50 p-3">{applyPacket.coverLetterMarkdown}</pre>
             <p className="font-medium">Common screener answers</p>
-            <ul className="space-y-2">
-              {tailoringPacket.screenerAnswers.map((item) => (
-                <li key={item.question}>
-                  <p className="font-medium">{item.question}</p>
-                  <p>{item.answer}</p>
-                </li>
-              ))}
-            </ul>
+            <pre className="whitespace-pre-wrap rounded-md bg-muted/50 p-3">{applyPacket.screenerAnswersText}</pre>
           </CardContent>
         </Card>
       ) : null}


### PR DESCRIPTION
### Motivation
- Ensure the Apply tab displays the exact content that is exported/copied by using the normalized fields from the generated apply packet so the UI matches the Apply Packet artifact.

### Description
- Replace rendering of `tailoringPacket.coverLetterDraft` and the mapped `tailoringPacket.screenerAnswers` with `applyPacket.coverLetterMarkdown` and `applyPacket.screenerAnswersText` (rendered in the existing `<pre>` block) in `ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx`, leaving packet generation, packet structure, clipboard buttons, and tests unchanged.

### Testing
- Ran `cd ui/partner-hub && npm run lint`, `cd ui/partner-hub && npm run typecheck`, and `cd ui/partner-hub && npm run test`, and all commands completed successfully (no lint errors, no typecheck errors, and test suite passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee391ed8483309fed2d19d270be57)