### PR TITLE
Move Job Hunter application seeding out of render initializer

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { EmptyState } from "@/components/job-hunter/EmptyState";
 import { Button } from "@/components/ui/button";
@@ -29,23 +29,7 @@ export default function JobDetailPage({ params }: PageProps) {
   const job = store.jobsById[decodedJobId];
   const preferences = normalizePreferences(store.preferences);
   const [activeTab, setActiveTab] = useState<Tab>("Overview");
-  const [applicationById, setApplicationById] = useState(() => {
-    if (!job) {
-      return store.applicationsById ?? {};
-    }
-
-    const seeded = { ...(store.applicationsById ?? {}) };
-    if (!seeded[job.id]) {
-      seeded[job.id] = createApplicationFromJob(job, new Date().toISOString());
-      saveJobHunterStore({
-        ...store,
-        applicationsById: seeded,
-        applications: Object.values(seeded),
-      });
-    }
-
-    return seeded;
-  });
+  const [applicationById, setApplicationById] = useState(() => store.applicationsById ?? {});
   const [workspaceMessage, setWorkspaceMessage] = useState<string | null>(null);
   const fit = useMemo(() => (job ? scoreJobFit(job, preferences) : null), [job, preferences]);
   const tailoringPacket = useMemo(
@@ -59,7 +43,7 @@ export default function JobDetailPage({ params }: PageProps) {
   const application = job ? applicationById[job.id] : undefined;
   const checklist = application ? getApplicationChecklist(application) : null;
 
-  const saveApplications = (next: typeof applicationById) => {
+  const saveApplications = useCallback((next: typeof applicationById) => {
     setApplicationById(next);
     const current = loadJobHunterStore();
     saveJobHunterStore({
@@ -67,7 +51,25 @@ export default function JobDetailPage({ params }: PageProps) {
       applicationsById: next,
       applications: Object.values(next),
     });
-  };
+  }, []);
+
+  useEffect(() => {
+    if (!job || applicationById[job.id]) {
+      return;
+    }
+
+    const current = loadJobHunterStore();
+    const persisted = current.applicationsById ?? {};
+    if (persisted[job.id]) {
+      setApplicationById(persisted);
+      return;
+    }
+
+    saveApplications({
+      ...applicationById,
+      [job.id]: createApplicationFromJob(job, new Date().toISOString()),
+    });
+  }, [applicationById, job, saveApplications]);
 
   const handleDownloadMarkdown = () => {
     if (!tailoringPacket || !job) {


### PR DESCRIPTION
### Motivation
- Remove persistence side-effects from the Job Hunter job detail `useState` initializer so render-time initialization is pure while preserving the exact current UX and behavior.

### Description
- Updated `ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx` to initialize `applicationById` as `store.applicationsById ?? {}` (pure render-time state).
- Wrapped the existing persistence helper as a stable `saveApplications` using `useCallback` and kept persistence centralized via `saveJobHunterStore`.
- Moved the “seed missing application for the current job” logic into a `useEffect` that checks persisted storage first and seeds only once to avoid duplicate writes and React Strict Mode double-invocation issues.
- No UX or behavior changes to apply/checklist/notes/mark-applied flows; only the seeding timing was moved.

### Testing
- Ran `cd ui/partner-hub && npm run lint` and it completed with no ESLint warnings or errors.
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> partner-hub@0.0.1 lint
> next lint

`next lint` is deprecated and will be removed in Next.js 16.
For new projects, use create-next-app to choose your preferred linter.
For existing projects, migrate to the ESLint CLI:
npx @next/codemod@canary next-lint-to-eslint-cli .

Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

✔ No ESLint warnings or errors
```
- Ran `cd ui/partner-hub && npm run typecheck` and the TypeScript check completed without errors.
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> partner-hub@0.0.1 typecheck
> tsc --noEmit
```
- Ran `cd ui/partner-hub && npm run test` and the test suite passed (78 tests across 25 suites).
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> partner-hub@0.0.1 test
> tsc --noEmit false --module commonjs --moduleResolution node --target ES2020 --outDir .tmp-tests --rootDir . ... && node --test ...

TAP version 13
...
1..25
# tests 78
# suites 25
# pass 78
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 2821.714206
```

Changed files:
- `ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx` (22 insertions, 20 deletions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af5355c01883309706a54f60c9de2b)