### PR TITLE
Add guided apply workflow and submission tracking to Job Hunter

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/applications/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/applications/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -9,7 +10,9 @@ import {
   applicationReducer,
   buildAnswerPack,
   buildFollowUpEmail,
+  createApplicationFromJob,
   exportApplicationsCsv,
+  resolveApplicationJobDetails,
 } from "@/lib/job-hunter/applications";
 import { loadJobHunterStore, saveJobHunterStore } from "@/lib/job-hunter/storage";
 import type { ApplicationStatus, JobPosting } from "@/lib/job-hunter/types";
@@ -27,13 +30,7 @@ export default function JobHunterApplicationsPage() {
 
     Object.values(jobsById).forEach((job) => {
       if (!seeded[job.id]) {
-        seeded[job.id] = {
-          id: job.id,
-          jobId: job.id,
-          status: "prepared",
-          createdAt: now,
-          updatedAt: now,
-        };
+        seeded[job.id] = createApplicationFromJob(job, now);
       }
     });
 
@@ -55,7 +52,12 @@ export default function JobHunterApplicationsPage() {
   };
 
   const setStatus = (jobId: string, status: ApplicationStatus) => {
-    save(applicationReducer(applicationsById, { type: "setStatus", jobId, status }));
+    const job = jobsById[jobId];
+    let next = applicationReducer(applicationsById, { type: "setStatus", jobId, status });
+    if (status === "applied" && job) {
+      next = applicationReducer(next, { type: "ensureSnapshotFromJob", jobId, job });
+    }
+    save(next);
   };
 
   const setReminder = (jobId: string, reminderAt?: string) => {
@@ -98,47 +100,58 @@ export default function JobHunterApplicationsPage() {
               <h2 className="text-sm font-semibold">{STATUS_LABELS[status]}</h2>
               {items.map((application) => {
                 const job = jobsById[application.jobId];
-                if (!job) {
-                  return null;
-                }
+                const jobDetails = resolveApplicationJobDetails(application, jobsById);
 
                 return (
                   <article className="space-y-2 rounded-md border border-border/60 bg-background p-3" key={application.id}>
-                    <p className="text-sm font-medium">{job.title}</p>
-                    <p className="text-xs text-foreground/70">{job.company}</p>
+                    <p className="text-sm font-medium">{jobDetails.title}</p>
+                    <p className="text-xs text-foreground/70">{jobDetails.company}</p>
+                    {jobDetails.missingLiveJob ? (
+                      <p className="text-xs text-amber-700">Posting no longer in current sync. Showing stored application snapshot.</p>
+                    ) : (
+                      <Link className="text-xs text-blue-600 hover:underline" href={`/job-hunter/jobs/${encodeURIComponent(application.jobId)}`}>
+                        Open Job Workspace
+                      </Link>
+                    )}
+                    {application.notes ? <p className="rounded bg-muted/40 p-2 text-xs">Notes: {application.notes}</p> : null}
+
                     <div className="flex flex-wrap gap-2">
-                      {job.sourceUrl ? (
-                        <a className="text-xs text-blue-600 hover:underline" href={job.sourceUrl} rel="noreferrer" target="_blank">
+                      {jobDetails.sourceUrl ? (
+                        <a className="text-xs text-blue-600 hover:underline" href={jobDetails.sourceUrl} rel="noreferrer" target="_blank">
                           Open application link
                         </a>
                       ) : null}
-                      <button
-                        className="text-xs text-blue-600 hover:underline"
-                        onClick={async () => {
-                          await copyText(buildAnswerPack(job));
-                          setMessage(`Copied answer pack for ${job.company}.`);
-                        }}
-                        type="button"
-                      >
-                        Pre-fill answer pack
-                      </button>
-                      <button
-                        className="text-xs text-blue-600 hover:underline"
-                        onClick={async () => {
-                          await copyText(buildFollowUpEmail(job));
-                          setMessage(`Copied follow-up email for ${job.company}.`);
-                        }}
-                        type="button"
-                      >
-                        Copy follow-up email
-                      </button>
+                      {job ? (
+                        <>
+                          <button
+                            className="text-xs text-blue-600 hover:underline"
+                            onClick={async () => {
+                              await copyText(buildAnswerPack(job));
+                              setMessage(`Copied answer pack for ${job.company}.`);
+                            }}
+                            type="button"
+                          >
+                            Pre-fill answer pack
+                          </button>
+                          <button
+                            className="text-xs text-blue-600 hover:underline"
+                            onClick={async () => {
+                              await copyText(buildFollowUpEmail(job));
+                              setMessage(`Copied follow-up email for ${job.company}.`);
+                            }}
+                            type="button"
+                          >
+                            Copy follow-up email
+                          </button>
+                        </>
+                      ) : null}
                     </div>
 
                     <div className="flex flex-wrap gap-2">
-                      <Button onClick={() => setStatus(job.id, "applied")} size="sm" type="button" variant="ghost">Mark applied</Button>
-                      <Button onClick={() => setStatus(job.id, "interview")} size="sm" type="button" variant="ghost">Interview</Button>
-                      <Button onClick={() => setStatus(job.id, "offer")} size="sm" type="button" variant="ghost">Offer</Button>
-                      <Button onClick={() => setStatus(job.id, "rejected")} size="sm" type="button" variant="ghost">Reject</Button>
+                      <Button onClick={() => setStatus(application.jobId, "applied")} size="sm" type="button" variant="ghost">Mark applied</Button>
+                      <Button onClick={() => setStatus(application.jobId, "interview")} size="sm" type="button" variant="ghost">Interview</Button>
+                      <Button onClick={() => setStatus(application.jobId, "offer")} size="sm" type="button" variant="ghost">Offer</Button>
+                      <Button onClick={() => setStatus(application.jobId, "rejected")} size="sm" type="button" variant="ghost">Reject</Button>
                     </div>
 
                     <label className="block text-xs text-foreground/70">
@@ -147,7 +160,7 @@ export default function JobHunterApplicationsPage() {
                         className="mt-1 w-full rounded-md border border-border/60 bg-background px-2 py-1 text-xs"
                         onChange={(event) => {
                           const value = event.target.value;
-                          setReminder(job.id, value ? new Date(value).toISOString() : undefined);
+                          setReminder(application.jobId, value ? new Date(value).toISOString() : undefined);
                         }}
                         type="date"
                         value={application.reminderAt ? application.reminderAt.slice(0, 10) : ""}

--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
@@ -6,12 +6,13 @@ import { useMemo, useState } from "react";
 import { EmptyState } from "@/components/job-hunter/EmptyState";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { masterResume } from "@/lib/job-hunter/resume/masterResume";
+import { applicationReducer, createApplicationFromJob, getApplicationChecklist } from "@/lib/job-hunter/applications";
 import { buildApplyPacket } from "@/lib/job-hunter/applyPacket";
-import { generateTailoringPacket } from "@/lib/job-hunter/resume/tailor";
 import { normalizePreferences } from "@/lib/job-hunter/preferences";
+import { masterResume } from "@/lib/job-hunter/resume/masterResume";
+import { generateTailoringPacket } from "@/lib/job-hunter/resume/tailor";
 import { scoreJobFit } from "@/lib/job-hunter/scoring";
-import { loadJobHunterStore } from "@/lib/job-hunter/storage";
+import { loadJobHunterStore, saveJobHunterStore } from "@/lib/job-hunter/storage";
 
 type PageProps = {
   params: {
@@ -28,6 +29,24 @@ export default function JobDetailPage({ params }: PageProps) {
   const job = store.jobsById[decodedJobId];
   const preferences = normalizePreferences(store.preferences);
   const [activeTab, setActiveTab] = useState<Tab>("Overview");
+  const [applicationById, setApplicationById] = useState(() => {
+    if (!job) {
+      return store.applicationsById ?? {};
+    }
+
+    const seeded = { ...(store.applicationsById ?? {}) };
+    if (!seeded[job.id]) {
+      seeded[job.id] = createApplicationFromJob(job, new Date().toISOString());
+      saveJobHunterStore({
+        ...store,
+        applicationsById: seeded,
+        applications: Object.values(seeded),
+      });
+    }
+
+    return seeded;
+  });
+  const [workspaceMessage, setWorkspaceMessage] = useState<string | null>(null);
   const fit = useMemo(() => (job ? scoreJobFit(job, preferences) : null), [job, preferences]);
   const tailoringPacket = useMemo(
     () => (job ? generateTailoringPacket(job, store.resumeProfile ?? masterResume, preferences) : null),
@@ -37,6 +56,18 @@ export default function JobDetailPage({ params }: PageProps) {
     () => (job && tailoringPacket ? buildApplyPacket(job, tailoringPacket) : null),
     [job, tailoringPacket],
   );
+  const application = job ? applicationById[job.id] : undefined;
+  const checklist = application ? getApplicationChecklist(application) : null;
+
+  const saveApplications = (next: typeof applicationById) => {
+    setApplicationById(next);
+    const current = loadJobHunterStore();
+    saveJobHunterStore({
+      ...current,
+      applicationsById: next,
+      applications: Object.values(next),
+    });
+  };
 
   const handleDownloadMarkdown = () => {
     if (!tailoringPacket || !job) {
@@ -68,6 +99,24 @@ export default function JobDetailPage({ params }: PageProps) {
 
   const copyText = (text: string) => {
     void navigator.clipboard.writeText(text);
+  };
+
+  const setChecklistItem = (item: keyof NonNullable<typeof checklist>, value: boolean) => {
+    if (!job) return;
+    saveApplications(applicationReducer(applicationById, { type: "setChecklistItem", jobId: job.id, item, value }));
+  };
+
+  const setNotes = (notes: string) => {
+    if (!job) return;
+    saveApplications(applicationReducer(applicationById, { type: "setNotes", jobId: job.id, notes }));
+  };
+
+  const markApplied = () => {
+    if (!job) return;
+    const withSnapshot = applicationReducer(applicationById, { type: "ensureSnapshotFromJob", jobId: job.id, job });
+    const withApplied = applicationReducer(withSnapshot, { type: "setStatus", jobId: job.id, status: "applied" });
+    saveApplications(withApplied);
+    setWorkspaceMessage("Application marked as applied and snapshot saved.");
   };
 
   if (!job) {
@@ -170,6 +219,34 @@ export default function JobDetailPage({ params }: PageProps) {
               <Button onClick={() => copyText(applyPacket.coverLetterMarkdown)} size="sm" type="button" variant="secondary">Copy Cover Letter</Button>
               <Button onClick={() => copyText(applyPacket.screenerAnswersText)} size="sm" type="button" variant="secondary">Copy Screener Answers</Button>
             </div>
+
+            <section className="space-y-3 rounded-md border border-border/60 p-3">
+              <h3 className="font-medium">Apply Checklist</h3>
+              {checklist ? (
+                <div className="grid gap-2 md:grid-cols-2">
+                  <label className="flex items-center gap-2"><input checked={checklist.resumeReviewed} onChange={(e) => setChecklistItem("resumeReviewed", e.target.checked)} type="checkbox" />Resume reviewed</label>
+                  <label className="flex items-center gap-2"><input checked={checklist.coverLetterReviewed} onChange={(e) => setChecklistItem("coverLetterReviewed", e.target.checked)} type="checkbox" />Cover letter reviewed</label>
+                  <label className="flex items-center gap-2"><input checked={checklist.screenerAnswersReviewed} onChange={(e) => setChecklistItem("screenerAnswersReviewed", e.target.checked)} type="checkbox" />Screener answers reviewed</label>
+                  <label className="flex items-center gap-2"><input checked={checklist.appliedExternally} onChange={(e) => setChecklistItem("appliedExternally", e.target.checked)} type="checkbox" />Applied externally</label>
+                  <label className="flex items-center gap-2"><input checked={checklist.followUpScheduled} onChange={(e) => setChecklistItem("followUpScheduled", e.target.checked)} type="checkbox" />Follow-up scheduled</label>
+                </div>
+              ) : null}
+              <label className="block text-xs text-foreground/70">
+                Notes
+                <textarea
+                  className="mt-1 min-h-24 w-full rounded-md border border-border/60 bg-background px-2 py-1 text-sm"
+                  onChange={(event) => setNotes(event.target.value)}
+                  placeholder="Track what you actually submitted, recruiter details, and follow-up plan."
+                  value={application?.notes ?? ""}
+                />
+              </label>
+              <div className="flex items-center gap-3">
+                <Button onClick={markApplied} size="sm" type="button">Mark as Applied</Button>
+                {application?.appliedAt ? <span className="text-xs text-foreground/70">Applied at {new Date(application.appliedAt).toLocaleString()}</span> : null}
+              </div>
+              {workspaceMessage ? <p className="text-xs text-emerald-700">{workspaceMessage}</p> : null}
+            </section>
+
             <p className="font-medium">Apply Packet Preview</p>
             <pre className="whitespace-pre-wrap rounded-md bg-muted/50 p-3 text-xs">{applyPacket.fullPacketMarkdown}</pre>
             <p className="font-medium">Cover-letter draft</p>

--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx
@@ -3,19 +3,12 @@
 import { useMemo, useState } from "react";
 
 import { EmptyState } from "@/components/job-hunter/EmptyState";
-import { JobList } from "@/components/job-hunter/JobList";
+import { JobList, type JobListRow } from "@/components/job-hunter/JobList";
 import { Button } from "@/components/ui/button";
 import { getDefaultPreferences, jobMatchesPreferences, normalizePreferences } from "@/lib/job-hunter/preferences";
 import { scoreJobFit } from "@/lib/job-hunter/scoring";
 import { loadJobHunterStore, saveJobHunterStore } from "@/lib/job-hunter/storage";
 import type { JobHunterPreferences, JobPosting } from "@/lib/job-hunter/types";
-
-type FilteredJob = {
-  job: JobPosting;
-  score: number;
-  excluded: boolean;
-  reasons: string[];
-};
 
 export default function JobHunterJobsPage() {
   const initialStore = loadJobHunterStore();
@@ -41,7 +34,7 @@ export default function JobHunterJobsPage() {
     [preferences, remoteOnly],
   );
 
-  const filteredJobs = useMemo<FilteredJob[]>(() => {
+  const filteredJobs = useMemo<JobListRow[]>(() => {
     const query = search.trim().toLowerCase();
 
     return jobs
@@ -53,7 +46,10 @@ export default function JobHunterJobsPage() {
           job,
           score: fit.score,
           excluded: exclusion.excluded,
-          reasons: exclusion.reasons,
+          exclusionReasons: exclusion.reasons,
+          reasonSummary:
+            fit.preferenceSignals[0] ??
+            (exclusion.reasons.length > 0 ? `Excluded: ${exclusion.reasons.join(", ")}` : "No preference signal"),
         };
       })
       .filter(({ job, score, excluded }) => {
@@ -192,7 +188,7 @@ export default function JobHunterJobsPage() {
 
       {filteredJobs.length > 0 ? (
         <>
-          <JobList jobs={filteredJobs.map((item) => item.job)} />
+          <JobList rows={filteredJobs} />
           {!hideExcluded ? (
             <section className="space-y-2 rounded-lg border border-border/60 p-4 text-xs">
               <p className="font-medium">Excluded reasons</p>
@@ -200,7 +196,7 @@ export default function JobHunterJobsPage() {
                 .filter((item) => item.excluded)
                 .map((item) => (
                   <p key={item.job.id}>
-                    {item.job.title} at {item.job.company}: {item.reasons.join(", ")}
+                    {item.job.title} at {item.job.company}: {item.exclusionReasons.join(", ")}
                   </p>
                 ))}
             </section>

--- a/ui/partner-hub/components/job-hunter/JobList.tsx
+++ b/ui/partner-hub/components/job-hunter/JobList.tsx
@@ -3,15 +3,23 @@ import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { JobPosting } from "@/lib/job-hunter/types";
 
-type JobListProps = {
-  jobs: JobPosting[];
+export type JobListRow = {
+  job: JobPosting;
+  score: number;
+  excluded: boolean;
+  exclusionReasons: string[];
+  reasonSummary: string;
 };
 
-export function JobList({ jobs }: JobListProps) {
+type JobListProps = {
+  rows: JobListRow[];
+};
+
+export function JobList({ rows }: JobListProps) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Synced jobs ({jobs.length})</CardTitle>
+        <CardTitle>Synced jobs ({rows.length})</CardTitle>
       </CardHeader>
       <CardContent>
         <div className="overflow-x-auto rounded-lg border border-border/60">
@@ -21,31 +29,44 @@ export function JobList({ jobs }: JobListProps) {
                 <th className="px-3 py-2 text-left font-medium">Title</th>
                 <th className="px-3 py-2 text-left font-medium">Company</th>
                 <th className="px-3 py-2 text-left font-medium">Location</th>
-                <th className="px-3 py-2 text-left font-medium">Department</th>
+                <th className="px-3 py-2 text-left font-medium">Fit</th>
                 <th className="px-3 py-2 text-left font-medium">Posted</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border/60">
-              {jobs.map((job) => (
-                <tr key={job.id}>
-                  <td className="px-3 py-2">
-                    <div className="flex flex-col gap-1">
-                      <Link className="font-medium text-blue-600 hover:underline" href={`/job-hunter/jobs/${encodeURIComponent(job.id)}`}>
-                        {job.title}
-                      </Link>
-                      {job.sourceUrl ? (
-                        <a className="text-xs text-foreground/70 underline-offset-2 hover:underline" href={job.sourceUrl} rel="noreferrer" target="_blank">
-                          Open source posting
-                        </a>
-                      ) : null}
-                    </div>
-                  </td>
-                  <td className="px-3 py-2">{job.company}</td>
-                  <td className="px-3 py-2">{job.location ?? "Remote / TBD"}</td>
-                  <td className="px-3 py-2">{job.department ?? "—"}</td>
-                  <td className="px-3 py-2">{(job.postedAt ?? job.updatedAt).slice(0, 10)}</td>
-                </tr>
-              ))}
+              {rows.map((row) => {
+                const { job } = row;
+                return (
+                  <tr key={job.id}>
+                    <td className="px-3 py-2">
+                      <div className="flex flex-col gap-1">
+                        <Link className="font-medium text-blue-600 hover:underline" href={`/job-hunter/jobs/${encodeURIComponent(job.id)}`}>
+                          {job.title}
+                        </Link>
+                        <p className="text-xs text-foreground/70">{row.reasonSummary}</p>
+                        {job.sourceUrl ? (
+                          <a className="text-xs text-foreground/70 underline-offset-2 hover:underline" href={job.sourceUrl} rel="noreferrer" target="_blank">
+                            Open source posting
+                          </a>
+                        ) : null}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2">{job.company}</td>
+                    <td className="px-3 py-2">{job.location ?? "Remote / TBD"}</td>
+                    <td className="px-3 py-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium">{row.score}/100</span>
+                        {row.excluded ? (
+                          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-900" title={row.exclusionReasons.join(", ")}>
+                            Excluded
+                          </span>
+                        ) : null}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2">{(job.postedAt ?? job.updatedAt).slice(0, 10)}</td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/ui/partner-hub/lib/job-hunter/applications.test.ts
+++ b/ui/partner-hub/lib/job-hunter/applications.test.ts
@@ -1,7 +1,13 @@
 import * as assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { applicationReducer, createApplicationFromJob, exportApplicationsCsv } from "./applications";
+import {
+  applicationReducer,
+  createApplicationFromJob,
+  exportApplicationsCsv,
+  resolveApplicationJobDetails,
+  toJobSnapshot,
+} from "./applications";
 import type { JobPosting } from "./types";
 
 const job: JobPosting = {
@@ -10,6 +16,9 @@ const job: JobPosting = {
   company: "Acme",
   source: "company-site",
   sourceUrl: "https://example.com/jobs/1",
+  location: "Remote",
+  department: "Product",
+  postedAt: "2024-02-01T00:00:00.000Z",
   createdAt: "2024-01-01T00:00:00.000Z",
   updatedAt: "2024-01-01T00:00:00.000Z",
 };
@@ -20,6 +29,7 @@ describe("job hunter application reducer", () => {
 
     assert.equal(created.status, "prepared");
     assert.equal(created.jobId, job.id);
+    assert.equal(created.checklist?.resumeReviewed, false);
   });
 
   it("updates status timestamps", () => {
@@ -38,17 +48,63 @@ describe("job hunter application reducer", () => {
     assert.equal(applied[job.id].status, "applied");
   });
 
+  it("updates checklist and notes", () => {
+    const initial = { [job.id]: createApplicationFromJob(job, "2024-03-01T10:00:00.000Z") };
+    const withChecklist = applicationReducer(initial, {
+      type: "setChecklistItem",
+      jobId: job.id,
+      item: "resumeReviewed",
+      value: true,
+      now: "2024-03-02T10:00:00.000Z",
+    });
+    const withNotes = applicationReducer(withChecklist, {
+      type: "setNotes",
+      jobId: job.id,
+      notes: "Submitted tailored resume and letter.",
+      now: "2024-03-03T10:00:00.000Z",
+    });
+
+    assert.equal(withNotes[job.id].checklist?.resumeReviewed, true);
+    assert.equal(withNotes[job.id].notes, "Submitted tailored resume and letter.");
+  });
+
+  it("captures immutable snapshot when requested", () => {
+    const initial = { [job.id]: createApplicationFromJob(job, "2024-03-01T10:00:00.000Z") };
+    const withSnapshot = applicationReducer(initial, {
+      type: "ensureSnapshotFromJob",
+      jobId: job.id,
+      job,
+      now: "2024-03-02T10:00:00.000Z",
+    });
+
+    assert.deepEqual(withSnapshot[job.id].jobSnapshot, toJobSnapshot(job));
+  });
+
+  it("falls back to snapshot when live job is missing", () => {
+    const application = {
+      ...createApplicationFromJob(job, "2024-03-01T10:00:00.000Z"),
+      jobSnapshot: toJobSnapshot(job),
+    };
+
+    const details = resolveApplicationJobDetails(application, {});
+
+    assert.equal(details.missingLiveJob, true);
+    assert.equal(details.title, "Product Manager");
+    assert.equal(details.company, "Acme");
+  });
+
   it("exports applications as csv", () => {
     const applications = [
       {
         ...createApplicationFromJob(job, "2024-03-01T10:00:00.000Z"),
         status: "applied" as const,
+        notes: "done",
       },
     ];
 
     const csv = exportApplicationsCsv(applications, { [job.id]: job });
 
-    assert.match(csv, /"jobId","company","title"/);
-    assert.match(csv, /"job-1","Acme","Product Manager"/);
+    assert.match(csv, /"jobId","company","title","status","notes"/);
+    assert.match(csv, /"job-1","Acme","Product Manager","applied","done"/);
   });
 });

--- a/ui/partner-hub/lib/job-hunter/applications.ts
+++ b/ui/partner-hub/lib/job-hunter/applications.ts
@@ -1,4 +1,4 @@
-import type { Application, ApplicationStatus, JobPosting } from "./types";
+import type { Application, ApplicationStatus, ApplyChecklist, ApplicationJobSnapshot, JobPosting } from "./types";
 
 export const APPLICATION_STATUSES: ApplicationStatus[] = ["prepared", "applied", "interview", "rejected", "offer"];
 
@@ -10,10 +10,23 @@ export const STATUS_LABELS: Record<ApplicationStatus, string> = {
   offer: "Offer",
 };
 
+export const DEFAULT_APPLY_CHECKLIST: ApplyChecklist = {
+  resumeReviewed: false,
+  coverLetterReviewed: false,
+  screenerAnswersReviewed: false,
+  appliedExternally: false,
+  followUpScheduled: false,
+};
+
+export type ChecklistKey = keyof ApplyChecklist;
+
 export type ApplicationAction =
   | { type: "upsertFromJob"; job: JobPosting; now?: string }
   | { type: "setStatus"; jobId: string; status: ApplicationStatus; now?: string }
-  | { type: "setReminder"; jobId: string; reminderAt?: string; now?: string };
+  | { type: "setReminder"; jobId: string; reminderAt?: string; now?: string }
+  | { type: "setNotes"; jobId: string; notes?: string; now?: string }
+  | { type: "setChecklistItem"; jobId: string; item: ChecklistKey; value: boolean; now?: string }
+  | { type: "ensureSnapshotFromJob"; jobId: string; job: JobPosting; now?: string };
 
 export const buildFollowUpEmail = (job: JobPosting) => {
   return `Hi ${job.company} recruiting team,\n\nI applied for the ${job.title} role and wanted to follow up on next steps. I remain very interested in the position and would be happy to share any additional information.\n\nBest regards,\n[Your Name]`;
@@ -38,13 +51,56 @@ const statusTimestampPatch = (status: ApplicationStatus, now: string): Partial<A
   return {};
 };
 
+export const toJobSnapshot = (job: JobPosting): ApplicationJobSnapshot => ({
+  jobId: job.id,
+  title: job.title,
+  company: job.company,
+  location: job.location,
+  sourceUrl: job.sourceUrl,
+  department: job.department,
+  postedAt: job.postedAt,
+});
+
 export const createApplicationFromJob = (job: JobPosting, now: string): Application => ({
   id: job.id,
   jobId: job.id,
   status: "prepared",
+  checklist: { ...DEFAULT_APPLY_CHECKLIST },
   createdAt: now,
   updatedAt: now,
 });
+
+export const getApplicationChecklist = (application: Application): ApplyChecklist => ({
+  ...DEFAULT_APPLY_CHECKLIST,
+  ...(application.checklist ?? {}),
+});
+
+export const resolveApplicationJobDetails = (application: Application, jobsById: Record<string, JobPosting>) => {
+  const liveJob = jobsById[application.jobId];
+
+  if (liveJob) {
+    return {
+      missingLiveJob: false,
+      title: liveJob.title,
+      company: liveJob.company,
+      location: liveJob.location,
+      sourceUrl: liveJob.sourceUrl,
+      department: liveJob.department,
+      postedAt: liveJob.postedAt,
+    };
+  }
+
+  const snapshot = application.jobSnapshot;
+  return {
+    missingLiveJob: true,
+    title: snapshot?.title ?? "Unknown role",
+    company: snapshot?.company ?? "Unknown company",
+    location: snapshot?.location,
+    sourceUrl: snapshot?.sourceUrl,
+    department: snapshot?.department,
+    postedAt: snapshot?.postedAt,
+  };
+};
 
 export const applicationReducer = (
   state: Record<string, Application>,
@@ -70,11 +126,12 @@ export const applicationReducer = (
   }
 
   if (action.type === "setStatus") {
-    const next = {
+    const next: Application = {
       ...existing,
       status: action.status,
       updatedAt: now,
       ...statusTimestampPatch(action.status, now),
+      checklist: getApplicationChecklist(existing),
     };
 
     return {
@@ -89,6 +146,49 @@ export const applicationReducer = (
       [action.jobId]: {
         ...existing,
         reminderAt: action.reminderAt,
+        checklist: getApplicationChecklist(existing),
+        updatedAt: now,
+      },
+    };
+  }
+
+  if (action.type === "setNotes") {
+    return {
+      ...state,
+      [action.jobId]: {
+        ...existing,
+        notes: action.notes,
+        checklist: getApplicationChecklist(existing),
+        updatedAt: now,
+      },
+    };
+  }
+
+  if (action.type === "setChecklistItem") {
+    return {
+      ...state,
+      [action.jobId]: {
+        ...existing,
+        checklist: {
+          ...getApplicationChecklist(existing),
+          [action.item]: action.value,
+        },
+        updatedAt: now,
+      },
+    };
+  }
+
+  if (action.type === "ensureSnapshotFromJob") {
+    if (existing.jobSnapshot) {
+      return state;
+    }
+
+    return {
+      ...state,
+      [action.jobId]: {
+        ...existing,
+        checklist: getApplicationChecklist(existing),
+        jobSnapshot: toJobSnapshot(action.job),
         updatedAt: now,
       },
     };
@@ -104,6 +204,7 @@ export const exportApplicationsCsv = (applications: Application[], jobsById: Rec
     "company",
     "title",
     "status",
+    "notes",
     "createdAt",
     "appliedAt",
     "interviewedAt",
@@ -114,12 +215,13 @@ export const exportApplicationsCsv = (applications: Application[], jobsById: Rec
   ];
 
   const rows = applications.map((application) => {
-    const job = jobsById[application.jobId];
+    const jobDetails = resolveApplicationJobDetails(application, jobsById);
     return [
       application.jobId,
-      job?.company ?? "",
-      job?.title ?? "",
+      jobDetails.company,
+      jobDetails.title,
       application.status,
+      application.notes ?? "",
       application.createdAt,
       application.appliedAt ?? "",
       application.interviewedAt ?? "",

--- a/ui/partner-hub/lib/job-hunter/storage.test.ts
+++ b/ui/partner-hub/lib/job-hunter/storage.test.ts
@@ -56,6 +56,47 @@ describe("job hunter storage", () => {
     });
   });
 
+
+  it("hydrates legacy applications without checklist fields", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      JOB_HUNTER_STORAGE_KEY,
+      JSON.stringify({
+        jobsById: {},
+        jobs: [],
+        applicationsById: {
+          "job-legacy": {
+            id: "job-legacy",
+            jobId: "job-legacy",
+            status: "prepared",
+            notes: "legacy note",
+            createdAt: "2024-03-01T10:00:00.000Z",
+            updatedAt: "2024-03-01T10:00:00.000Z",
+          },
+        },
+      }),
+    );
+
+    const previousWindow = globalThis.window;
+    Object.defineProperty(globalThis, "window", {
+      value: { localStorage: storage },
+      configurable: true,
+      writable: true,
+    });
+
+    const loaded = loadJobHunterStore();
+
+    assert.equal(loaded.applicationsById["job-legacy"].notes, "legacy note");
+    assert.equal(loaded.applicationsById["job-legacy"].checklist?.resumeReviewed, false);
+    assert.equal(loaded.applicationsById["job-legacy"].checklist?.followUpScheduled, false);
+
+    Object.defineProperty(globalThis, "window", {
+      value: previousWindow,
+      configurable: true,
+      writable: true,
+    });
+  });
+
   it("validates source payloads", () => {
     assert.equal(isValidJobSourceConfig({ company: "Acme", boardType: "greenhouse", boardToken: "acme" }), true);
     assert.equal(isValidJobSourceConfig({ company: "", boardType: "greenhouse", boardToken: "acme" }), false);

--- a/ui/partner-hub/lib/job-hunter/storage.ts
+++ b/ui/partner-hub/lib/job-hunter/storage.ts
@@ -1,6 +1,7 @@
-import type { Application, BoardType, JobHunterStore, JobSourceConfig } from "./types";
+import { DEFAULT_APPLY_CHECKLIST, getApplicationChecklist } from "./applications";
 import { getDefaultPreferences, normalizePreferences } from "./preferences";
 import { normalizeResumeProfile } from "./resumeProfile";
+import type { Application, ApplyChecklist, BoardType, JobHunterStore, JobSourceConfig } from "./types";
 
 export const JOB_HUNTER_STORAGE_KEY = "partner-hub:job-hunter:v1";
 
@@ -15,9 +16,41 @@ const DEFAULT_STORE: JobHunterStore = {
 
 const BOARD_TYPES: BoardType[] = ["greenhouse", "lever"];
 
+const normalizeChecklist = (value: unknown): ApplyChecklist => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { ...DEFAULT_APPLY_CHECKLIST };
+  }
+
+  const list = value as Partial<ApplyChecklist>;
+  return {
+    resumeReviewed: Boolean(list.resumeReviewed),
+    coverLetterReviewed: Boolean(list.coverLetterReviewed),
+    screenerAnswersReviewed: Boolean(list.screenerAnswersReviewed),
+    appliedExternally: Boolean(list.appliedExternally),
+    followUpScheduled: Boolean(list.followUpScheduled),
+  };
+};
+
+const normalizeApplication = (value: Application): Application => ({
+  ...value,
+  checklist: normalizeChecklist(value.checklist),
+  jobSnapshot:
+    value.jobSnapshot && typeof value.jobSnapshot === "object"
+      ? {
+          jobId: value.jobSnapshot.jobId,
+          title: value.jobSnapshot.title,
+          company: value.jobSnapshot.company,
+          location: value.jobSnapshot.location,
+          sourceUrl: value.jobSnapshot.sourceUrl,
+          department: value.jobSnapshot.department,
+          postedAt: value.jobSnapshot.postedAt,
+        }
+      : undefined,
+});
+
 const toApplicationsById = (applications: Application[]) =>
   applications.reduce<Record<string, Application>>((acc, application) => {
-    acc[application.jobId] = application;
+    acc[application.jobId] = normalizeApplication(application);
     return acc;
   }, {});
 
@@ -70,11 +103,21 @@ export const loadJobHunterStore = (): JobHunterStore => {
 
     const jobs = Array.isArray(parsed.jobs) ? parsed.jobs : Object.values(jobsById);
 
-    const applicationsFromArray = Array.isArray(parsed.applications) ? parsed.applications : [];
-    const applicationsById =
+    const applicationsFromArray = Array.isArray(parsed.applications)
+      ? parsed.applications.filter((item): item is Application => Boolean(item && item.jobId)).map(normalizeApplication)
+      : [];
+    const rawApplicationsById =
       parsed.applicationsById && typeof parsed.applicationsById === "object" && !Array.isArray(parsed.applicationsById)
         ? parsed.applicationsById
         : toApplicationsById(applicationsFromArray);
+    const applicationsById = Object.entries(rawApplicationsById).reduce<Record<string, Application>>((acc, [jobId, application]) => {
+      const normalized = normalizeApplication({ ...application, jobId });
+      acc[jobId] = {
+        ...normalized,
+        checklist: getApplicationChecklist(normalized),
+      };
+      return acc;
+    }, {});
     const applications = Object.values(applicationsById);
 
     return {
@@ -97,10 +140,20 @@ export const saveJobHunterStore = (store: JobHunterStore) => {
     return;
   }
 
+  const applicationsById = Object.entries(store.applicationsById ?? {}).reduce<Record<string, Application>>((acc, [jobId, application]) => {
+    acc[jobId] = {
+      ...application,
+      checklist: getApplicationChecklist(application),
+    };
+    return acc;
+  }, {});
+
   window.localStorage.setItem(
     JOB_HUNTER_STORAGE_KEY,
     JSON.stringify({
       ...store,
+      applicationsById,
+      applications: Object.values(applicationsById),
       resumeProfile: store.resumeProfile ? normalizeResumeProfile(store.resumeProfile) : undefined,
       preferences: normalizePreferences(store.preferences),
     }),

--- a/ui/partner-hub/lib/job-hunter/types.ts
+++ b/ui/partner-hub/lib/job-hunter/types.ts
@@ -10,6 +10,24 @@ export type JobSourceConfig = {
 
 export type ApplicationStatus = "prepared" | "applied" | "interview" | "rejected" | "offer";
 
+export type ApplicationJobSnapshot = {
+  jobId: string;
+  title: string;
+  company: string;
+  location?: string;
+  sourceUrl?: string;
+  department?: string;
+  postedAt?: string;
+};
+
+export type ApplyChecklist = {
+  resumeReviewed: boolean;
+  coverLetterReviewed: boolean;
+  screenerAnswersReviewed: boolean;
+  appliedExternally: boolean;
+  followUpScheduled: boolean;
+};
+
 export type JobPosting = {
   id: string;
   title: string;
@@ -37,6 +55,8 @@ export type Application = {
   offeredAt?: string;
   rejectedAt?: string;
   notes?: string;
+  checklist?: ApplyChecklist;
+  jobSnapshot?: ApplicationJobSnapshot;
   createdAt: string;
   updatedAt: string;
 };


### PR DESCRIPTION
### Motivation
- Provide a deterministic, production-safe guided apply workflow so users can complete and track applications without auto-submission.
- Preserve visibility of applied jobs even if the source posting is later removed from sync by capturing an immutable lightweight job snapshot.
- Surface explainability (fit score and why) in the jobs list so users can prioritize and understand automated scoring.

### Description
- Show fit score, exclusion indicator, and a compact reason summary in the jobs list by passing a richer row model into `JobList` and rendering a `Fit` badge and reason text (UI changes in `JobList` and `jobs/page.tsx`).
- Add durable snapshot and checklist types (`ApplicationJobSnapshot`, `ApplyChecklist`) and extend `Application` with `checklist` and `jobSnapshot` fields to persist what was actually submitted and checklist state (`types.ts`).
- Extend `applicationReducer` with `setNotes`, `setChecklistItem`, and `ensureSnapshotFromJob` actions and wire snapshot capture on apply, plus CSV export now includes `notes` and uses snapshot-backed job details when live postings are missing (`applications.ts`).
- Normalize and persist new application fields in storage, provide backward-compatible hydration for legacy records (default checklist), and ensure saved store includes normalized `applicationsById` and `applications` (`storage.ts`); add an Apply Workspace on the job detail page with deterministic checklist, notes, and a `Mark as Applied` action that stamps `appliedAt` and ensures a job snapshot (`jobs/[jobId]/page.tsx`).
- Improve Applications Kanban to render snapshot-backed cards with clear "posting no longer in current sync" messaging and link back to the live workspace when available, plus tests and small UI wiring in `applications/page.tsx`.

Changed files (key): `ui/partner-hub/components/job-hunter/JobList.tsx`, `ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx`, `ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx`, `ui/partner-hub/app/(routes)/job-hunter/applications/page.tsx`, `ui/partner-hub/lib/job-hunter/types.ts`, `ui/partner-hub/lib/job-hunter/applications.ts`, `ui/partner-hub/lib/job-hunter/storage.ts`, `ui/partner-hub/lib/job-hunter/applications.test.ts`, `ui/partner-hub/lib/job-hunter/storage.test.ts`.

### Testing
- Ran `cd ui/partner-hub && npm run lint` which passed with: `✔ No ESLint warnings or errors`.
- Ran `cd ui/partner-hub && npm run typecheck` which invoked `tsc --noEmit` and completed without type errors.
- Ran `cd ui/partner-hub && npm run test` and the test suite passed; relevant summary from the run was: `# tests 78` `# suites 25` `# pass 78` `# fail 0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af4e76b28883309d5244592446b420)