### PR TITLE
Use candidate identity in Job Hunter tailoring outputs

### DIFF
--- a/ui/partner-hub/lib/job-hunter/resume/tailor.test.ts
+++ b/ui/partner-hub/lib/job-hunter/resume/tailor.test.ts
@@ -83,7 +83,38 @@ describe("generateTailoringPacket", () => {
     });
 
     assert.ok(packet.tailoredSummary.includes("Profile summary"));
+    assert.ok(packet.coverLetterDraft.includes("Best regards,"));
+    assert.ok(packet.coverLetterDraft.includes("James Wang"));
+  });
+
+  it("falls back to default signature and signer when resume profile identity is blank", () => {
+    const job: JobPosting = {
+      id: "greenhouse:empty-profile",
+      title: "Solutions Architect",
+      company: "Acme",
+      source: "company-site",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-02T00:00:00.000Z",
+    };
+
+    const packet = generateTailoringPacket(job, {
+      fullName: "   ",
+      email: "james@example.com",
+      phone: "555-0101",
+      cityState: "Austin, TX",
+      linkedinUrl: "https://linkedin.com/in/james",
+      websiteUrl: "",
+      workAuthorizationNote: "US Citizen",
+      signatureLine: "   ",
+      headline: "Staff Engineer",
+      summary: "Profile summary",
+      skills: ["Cloud"],
+      experience: [{ company: "Acme", title: "Architect", bullets: ["Built platform"] }],
+      achievements: ["Led migration"],
+    });
+
     assert.ok(packet.coverLetterDraft.includes("Sincerely,"));
+    assert.ok(packet.coverLetterDraft.includes("Candidate"));
   });
 
   it("uses posting snapshot notes in tailored outputs", () => {

--- a/ui/partner-hub/lib/job-hunter/resume/tailor.ts
+++ b/ui/partner-hub/lib/job-hunter/resume/tailor.ts
@@ -35,6 +35,7 @@ const toSnapshot = (value: string | undefined, max = 220) => {
 type TailoringResume = {
   summary: string;
   achievements: string[];
+  signatureLine: string;
   signer: string;
 };
 
@@ -43,6 +44,7 @@ const toTailoringResume = (resume: MasterResume | ResumeProfile): TailoringResum
     return {
       summary: resume.summary,
       achievements: resume.achievements,
+      signatureLine: "Sincerely,",
       signer: resume.name,
     };
   }
@@ -51,7 +53,8 @@ const toTailoringResume = (resume: MasterResume | ResumeProfile): TailoringResum
   return {
     summary: normalized.summary,
     achievements: normalized.achievements,
-    signer: "Candidate",
+    signatureLine: normalized.signatureLine || "Sincerely,",
+    signer: normalized.fullName || "Candidate",
   };
 };
 
@@ -67,7 +70,7 @@ const buildCoverLetter = (resume: TailoringResume, job: JobPosting, matchedKeywo
     "",
     "Thank you for your consideration. I would welcome the opportunity to discuss how I can help your team accelerate customer success.",
     "",
-    `Sincerely,`,
+    resume.signatureLine,
     resume.signer,
   ].join("\n");
 };


### PR DESCRIPTION
### Motivation
- Finish Prompt 1 follow-up so Tailor/cover-letter outputs use the real candidate identity/signature from `ResumeProfile` rather than the generic fallback when a profile is present.

### Description
- Update `toTailoringResume` in `ui/partner-hub/lib/job-hunter/resume/tailor.ts` to populate `signer` from `normalized.fullName` with fallback to `"Candidate"` and to include `signatureLine` (fallback `"Sincerely,"`).
- Change cover letter rendering to use the resolved `resume.signatureLine` instead of a hardcoded closing, while preserving `MasterResume` behavior.
- Add deterministic tests in `ui/partner-hub/lib/job-hunter/resume/tailor.test.ts` to assert use of `fullName` and `signatureLine`, and to verify fallback behavior when identity/signature fields are blank.
- No changes to scoring, schemas, UI routes, or other systems were made.

### Testing
- Ran `cd ui/partner-hub && npm run lint` which completed successfully with no ESLint warnings or errors.
- Ran `cd ui/partner-hub && npm run typecheck` which completed successfully with no TypeScript errors.
- Ran `cd ui/partner-hub && npm run test` which completed successfully with all tests passing: `# tests 91`, `# pass 91`, `# fail 0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b068425e98833098fe5ea96f8cc58b)