### PR TITLE
Add Job Hunter apply queue and candidate identity profile

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/applications/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/applications/page.tsx
@@ -36,6 +36,7 @@ export default function JobHunterApplicationsPage() {
 
     return seeded;
   });
+  const [selectedJobIds] = useState<string[]>(initialStore.selectedJobIds ?? []);
   const [message, setMessage] = useState<string | null>(null);
 
   const applications = useMemo(() => Object.values(applicationsById), [applicationsById]);
@@ -113,6 +114,14 @@ export default function JobHunterApplicationsPage() {
                         Open Job Workspace
                       </Link>
                     )}
+                    <div className="flex flex-wrap items-center gap-2 text-xs">
+                      {selectedJobIds.includes(application.jobId) ? (
+                        <span className="rounded-full bg-blue-100 px-2 py-0.5 text-blue-800">In apply queue</span>
+                      ) : null}
+                      {application.status === "applied" ? (
+                        <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-emerald-800">Applied</span>
+                      ) : null}
+                    </div>
                     {application.notes ? <p className="rounded bg-muted/40 p-2 text-xs">Notes: {application.notes}</p> : null}
 
                     <div className="flex flex-wrap gap-2">
@@ -136,7 +145,7 @@ export default function JobHunterApplicationsPage() {
                           <button
                             className="text-xs text-blue-600 hover:underline"
                             onClick={async () => {
-                              await copyText(buildFollowUpEmail(job));
+                              await copyText(buildFollowUpEmail(job, initialStore.resumeProfile));
                               setMessage(`Copied follow-up email for ${job.company}.`);
                             }}
                             type="button"

--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
@@ -37,8 +37,8 @@ export default function JobDetailPage({ params }: PageProps) {
     [job, preferences, store.resumeProfile],
   );
   const applyPacket = useMemo(
-    () => (job && tailoringPacket ? buildApplyPacket(job, tailoringPacket) : null),
-    [job, tailoringPacket],
+    () => (job && tailoringPacket ? buildApplyPacket(job, tailoringPacket, store.resumeProfile) : null),
+    [job, store.resumeProfile, tailoringPacket],
   );
   const application = job ? applicationById[job.id] : undefined;
   const checklist = application ? getApplicationChecklist(application) : null;

--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useMemo, useState } from "react";
 
 import { EmptyState } from "@/components/job-hunter/EmptyState";
@@ -7,6 +8,7 @@ import { JobList, type JobListRow } from "@/components/job-hunter/JobList";
 import { Button } from "@/components/ui/button";
 import { getDefaultPreferences, jobMatchesPreferences, normalizePreferences } from "@/lib/job-hunter/preferences";
 import { scoreJobFit } from "@/lib/job-hunter/scoring";
+import { toggleJobSelection } from "@/lib/job-hunter/queue";
 import { loadJobHunterStore, saveJobHunterStore } from "@/lib/job-hunter/storage";
 import type { JobHunterPreferences, JobPosting } from "@/lib/job-hunter/types";
 
@@ -15,6 +17,7 @@ export default function JobHunterJobsPage() {
   const initialPreferences = normalizePreferences(initialStore.preferences);
 
   const [jobsById, setJobsById] = useState<Record<string, JobPosting>>(initialStore.jobsById ?? {});
+  const [selectedJobIds, setSelectedJobIds] = useState<string[]>(initialStore.selectedJobIds ?? []);
   const [lastSyncedAt, setLastSyncedAt] = useState<string | undefined>(initialStore.lastSyncedAt);
   const [preferences] = useState<JobHunterPreferences>(initialPreferences);
   const [error, setError] = useState<string | null>(null);
@@ -74,7 +77,23 @@ export default function JobHunterJobsPage() {
       });
   }, [activePreferences, hideExcluded, jobs, minDate, minScore, search]);
 
+  const selectedJobs = useMemo(
+    () => selectedJobIds.map((jobId) => jobsById[jobId]).filter((job): job is JobPosting => Boolean(job)),
+    [jobsById, selectedJobIds],
+  );
+
   const excludedVisible = filteredJobs.filter((item) => item.excluded).length;
