### PR TITLE
Add Apply Packet markdown preview panel in Job Hunter Apply tab

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
@@ -168,6 +168,8 @@ export default function JobDetailPage({ params }: PageProps) {
               <Button onClick={() => copyText(applyPacket.coverLetterMarkdown)} size="sm" type="button" variant="secondary">Copy Cover Letter</Button>
               <Button onClick={() => copyText(applyPacket.screenerAnswersText)} size="sm" type="button" variant="secondary">Copy Screener Answers</Button>
             </div>
+            <p className="font-medium">Apply Packet Preview</p>
+            <pre className="whitespace-pre-wrap rounded-md bg-muted/50 p-3 text-xs">{applyPacket.fullPacketMarkdown}</pre>
             <p className="font-medium">Cover-letter draft</p>
             <pre className="whitespace-pre-wrap rounded-md bg-muted/50 p-3">{applyPacket.coverLetterMarkdown}</pre>
             <p className="font-medium">Common screener answers</p>


### PR DESCRIPTION
### Motivation
- Allow users to review the full generated Apply Packet markdown in the Apply tab before copying or downloading it.

### Description
- Append an "Apply Packet Preview" heading and a styled `<pre>` block rendering `applyPacket.fullPacketMarkdown` using the existing code-like style (`whitespace-pre-wrap rounded-md bg-muted/50 p-3 text-xs`) and keep it gated by the existing `activeTab === "Apply" && tailoringPacket && applyPacket` condition; no packet generation, download, copy logic, or tests were changed.

### Testing
- Ran `cd ui/partner-hub && npm run lint` which passed with no ESLint errors; `cd ui/partner-hub && npm run typecheck` which completed successfully; and `cd ui/partner-hub && npm run test` where all tests passed (60 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee546e30c83309a84cde3fd0e26bf)