### PR TITLE
Align Job Hunter scoring and tailoring with preferences

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { masterResume } from "@/lib/job-hunter/resume/masterResume";
 import { buildApplyPacket } from "@/lib/job-hunter/applyPacket";
 import { generateTailoringPacket } from "@/lib/job-hunter/resume/tailor";
+import { normalizePreferences } from "@/lib/job-hunter/preferences";
 import { scoreJobFit } from "@/lib/job-hunter/scoring";
 import { loadJobHunterStore } from "@/lib/job-hunter/storage";
 
@@ -25,11 +26,12 @@ export default function JobDetailPage({ params }: PageProps) {
   const decodedJobId = decodeURIComponent(params.jobId);
   const store = loadJobHunterStore();
   const job = store.jobsById[decodedJobId];
+  const preferences = normalizePreferences(store.preferences);
   const [activeTab, setActiveTab] = useState<Tab>("Overview");
-  const fit = useMemo(() => (job ? scoreJobFit(job) : null), [job]);
+  const fit = useMemo(() => (job ? scoreJobFit(job, preferences) : null), [job, preferences]);
   const tailoringPacket = useMemo(
-    () => (job ? generateTailoringPacket(job, store.resumeProfile ?? masterResume) : null),
-    [job, store.resumeProfile],
+    () => (job ? generateTailoringPacket(job, store.resumeProfile ?? masterResume, preferences) : null),
+    [job, preferences, store.resumeProfile],
   );
   const applyPacket = useMemo(
     () => (job && tailoringPacket ? buildApplyPacket(job, tailoringPacket) : null),

--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx
@@ -33,14 +33,21 @@ export default function JobHunterJobsPage() {
   const [minDate, setMinDate] = useState("");
 
   const jobs = useMemo(() => Object.values(jobsById), [jobsById]);
+  const activePreferences = useMemo(
+    () => ({
+      ...preferences,
+      remoteOnly,
+    }),
+    [preferences, remoteOnly],
+  );
 
   const filteredJobs = useMemo<FilteredJob[]>(() => {
     const query = search.trim().toLowerCase();
 
     return jobs
       .map((job) => {
-        const fit = scoreJobFit(job, preferences);
-        const exclusion = jobMatchesPreferences(job, preferences);
+        const fit = scoreJobFit(job, activePreferences);
+        const exclusion = jobMatchesPreferences(job, activePreferences);
 
         return {
           job,
@@ -54,13 +61,13 @@ export default function JobHunterJobsPage() {
           query.length === 0 ||
           job.title.toLowerCase().includes(query) ||
           job.company.toLowerCase().includes(query);
-        const matchesRemote = !remoteOnly || job.isRemote === true;
-        const matchesScore = score >= Math.max(0, Math.min(100, minScore));
+        const minScoreThreshold = Math.max(0, Math.min(100, minScore));
+        const matchesScore = excluded && !hideExcluded ? true : score >= minScoreThreshold;
         const jobDate = (job.postedAt ?? job.updatedAt).slice(0, 10);
         const matchesDate = !minDate || jobDate >= minDate;
         const passesExcluded = !hideExcluded || !excluded;
 
-        return matchesQuery && matchesRemote && matchesScore && matchesDate && passesExcluded;
+        return matchesQuery && matchesScore && matchesDate && passesExcluded;
       })
       .sort((a, b) => {
         if (b.score !== a.score) {
@@ -69,7 +76,7 @@ export default function JobHunterJobsPage() {
 
         return b.job.updatedAt.localeCompare(a.job.updatedAt);
       });
-  }, [hideExcluded, jobs, minDate, minScore, preferences, remoteOnly, search]);
+  }, [activePreferences, hideExcluded, jobs, minDate, minScore, search]);
 
   const excludedVisible = filteredJobs.filter((item) => item.excluded).length;
 

--- a/ui/partner-hub/lib/job-hunter/resume/tailor.test.ts
+++ b/ui/partner-hub/lib/job-hunter/resume/tailor.test.ts
@@ -29,6 +29,33 @@ describe("generateTailoringPacket", () => {
     assert.ok(packet.markdown.includes("## Cover Letter Draft"));
   });
 
+
+  it("uses preferences when calculating fit", () => {
+    const job: JobPosting = {
+      id: "pref:789",
+      title: "Solutions Architect",
+      company: "Nimbus Data",
+      source: "company-site",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-02T00:00:00.000Z",
+    };
+
+    const withoutPreferences = generateTailoringPacket(job, masterResume);
+    const withExclusion = generateTailoringPacket(job, masterResume, {
+      targetRoles: [],
+      targetKeywords: [],
+      targetLocations: [],
+      remoteOnly: false,
+      excludedCompanies: ["Nimbus"],
+      excludedTitles: [],
+      minimumScore: 0,
+    });
+
+    assert.notEqual(withoutPreferences.fit.score, 0);
+    assert.equal(withExclusion.fit.score, 0);
+    assert.ok(withExclusion.fit.preferenceSignals.includes("Excluded company match"));
+  });
+
   it("supports resume profile input", () => {
     const job: JobPosting = {
       id: "greenhouse:456",

--- a/ui/partner-hub/lib/job-hunter/resume/tailor.ts
+++ b/ui/partner-hub/lib/job-hunter/resume/tailor.ts
@@ -1,6 +1,6 @@
 import { scoreJobFit } from "../scoring";
 import { normalizeResumeProfile } from "../resumeProfile";
-import type { JobPosting, ResumeProfile } from "../types";
+import type { JobHunterPreferences, JobPosting, ResumeProfile } from "../types";
 import type { MasterResume } from "./masterResume";
 
 export type TailoringPacket = {
@@ -60,9 +60,13 @@ const buildCoverLetter = (resume: TailoringResume, job: JobPosting, matchedKeywo
   ].join("\n");
 };
 
-export const generateTailoringPacket = (job: JobPosting, resume: MasterResume | ResumeProfile): TailoringPacket => {
+export const generateTailoringPacket = (
+  job: JobPosting,
+  resume: MasterResume | ResumeProfile,
+  preferences?: JobHunterPreferences,
+): TailoringPacket => {
   const tailoringResume = toTailoringResume(resume);
-  const fit = scoreJobFit(job);
+  const fit = scoreJobFit(job, preferences);
   const matchedKeywords = fit.matched.map((item) => item.keyword);
   const missingKeywords = fit.missing.map((item) => item.keyword);
 

--- a/ui/partner-hub/lib/job-hunter/storage.test.ts
+++ b/ui/partner-hub/lib/job-hunter/storage.test.ts
@@ -1,6 +1,7 @@
 import * as assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import { getDefaultPreferences } from "./preferences";
 import { JOB_HUNTER_STORAGE_KEY, isValidJobSourceConfig, loadJobHunterStore, saveJobHunterStore, validateJobSources } from "./storage";
 import { getSourceValidationMessage, truncateBoardToken } from "./sourceSettings";
 
@@ -98,6 +99,82 @@ describe("job hunter storage", () => {
       writable: true,
     });
   });
+
+
+  it("round-trips normalized preferences through local storage", () => {
+    const storage = new MemoryStorage();
+    const previousWindow = globalThis.window;
+    Object.defineProperty(globalThis, "window", {
+      value: { localStorage: storage },
+      configurable: true,
+      writable: true,
+    });
+
+    saveJobHunterStore({
+      jobs: [],
+      jobsById: {},
+      applications: [],
+      applicationsById: {},
+      sources: [],
+      preferences: {
+        targetRoles: ["  Solutions Architect  ", ""],
+        targetKeywords: ["AWS"],
+        targetLocations: [" Remote "],
+        remoteOnly: true,
+        excludedCompanies: ["  BadCo "],
+        excludedTitles: [" Senior Manager "],
+        minimumScore: 120,
+      },
+    });
+
+    const loaded = loadJobHunterStore();
+    assert.deepEqual(loaded.preferences, {
+      targetRoles: ["Solutions Architect"],
+      targetKeywords: ["AWS"],
+      targetLocations: ["Remote"],
+      remoteOnly: true,
+      excludedCompanies: ["BadCo"],
+      excludedTitles: ["Senior Manager"],
+      minimumScore: 100,
+    });
+
+    Object.defineProperty(globalThis, "window", {
+      value: previousWindow,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it("hydrates default preferences when missing from stored payload", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      JOB_HUNTER_STORAGE_KEY,
+      JSON.stringify({
+        jobsById: {},
+        jobs: [],
+        sources: [],
+        applications: [],
+        applicationsById: {},
+      }),
+    );
+
+    const previousWindow = globalThis.window;
+    Object.defineProperty(globalThis, "window", {
+      value: { localStorage: storage },
+      configurable: true,
+      writable: true,
+    });
+
+    const loaded = loadJobHunterStore();
+    assert.deepEqual(loaded.preferences, getDefaultPreferences());
+
+    Object.defineProperty(globalThis, "window", {
+      value: previousWindow,
+      configurable: true,
+      writable: true,
+    });
+  });
+
 
   it("returns an empty source list for non-array payloads", () => {
     assert.deepEqual(validateJobSources(null), []);


### PR DESCRIPTION
### Motivation
- Eliminate consistency gaps introduced by the targeting-preferences change so Jobs list, Job Detail Fit tab, Tailor, and Apply use the same preference inputs for scoring and exclusion.
- Ensure page-level controls behave as intended by keeping `minimumScore` a page-only filter and allowing users to reveal excluded jobs regardless of the min-score filter.

### Description
- Create a derived `activePreferences` on the Jobs page (normalized saved preferences overridden by page `remoteOnly`) and use it for both `scoreJobFit(job, ...)` and `jobMatchesPreferences(job, ...)` to unify list scoring/exclusion behavior.
- Change Jobs page filtering so `minimumScore` remains page-local and excluded jobs remain visible when `hideExcluded === false` even if their score is 0, while non-excluded jobs continue to respect the min-score threshold.
- Load and normalize stored preferences in Job Detail and pass them into both `scoreJobFit(job, preferences)` (Fit tab) and `generateTailoringPacket(job, resume, preferences)` so Fit/Tailor/Apply use identical preference inputs.
- Extend `generateTailoringPacket` to accept an optional `JobHunterPreferences` argument and use it for fit computation while preserving backward compatibility for callers that omit preferences.
- Add tests and update existing tests: `ui/partner-hub/lib/job-hunter/resume/tailor.test.ts` gains a deterministic case proving preferences affect tailoring fit; `ui/partner-hub/lib/job-hunter/storage.test.ts` gains round-trip normalization and default-hydration coverage; changed files: `ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx`, `ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx`, `ui/partner-hub/lib/job-hunter/resume/tailor.ts`, `ui/partner-hub/lib/job-hunter/resume/tailor.test.ts`, `ui/partner-hub/lib/job-hunter/storage.test.ts`.

### Testing
- Ran `cd ui/partner-hub && npm run lint` which reported `✔ No ESLint warnings or errors`.
- Ran `cd ui/partner-hub && npm run typecheck` which completed (`tsc --noEmit`) with no type errors.
- Ran `cd ui/partner-hub && npm run test` which completed with all tests passing (`# pass 74`, `# fail 0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af4484352c8330be54fdbd678f22e9)