+
+  const handleToggleSelectedJob = (jobId: string) => {
+    const nextSelected = toggleJobSelection(selectedJobIds, jobId);
+    setSelectedJobIds(nextSelected);
+
+    const currentStore = loadJobHunterStore();
+    saveJobHunterStore({
+      ...currentStore,
+      selectedJobIds: nextSelected,
+    });
+  };
 
   const handleSync = async () => {
     setError(null);
@@ -140,6 +159,26 @@ export default function JobHunterJobsPage() {
         {error ? <p className="text-xs text-red-600">{error}</p> : null}
       </section>
 
+      <section className="space-y-2 rounded-lg border border-border/60 p-4">
+        <h2 className="text-sm font-semibold">Apply Queue ({selectedJobs.length})</h2>
+        {selectedJobs.length > 0 ? (
+          <ul className="space-y-1 text-sm">
+            {selectedJobs.map((job) => (
+              <li className="flex items-center justify-between gap-2" key={job.id}>
+                <Link className="text-blue-600 hover:underline" href={`/job-hunter/jobs/${encodeURIComponent(job.id)}`}>
+                  {job.title} · {job.company}
+                </Link>
+                <button className="text-xs text-blue-600 hover:underline" onClick={() => handleToggleSelectedJob(job.id)} type="button">
+                  Remove from Apply Queue
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-xs text-foreground/70">No jobs selected yet. Use “Select for Apply” in the list below.</p>
+        )}
+      </section>
+
       <section className="grid gap-3 rounded-lg border border-border/60 p-4 md:grid-cols-3">
         <input
           className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
@@ -188,7 +227,7 @@ export default function JobHunterJobsPage() {
 
       {filteredJobs.length > 0 ? (
         <>
-          <JobList rows={filteredJobs} />
+          <JobList onToggleSelectedJob={handleToggleSelectedJob} rows={filteredJobs} selectedJobIds={selectedJobIds} />
           {!hideExcluded ? (
             <section className="space-y-2 rounded-lg border border-border/60 p-4 text-xs">
               <p className="font-medium">Excluded reasons</p>

--- a/ui/partner-hub/app/(routes)/job-hunter/resume/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/resume/page.tsx
@@ -47,6 +47,26 @@ export default function JobHunterResumePage() {
       </header>
 
       <section className="space-y-3 rounded-lg border border-border/60 p-4">
+        <h2 className="text-sm font-semibold">Candidate Identity</h2>
+        <div className="grid gap-2 md:grid-cols-2">
+          <input className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm" onChange={(e) => setProfile((p) => ({ ...p, fullName: e.target.value }))} placeholder="Full name" value={profile.fullName} />
+          <input className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm" onChange={(e) => setProfile((p) => ({ ...p, headline: e.target.value }))} placeholder="Headline (optional)" value={profile.headline ?? ""} />
+          <input className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm" onChange={(e) => setProfile((p) => ({ ...p, email: e.target.value }))} placeholder="Email" value={profile.email} />
+          <input className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm" onChange={(e) => setProfile((p) => ({ ...p, phone: e.target.value }))} placeholder="Phone" value={profile.phone} />
+          <input className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm" onChange={(e) => setProfile((p) => ({ ...p, cityState: e.target.value }))} placeholder="City, State" value={profile.cityState} />
+          <input className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm" onChange={(e) => setProfile((p) => ({ ...p, linkedinUrl: e.target.value }))} placeholder="LinkedIn URL" value={profile.linkedinUrl} />
+          <input className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm" onChange={(e) => setProfile((p) => ({ ...p, websiteUrl: e.target.value }))} placeholder="Website URL (optional)" value={profile.websiteUrl ?? ""} />
+          <input className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm" onChange={(e) => setProfile((p) => ({ ...p, signatureLine: e.target.value }))} placeholder="Signature line (e.g. Best regards,)" value={profile.signatureLine} />
+        </div>
+        <textarea
+          className="min-h-20 w-full rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
+          onChange={(event) => setProfile((prev) => ({ ...prev, workAuthorizationNote: event.target.value }))}
+          placeholder="Work authorization note"
+          value={profile.workAuthorizationNote}
+        />
+      </section>
+
+      <section className="space-y-3 rounded-lg border border-border/60 p-4">
         <h2 className="text-sm font-semibold">Summary</h2>
         <textarea
           className="min-h-24 w-full rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
@@ -89,125 +109,21 @@ export default function JobHunterResumePage() {
           {profile.experience.map((experience, index) => (
             <div className="space-y-2 rounded-md border border-border/60 p-3" key={`experience-${index}`}>
               <div className="grid gap-2 md:grid-cols-2">
-                <input
-                  className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
-                  onChange={(event) =>
-                    setProfile((prev) => ({
-                      ...prev,
-                      experience: prev.experience.map((item, itemIndex) =>
-                        itemIndex === index ? { ...item, company: event.target.value } : item,
-                      ),
-                    }))
-                  }
-                  placeholder="Company"
-                  value={experience.company}
-                />
-                <input
-                  className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
-                  onChange={(event) =>
-                    setProfile((prev) => ({
-                      ...prev,
-                      experience: prev.experience.map((item, itemIndex) =>
-                        itemIndex === index ? { ...item, title: event.target.value } : item,
-                      ),
-                    }))
-                  }
-                  placeholder="Title"
-                  value={experience.title}
-                />
-                <input
-                  className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
-                  onChange={(event) =>
-                    setProfile((prev) => ({
-                      ...prev,
-                      experience: prev.experience.map((item, itemIndex) =>
-                        itemIndex === index ? { ...item, start: event.target.value } : item,
-                      ),
-                    }))
-                  }
-                  placeholder="Start"
-                  value={experience.start ?? ""}
-                />
-                <input
-                  className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
-                  onChange={(event) =>
-                    setProfile((prev) => ({
-                      ...prev,
-                      experience: prev.experience.map((item, itemIndex) =>
-                        itemIndex === index ? { ...item, end: event.target.value } : item,
-                      ),
-                    }))
-                  }
-                  placeholder="End"
-                  value={experience.end ?? ""}
-                />
+                <input className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm" onChange={(event) => setProfile((prev) => ({ ...prev, experience: prev.experience.map((item, itemIndex) => itemIndex === index ? { ...item, company: event.target.value } : item) }))} placeholder="Company" value={experience.company} />
+                <input className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm" onChange={(event) => setProfile((prev) => ({ ...prev, experience: prev.experience.map((item, itemIndex) => itemIndex === index ? { ...item, title: event.target.value } : item) }))} placeholder="Title" value={experience.title} />
+                <input className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm" onChange={(event) => setProfile((prev) => ({ ...prev, experience: prev.experience.map((item, itemIndex) => itemIndex === index ? { ...item, start: event.target.value } : item) }))} placeholder="Start" value={experience.start ?? ""} />
+                <input className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm" onChange={(event) => setProfile((prev) => ({ ...prev, experience: prev.experience.map((item, itemIndex) => itemIndex === index ? { ...item, end: event.target.value } : item) }))} placeholder="End" value={experience.end ?? ""} />
               </div>
               <p className="text-xs font-medium uppercase text-foreground/70">Bullets</p>
               {experience.bullets.map((bullet, bulletIndex) => (
                 <div className="flex gap-2" key={`experience-${index}-bullet-${bulletIndex}`}>
-                  <input
-                    className="w-full rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
-                    onChange={(event) =>
-                      setProfile((prev) => ({
-                        ...prev,
-                        experience: prev.experience.map((item, itemIndex) =>
-                          itemIndex === index
-                            ? {
-                              ...item,
-                              bullets: item.bullets.map((line, lineIndex) => (lineIndex === bulletIndex ? event.target.value : line)),
-                            }
-                            : item,
-                        ),
-                      }))
-                    }
-                    value={bullet}
-                  />
-                  <Button
-                    onClick={() =>
-                      setProfile((prev) => ({
-                        ...prev,
-                        experience: prev.experience.map((item, itemIndex) =>
-                          itemIndex === index ? { ...item, bullets: item.bullets.filter((_, lineIndex) => lineIndex !== bulletIndex) } : item,
-                        ),
-                      }))
-                    }
-                    size="sm"
-                    type="button"
-                    variant="destructive"
-                  >
-                    Remove
-                  </Button>
+                  <input className="w-full rounded-md border border-border/60 bg-background px-3 py-2 text-sm" onChange={(event) => setProfile((prev) => ({ ...prev, experience: prev.experience.map((item, itemIndex) => itemIndex === index ? { ...item, bullets: item.bullets.map((line, lineIndex) => (lineIndex === bulletIndex ? event.target.value : line)) } : item) }))} value={bullet} />
+                  <Button onClick={() => setProfile((prev) => ({ ...prev, experience: prev.experience.map((item, itemIndex) => itemIndex === index ? { ...item, bullets: item.bullets.filter((_, lineIndex) => lineIndex !== bulletIndex) } : item) }))} size="sm" type="button" variant="destructive">Remove</Button>
                 </div>
               ))}
               <div className="flex gap-2">
-                <Button
-                  onClick={() =>
-                    setProfile((prev) => ({
-                      ...prev,
-                      experience: prev.experience.map((item, itemIndex) =>
-                        itemIndex === index ? { ...item, bullets: [...item.bullets, ""] } : item,
-                      ),
-                    }))
-                  }
-                  size="sm"
-                  type="button"
-                  variant="secondary"
-                >
-                  Add bullet
-                </Button>
-                <Button
-                  onClick={() =>
-                    setProfile((prev) => ({
-                      ...prev,
-                      experience: prev.experience.filter((_, itemIndex) => itemIndex !== index),
-                    }))
-                  }
-                  size="sm"
-                  type="button"
-                  variant="destructive"
-                >
-                  Remove experience
-                </Button>
+                <Button onClick={() => setProfile((prev) => ({ ...prev, experience: prev.experience.map((item, itemIndex) => itemIndex === index ? { ...item, bullets: [...item.bullets, ""] } : item) }))} size="sm" type="button" variant="secondary">Add bullet</Button>
+                <Button onClick={() => setProfile((prev) => ({ ...prev, experience: prev.experience.filter((_, itemIndex) => itemIndex !== index) }))} size="sm" type="button" variant="destructive">Remove experience</Button>
               </div>
             </div>
           ))}

--- a/ui/partner-hub/components/job-hunter/JobList.tsx
+++ b/ui/partner-hub/components/job-hunter/JobList.tsx
@@ -13,9 +13,11 @@ export type JobListRow = {
 
 type JobListProps = {
   rows: JobListRow[];
+  selectedJobIds: string[];
+  onToggleSelectedJob: (jobId: string) => void;
 };
 
-export function JobList({ rows }: JobListProps) {
+export function JobList({ rows, selectedJobIds, onToggleSelectedJob }: JobListProps) {
   return (
     <Card>
       <CardHeader>
@@ -30,12 +32,15 @@ export function JobList({ rows }: JobListProps) {
                 <th className="px-3 py-2 text-left font-medium">Company</th>
                 <th className="px-3 py-2 text-left font-medium">Location</th>
                 <th className="px-3 py-2 text-left font-medium">Fit</th>
+                <th className="px-3 py-2 text-left font-medium">Queue</th>
                 <th className="px-3 py-2 text-left font-medium">Posted</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border/60">
               {rows.map((row) => {
                 const { job } = row;
+                const selected = selectedJobIds.includes(job.id);
+
                 return (
                   <tr key={job.id}>
                     <td className="px-3 py-2">
@@ -61,6 +66,16 @@ export function JobList({ rows }: JobListProps) {
                             Excluded
                           </span>
                         ) : null}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2">
+                      <div className="flex flex-col items-start gap-2">
+                        <span className={`rounded-full px-2 py-0.5 text-xs ${selected ? "bg-blue-100 text-blue-800" : "bg-muted text-foreground/70"}`}>
+                          {selected ? "Selected" : "Not selected"}
+                        </span>
+                        <button className="text-xs text-blue-600 hover:underline" onClick={() => onToggleSelectedJob(job.id)} type="button">
+                          {selected ? "Remove from Apply Queue" : "Select for Apply"}
+                        </button>
                       </div>
                     </td>
                     <td className="px-3 py-2">{(job.postedAt ?? job.updatedAt).slice(0, 10)}</td>

--- a/ui/partner-hub/lib/job-hunter/applications.test.ts
+++ b/ui/partner-hub/lib/job-hunter/applications.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import {
   applicationReducer,
+  buildFollowUpEmail,
   createApplicationFromJob,
   exportApplicationsCsv,
   resolveApplicationJobDetails,
@@ -91,6 +92,29 @@ describe("job hunter application reducer", () => {
     assert.equal(details.missingLiveJob, true);
     assert.equal(details.title, "Product Manager");
     assert.equal(details.company, "Acme");
+  });
+
+
+  it("builds follow-up email with candidate identity", () => {
+    const email = buildFollowUpEmail(job, {
+      fullName: "James Wang",
+      email: "james@example.com",
+      phone: "555-0101",
+      cityState: "Austin, TX",
+      linkedinUrl: "https://linkedin.com/in/james",
+      websiteUrl: "",
+      workAuthorizationNote: "US Citizen",
+      signatureLine: "Sincerely,",
+      headline: "Staff Engineer",
+      summary: "Summary",
+      skills: [],
+      experience: [],
+      achievements: [],
+    });
+
+    assert.ok(email.includes("Sincerely,"));
+    assert.ok(email.includes("James Wang"));
+    assert.ok(!email.includes("[Your Name]"));
   });
 
   it("exports applications as csv", () => {

--- a/ui/partner-hub/lib/job-hunter/applications.ts
+++ b/ui/partner-hub/lib/job-hunter/applications.ts
@@ -1,4 +1,4 @@
-import type { Application, ApplicationStatus, ApplyChecklist, ApplicationJobSnapshot, JobPosting } from "./types";
+import type { Application, ApplicationStatus, ApplyChecklist, ApplicationJobSnapshot, JobPosting, ResumeProfile } from "./types";
 
 export const APPLICATION_STATUSES: ApplicationStatus[] = ["prepared", "applied", "interview", "rejected", "offer"];
 
@@ -28,8 +28,11 @@ export type ApplicationAction =
   | { type: "setChecklistItem"; jobId: string; item: ChecklistKey; value: boolean; now?: string }
   | { type: "ensureSnapshotFromJob"; jobId: string; job: JobPosting; now?: string };
 
-export const buildFollowUpEmail = (job: JobPosting) => {
-  return `Hi ${job.company} recruiting team,\n\nI applied for the ${job.title} role and wanted to follow up on next steps. I remain very interested in the position and would be happy to share any additional information.\n\nBest regards,\n[Your Name]`;
+export const buildFollowUpEmail = (job: JobPosting, profile?: ResumeProfile) => {
+  const signatureLine = profile?.signatureLine?.trim() || "Best regards,";
+  const signerName = profile?.fullName?.trim() || "Candidate";
+
+  return `Hi ${job.company} recruiting team,\n\nI applied for the ${job.title} role and wanted to follow up on next steps. I remain very interested in the position and would be happy to share any additional information.\n\n${signatureLine}\n${signerName}`;
 };
 
 export const buildAnswerPack = (job: JobPosting) => {

--- a/ui/partner-hub/lib/job-hunter/applyPacket.test.ts
+++ b/ui/partner-hub/lib/job-hunter/applyPacket.test.ts
@@ -3,7 +3,23 @@ import { describe, it } from "node:test";
 
 import { generateTailoringPacket } from "./resume/tailor";
 import { buildApplyPacket } from "./applyPacket";
-import type { JobPosting } from "./types";
+import type { JobPosting, ResumeProfile } from "./types";
+
+const profile: ResumeProfile = {
+  fullName: "James Wang",
+  email: "james@example.com",
+  phone: "555-0101",
+  cityState: "Austin, TX",
+  linkedinUrl: "https://linkedin.com/in/james",
+  websiteUrl: "",
+  workAuthorizationNote: "US Citizen",
+  signatureLine: "Best regards,",
+  headline: "Staff Engineer",
+  summary: "Built enterprise cloud solutions.",
+  skills: ["AWS", "Architecture"],
+  experience: [{ company: "Example", title: "Architect", bullets: ["Led platform modernization"] }],
+  achievements: ["Scaled migration program"],
+};
 
 describe("buildApplyPacket", () => {
   it("returns expected packet structure", () => {
@@ -16,19 +32,15 @@ describe("buildApplyPacket", () => {
       updatedAt: "2024-01-01T00:00:00.000Z",
     };
 
-    const tailoringPacket = generateTailoringPacket(job, {
-      summary: "Built enterprise cloud solutions.",
-      skills: ["AWS", "Architecture"],
-      experience: [{ company: "Example", title: "Architect", bullets: ["Led platform modernization"] }],
-      achievements: ["Scaled migration program"],
-    });
+    const tailoringPacket = generateTailoringPacket(job, profile);
 
-    const packet = buildApplyPacket(job, tailoringPacket);
+    const packet = buildApplyPacket(job, tailoringPacket, profile);
 
     assert.equal(packet.jobId, job.id);
     assert.ok(Date.parse(packet.generatedAt) > 0);
     assert.ok(packet.summaryMarkdown.includes("## Application Summary"));
     assert.ok(packet.fullPacketMarkdown.includes("# Job Hunter Apply Packet"));
+    assert.ok(packet.summaryMarkdown.includes("**Candidate:** James Wang"));
   });
 
   it("normalizes the output filename", () => {
@@ -41,14 +53,9 @@ describe("buildApplyPacket", () => {
       updatedAt: "2024-01-01T00:00:00.000Z",
     };
 
-    const tailoringPacket = generateTailoringPacket(job, {
-      summary: "Summary",
-      skills: ["Ops"],
-      experience: [{ company: "Example", title: "Engineer", bullets: ["Built systems"] }],
-      achievements: ["Improved reliability"],
-    });
+    const tailoringPacket = generateTailoringPacket(job, profile);
 
-    const packet = buildApplyPacket(job, tailoringPacket);
+    const packet = buildApplyPacket(job, tailoringPacket, profile);
 
     assert.equal(packet.fileBaseName, "munchen-sons-inc-staff-sre-platform-apply-packet");
   });
@@ -63,18 +70,15 @@ describe("buildApplyPacket", () => {
       updatedAt: "2024-01-01T00:00:00.000Z",
     };
 
-    const tailoringPacket = generateTailoringPacket(job, {
-      summary: "I help customers win with technical solutions.",
-      skills: ["Support"],
-      experience: [{ company: "Example", title: "Engineer", bullets: ["Delivered outcomes"] }],
-      achievements: ["Improved onboarding"],
-    });
+    const tailoringPacket = generateTailoringPacket(job, profile);
 
-    const packet = buildApplyPacket(job, tailoringPacket);
+    const packet = buildApplyPacket(job, tailoringPacket, profile);
 
     assert.ok(packet.coverLetterMarkdown.includes("Dear Hiring Team"));
     assert.ok(packet.screenerAnswersText.includes("Why are you interested in this role?"));
     assert.ok(packet.followUpEmailText.includes("wanted to follow up on next steps"));
+    assert.ok(packet.followUpEmailText.includes("James Wang"));
+    assert.ok(!packet.followUpEmailText.includes("[Your Name]"));
     assert.ok(packet.fullPacketMarkdown.includes("## Cover Letter"));
     assert.ok(packet.fullPacketMarkdown.includes("## Screener Answers"));
     assert.ok(packet.fullPacketMarkdown.includes("## Follow-up Email"));

--- a/ui/partner-hub/lib/job-hunter/applyPacket.ts
+++ b/ui/partner-hub/lib/job-hunter/applyPacket.ts
@@ -1,6 +1,6 @@
 import { buildFollowUpEmail } from "./applications";
 import type { TailoringPacket } from "./resume/tailor";
-import type { JobPosting } from "./types";
+import type { JobPosting, ResumeProfile } from "./types";
 
 export type ApplyPacket = {
   jobId: string;
@@ -25,12 +25,14 @@ const normalizeForFileName = (value: string) => {
   return normalized || "untitled";
 };
 
-const buildSummaryMarkdown = (job: JobPosting, tailoringPacket: TailoringPacket, generatedAt: string) => {
+const buildSummaryMarkdown = (job: JobPosting, tailoringPacket: TailoringPacket, generatedAt: string, profile?: ResumeProfile) => {
+  const candidateName = profile?.fullName?.trim() || "Candidate";
   return [
     "## Application Summary",
     `- **Role:** ${job.title}`,
     `- **Company:** ${job.company}`,
     `- **Job ID:** ${job.id}`,
+    `- **Candidate:** ${candidateName}`,
     `- **Generated:** ${generatedAt}`,
     "",
     "### Tailored Snapshot",
@@ -47,13 +49,13 @@ const buildScreenerAnswersText = (tailoringPacket: TailoringPacket) => {
     .join("\n\n");
 };
 
-export const buildApplyPacket = (job: JobPosting, tailoringPacket: TailoringPacket): ApplyPacket => {
+export const buildApplyPacket = (job: JobPosting, tailoringPacket: TailoringPacket, profile?: ResumeProfile): ApplyPacket => {
   const generatedAt = new Date().toISOString();
   const fileBaseName = `${normalizeForFileName(job.company)}-${normalizeForFileName(job.title)}-apply-packet`;
-  const summaryMarkdown = buildSummaryMarkdown(job, tailoringPacket, generatedAt);
+  const summaryMarkdown = buildSummaryMarkdown(job, tailoringPacket, generatedAt, profile);
   const coverLetterMarkdown = tailoringPacket.coverLetterDraft;
   const screenerAnswersText = buildScreenerAnswersText(tailoringPacket);
-  const followUpEmailText = buildFollowUpEmail(job);
+  const followUpEmailText = buildFollowUpEmail(job, profile);
 
   const fullPacketMarkdown = [
     "# Job Hunter Apply Packet",
@@ -61,6 +63,9 @@ export const buildApplyPacket = (job: JobPosting, tailoringPacket: TailoringPack
     `- **Company:** ${job.company}`,
     `- **Title:** ${job.title}`,
     `- **Job ID:** ${job.id}`,
+    `- **Candidate:** ${profile?.fullName?.trim() || "Candidate"}`,
+    `- **Email:** ${profile?.email?.trim() || "(not set)"}`,
+    `- **Phone:** ${profile?.phone?.trim() || "(not set)"}`,
     `- **Generated At:** ${generatedAt}`,
     "",
     summaryMarkdown,

--- a/ui/partner-hub/lib/job-hunter/queue.test.ts
+++ b/ui/partner-hub/lib/job-hunter/queue.test.ts
@@ -1,0 +1,19 @@
+import * as assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { isJobSelected, toggleJobSelection } from "./queue";
+
+describe("job apply queue helpers", () => {
+  it("adds missing jobs to the selected queue", () => {
+    assert.deepEqual(toggleJobSelection(["job-1"], "job-2"), ["job-1", "job-2"]);
+  });
+
+  it("removes existing jobs from the selected queue", () => {
+    assert.deepEqual(toggleJobSelection(["job-1", "job-2"], "job-2"), ["job-1"]);
+  });
+
+  it("checks selected state", () => {
+    assert.equal(isJobSelected(["job-1"], "job-1"), true);
+    assert.equal(isJobSelected(["job-1"], "job-2"), false);
+  });
+});

--- a/ui/partner-hub/lib/job-hunter/queue.ts
+++ b/ui/partner-hub/lib/job-hunter/queue.ts
@@ -1,0 +1,11 @@
+export const toggleJobSelection = (selectedJobIds: string[], jobId: string): string[] => {
+  const cleanIds = Array.from(new Set(selectedJobIds.filter((id) => typeof id === "string" && id.trim().length > 0)));
+
+  if (cleanIds.includes(jobId)) {
+    return cleanIds.filter((id) => id !== jobId);
+  }
+
+  return [...cleanIds, jobId];
+};
+
+export const isJobSelected = (selectedJobIds: string[], jobId: string) => selectedJobIds.includes(jobId);

--- a/ui/partner-hub/lib/job-hunter/resume/tailor.test.ts
+++ b/ui/partner-hub/lib/job-hunter/resume/tailor.test.ts
@@ -67,6 +67,15 @@ describe("generateTailoringPacket", () => {
     };
 
     const packet = generateTailoringPacket(job, {
+      fullName: "James Wang",
+      email: "james@example.com",
+      phone: "555-0101",
+      cityState: "Austin, TX",
+      linkedinUrl: "https://linkedin.com/in/james",
+      websiteUrl: "",
+      workAuthorizationNote: "US Citizen",
+      signatureLine: "Best regards,",
+      headline: "Staff Engineer",
       summary: "Profile summary",
       skills: ["Cloud"],
       experience: [{ company: "Acme", title: "Architect", bullets: ["Built platform"] }],

--- a/ui/partner-hub/lib/job-hunter/resumeProfile.test.ts
+++ b/ui/partner-hub/lib/job-hunter/resumeProfile.test.ts
@@ -11,31 +11,67 @@ describe("resumeProfile helpers", () => {
     assert.equal(profile.summary, masterResume.summary);
     assert.deepEqual(profile.skills, masterResume.skills);
     assert.equal(profile.experience[0]?.title, masterResume.experience[0]?.role);
+    assert.equal(profile.fullName, "");
+    assert.equal(profile.email, "");
   });
 
   it("normalizes arrays and filters blank entries", () => {
     const normalized = normalizeResumeProfile({
+      fullName: " James Wang ",
+      email: " james@example.com ",
+      phone: " 555-0101 ",
+      cityState: " Austin, TX ",
+      linkedinUrl: " https://linkedin.com/in/james ",
+      websiteUrl: " https://james.dev ",
+      workAuthorizationNote: " US Citizen ",
+      signatureLine: " Best regards, ",
+      headline: " Staff Engineer ",
       summary: "  Profile summary  ",
       skills: [" Architecture ", "", "  "],
       experience: [{ company: " Acme ", title: " SA ", bullets: [" Led delivery ", " "] }, { nope: true }],
       achievements: [" Won awards ", ""],
     });
 
+    assert.equal(normalized.fullName, "James Wang");
+    assert.equal(normalized.headline, "Staff Engineer");
     assert.equal(normalized.summary, "Profile summary");
     assert.deepEqual(normalized.skills, ["Architecture"]);
     assert.deepEqual(normalized.experience, [{ company: "Acme", title: "SA", bullets: ["Led delivery"], start: undefined, end: undefined }]);
     assert.deepEqual(normalized.achievements, ["Won awards"]);
   });
 
+  it("hydrates missing identity fields from legacy profile safely", () => {
+    const normalized = normalizeResumeProfile({
+      summary: "Legacy summary",
+      skills: ["Communication"],
+      experience: [],
+      achievements: [],
+    });
+
+    assert.equal(normalized.fullName, "");
+    assert.equal(normalized.signatureLine, "");
+    assert.equal(normalized.summary, "Legacy summary");
+  });
+
   it("renders profile markdown", () => {
     const markdown = resumeProfileToMarkdown({
+      fullName: "James Wang",
+      email: "james@example.com",
+      phone: "555-0101",
+      cityState: "Austin, TX",
+      linkedinUrl: "https://linkedin.com/in/james",
+      websiteUrl: "",
+      workAuthorizationNote: "US Citizen",
+      signatureLine: "Best regards,",
+      headline: "Staff Engineer",
       summary: "Summary",
       skills: ["Skill A"],
       experience: [{ company: "Acme", title: "Architect", start: "2020", end: "2023", bullets: ["Built platform"] }],
       achievements: ["Achievement A"],
     });
 
-    assert.ok(markdown.includes("# Resume Profile"));
+    assert.ok(markdown.includes("## Identity"));
+    assert.ok(markdown.includes("James Wang"));
     assert.ok(markdown.includes("## Experience"));
     assert.ok(markdown.includes("Built platform"));
   });

--- a/ui/partner-hub/lib/job-hunter/resumeProfile.ts
+++ b/ui/partner-hub/lib/job-hunter/resumeProfile.ts
@@ -1,6 +1,8 @@
 import { masterResume } from "./resume/masterResume";
 import type { ResumeExperience, ResumeProfile } from "./types";
 
+const normalizeString = (input: unknown) => (typeof input === "string" ? input.trim() : "");
+
 const normalizeStringArray = (input: unknown): string[] => {
   if (!Array.isArray(input)) {
     return [];
@@ -30,6 +32,15 @@ const normalizeResumeExperience = (input: unknown): ResumeExperience[] => {
 };
 
 export const getDefaultResumeProfile = (): ResumeProfile => ({
+  fullName: "",
+  email: "",
+  phone: "",
+  cityState: "",
+  linkedinUrl: "",
+  websiteUrl: "",
+  workAuthorizationNote: "",
+  signatureLine: "",
+  headline: "",
   summary: masterResume.summary,
   skills: [...masterResume.skills],
   experience: masterResume.experience.map((experience) => ({
@@ -50,6 +61,15 @@ export const normalizeResumeProfile = (input: unknown): ResumeProfile => {
   const partial = input as Partial<ResumeProfile>;
 
   return {
+    fullName: normalizeString(partial.fullName),
+    email: normalizeString(partial.email),
+    phone: normalizeString(partial.phone),
+    cityState: normalizeString(partial.cityState),
+    linkedinUrl: normalizeString(partial.linkedinUrl),
+    websiteUrl: normalizeString(partial.websiteUrl),
+    workAuthorizationNote: normalizeString(partial.workAuthorizationNote),
+    signatureLine: normalizeString(partial.signatureLine),
+    headline: normalizeString(partial.headline),
     summary: typeof partial.summary === "string" && partial.summary.trim().length > 0 ? partial.summary.trim() : defaults.summary,
     skills: normalizeStringArray(partial.skills),
     experience: normalizeResumeExperience(partial.experience),
@@ -64,6 +84,17 @@ export const resumeProfileToMarkdown = (profile: ResumeProfile): string => {
 
   return [
     "# Resume Profile",
+    "",
+    "## Identity",
+    `- Name: ${normalized.fullName || "(not set)"}`,
+    `- Headline: ${normalized.headline || "(not set)"}`,
+    `- Email: ${normalized.email || "(not set)"}`,
+    `- Phone: ${normalized.phone || "(not set)"}`,
+    `- Location: ${normalized.cityState || "(not set)"}`,
+    `- LinkedIn: ${normalized.linkedinUrl || "(not set)"}`,
+    `- Website: ${normalized.websiteUrl || "(not set)"}`,
+    `- Work Authorization: ${normalized.workAuthorizationNote || "(not set)"}`,
+    `- Signature Line: ${normalized.signatureLine || "(not set)"}`,
     "",
     "## Summary",
     normalized.summary,

--- a/ui/partner-hub/lib/job-hunter/storage.test.ts
+++ b/ui/partner-hub/lib/job-hunter/storage.test.ts
@@ -120,8 +120,18 @@ describe("job hunter storage", () => {
       jobsById: {},
       applications: [],
       applicationsById: {},
+      selectedJobIds: ["job-1"],
       sources: [{ company: "Acme", boardType: "greenhouse", boardToken: "acme" }],
       resumeProfile: {
+        fullName: "James Wang",
+        email: "james@example.com",
+        phone: "555-0101",
+        cityState: "Austin, TX",
+        linkedinUrl: "https://linkedin.com/in/james",
+        websiteUrl: "",
+        workAuthorizationNote: "US Citizen",
+        signatureLine: "Best regards,",
+        headline: "Staff Engineer",
         summary: "Summary",
         skills: ["Architecture"],
         experience: [{ company: "Acme", title: "SA", bullets: ["Led implementation"] }],
@@ -133,6 +143,7 @@ describe("job hunter storage", () => {
     assert.equal(loaded.sources.length, 1);
     assert.deepEqual(loaded.sources[0], { company: "Acme", boardType: "greenhouse", boardToken: "acme" });
     assert.equal(loaded.resumeProfile?.summary, "Summary");
+    assert.deepEqual(loaded.selectedJobIds, ["job-1"]);
 
     Object.defineProperty(globalThis, "window", {
       value: previousWindow,
@@ -156,6 +167,7 @@ describe("job hunter storage", () => {
       jobsById: {},
       applications: [],
       applicationsById: {},
+      selectedJobIds: [],
       sources: [],
       preferences: {
         targetRoles: ["  Solutions Architect  ", ""],
@@ -208,6 +220,38 @@ describe("job hunter storage", () => {
 
     const loaded = loadJobHunterStore();
     assert.deepEqual(loaded.preferences, getDefaultPreferences());
+
+    Object.defineProperty(globalThis, "window", {
+      value: previousWindow,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+
+  it("hydrates selected queue safely", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      JOB_HUNTER_STORAGE_KEY,
+      JSON.stringify({
+        jobsById: {},
+        jobs: [],
+        selectedJobIds: ["job-1", "job-1", "", 42],
+        sources: [],
+        applications: [],
+        applicationsById: {},
+      }),
+    );
+
+    const previousWindow = globalThis.window;
+    Object.defineProperty(globalThis, "window", {
+      value: { localStorage: storage },
+      configurable: true,
+      writable: true,
+    });
+
+    const loaded = loadJobHunterStore();
+    assert.deepEqual(loaded.selectedJobIds, ["job-1"]);
 
     Object.defineProperty(globalThis, "window", {
       value: previousWindow,

--- a/ui/partner-hub/lib/job-hunter/storage.ts
+++ b/ui/partner-hub/lib/job-hunter/storage.ts
@@ -8,6 +8,7 @@ export const JOB_HUNTER_STORAGE_KEY = "partner-hub:job-hunter:v1";
 const DEFAULT_STORE: JobHunterStore = {
   jobs: [],
   jobsById: {},
+  selectedJobIds: [],
   sources: [],
   applications: [],
   applicationsById: {},
@@ -15,6 +16,14 @@ const DEFAULT_STORE: JobHunterStore = {
 };
 
 const BOARD_TYPES: BoardType[] = ["greenhouse", "lever"];
+
+const normalizeSelectedJobIds = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return Array.from(new Set(value.filter((item): item is string => typeof item === "string" && item.trim().length > 0)));
+};
 
 const normalizeChecklist = (value: unknown): ApplyChecklist => {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -123,6 +132,7 @@ export const loadJobHunterStore = (): JobHunterStore => {
     return {
       jobs,
       jobsById,
+      selectedJobIds: normalizeSelectedJobIds(parsed.selectedJobIds),
       sources: validateJobSources(parsed.sources),
       lastSyncedAt: typeof parsed.lastSyncedAt === "string" ? parsed.lastSyncedAt : undefined,
       applications,

--- a/ui/partner-hub/lib/job-hunter/types.ts
+++ b/ui/partner-hub/lib/job-hunter/types.ts
@@ -72,6 +72,15 @@ export type ResumeExperience = {
 };
 
 export type ResumeProfile = {
+  fullName: string;
+  email: string;
+  phone: string;
+  cityState: string;
+  linkedinUrl: string;
+  websiteUrl?: string;
+  workAuthorizationNote: string;
+  signatureLine: string;
+  headline?: string;
   summary: string;
   skills: string[];
   experience: ResumeExperience[];
@@ -92,6 +101,7 @@ export type JobHunterPreferences = {
 export type JobHunterStore = {
   jobs: JobPosting[];
   jobsById: Record<string, JobPosting>;
+  selectedJobIds: string[];
   sources: JobSourceConfig[];
   lastSyncedAt?: string;
   applications: Application[];


### PR DESCRIPTION
### Motivation
- Introduce a persistent, simple selected-for-apply queue so jobs the user wants to pursue can be tracked independently of application status.
- Add a practical candidate identity/contact model so generated follow-ups and apply artifacts use real profile data instead of placeholders.
- Keep the change foundation-only and backward-compatible to enable later tailoring/automation work without touching server/auth or external automation.

### Description
- Add identity/contact fields to `ResumeProfile` (`fullName`, `email`, `phone`, `cityState`, `linkedinUrl`, optional `websiteUrl`, `workAuthorizationNote`, `signatureLine`, optional `headline`) and keep sensible default empty-string hydration in `normalizeResumeProfile` and `getDefaultResumeProfile` (`ui/partner-hub/lib/job-hunter/types.ts`, `resumeProfile.ts`).
- Add `selectedJobIds: string[]` to the persisted `JobHunterStore`, safe normalization and hydration helpers in storage, and persist/save behavior (`ui/partner-hub/lib/job-hunter/storage.ts`).
- Add pure queue helpers `toggleJobSelection` and `isJobSelected` plus deterministic tests for toggle/selected state (`ui/partner-hub/lib/job-hunter/queue.ts`, `queue.test.ts`).
- Update Jobs UI and `JobList` to show per-row “Select for Apply / Remove from Apply Queue” actions, a compact Selected indicator, and a top-level “Apply Queue” section listing selected roles while preserving existing ranking/filter behavior (`ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx`, `ui/partner-hub/components/job-hunter/JobList.tsx`).
- Extend Resume page UI with editable identity/contact fields while leaving summary/skills/experience/achievements editing intact (`ui/partner-hub/app/(routes)/job-hunter/resume/page.tsx`).
- Rework follow-up and apply packet generation to consume the stored `ResumeProfile` so follow-up emails and apply packets use the real candidate signature/name and include basic contact metadata, without redesigning the tailoring engine (`buildFollowUpEmail`, `buildApplyPacket`, and wiring in job workspace) (`ui/partner-hub/lib/job-hunter/applications.ts`, `applyPacket.ts`, `app/(routes)/job-hunter/jobs/[jobId]/page.tsx`).
- Make small Applications page UX improvements to surface whether a tracked application/job is in the apply queue or already applied, and update copy actions to use the resume profile when present (`ui/partner-hub/app/(routes)/job-hunter/applications/page.tsx`).
- Add/update unit tests covering resume profile normalization/back-compat, queue toggle behavior, and identity usage in follow-up/apply packet outputs and storage hydration (`*.test.ts`).

### Testing
- Ran lint with `cd ui/partner-hub && npm run lint` and received no ESLint warnings or errors (`✔ No ESLint warnings or errors`).
- Ran type checking with `cd ui/partner-hub && npm run typecheck` which executed `tsc --noEmit` with no reported errors.
- Ran the test suite with `cd ui/partner-hub && npm run test` and all tests passed: test summary shows `# tests 90`, `# pass 90`, and `# fail 0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0629f61088330809e93282a09d05f)