### PR TITLE
Add guided Job Hunter apply automation workflow

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/applications/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/applications/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -12,10 +12,34 @@ import {
   buildFollowUpEmail,
   createApplicationFromJob,
   exportApplicationsCsv,
+  getApplicationQueueStage,
+  getApplicationWorkflow,
   resolveApplicationJobDetails,
 } from "@/lib/job-hunter/applications";
 import { loadJobHunterStore, saveJobHunterStore } from "@/lib/job-hunter/storage";
-import type { ApplicationStatus, JobPosting } from "@/lib/job-hunter/types";
+import type { Application, ApplicationStatus, JobPosting } from "@/lib/job-hunter/types";
+
+const PIPELINE_COLUMNS = [
+  { key: "selected", label: "Selected" },
+  { key: "prepared", label: "Ready to Apply" },
+  { key: "in-progress", label: "In Progress" },
+  { key: "applied", label: "Applied" },
+  { key: "interview", label: "Interview" },
+  { key: "offer", label: "Offer" },
+  { key: "rejected", label: "Rejected" },
+] as const;
+
+const matchesColumn = (application: Application, column: (typeof PIPELINE_COLUMNS)[number]["key"]) => {
+  if (column === "interview" || column === "offer" || column === "rejected") {
+    return application.status === column;
+  }
+
+  if (column === "applied") {
+    return application.status === "applied";
+  }
+
+  return getApplicationQueueStage(application) === column;
+};
 
 const copyText = async (value: string) => {
   await navigator.clipboard.writeText(value);
@@ -51,6 +75,25 @@ export default function JobHunterApplicationsPage() {
       applications: Object.values(next),
     });
   };
+
+  useEffect(() => {
+    let next = applicationsById;
+    let changed = false;
+
+    selectedJobIds.forEach((jobId) => {
+      if (!next[jobId] || getApplicationWorkflow(next[jobId]).selectedForApply) {
+        return;
+      }
+
+      next = applicationReducer(next, { type: "setWorkflowItem", jobId, item: "selectedForApply", value: true });
+      changed = true;
+    });
+
+    if (changed) {
+      save(next);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [applicationsById, selectedJobIds]);
 
   const setStatus = (jobId: string, status: ApplicationStatus) => {
     const job = jobsById[jobId];
@@ -90,18 +133,19 @@ export default function JobHunterApplicationsPage() {
 
       {message ? <p className="text-sm text-emerald-700">{message}</p> : null}
 
-      <section className="grid gap-4 lg:grid-cols-5">
-        {APPLICATION_STATUSES.map((status) => {
+      <section className="grid gap-4 lg:grid-cols-7">
+        {PIPELINE_COLUMNS.map((column) => {
           const items = applications
-            .filter((application) => application.status === status)
+            .filter((application) => matchesColumn(application, column.key))
             .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
 
           return (
-            <div className="space-y-3 rounded-lg border border-border/60 bg-muted/10 p-3" key={status}>
-              <h2 className="text-sm font-semibold">{STATUS_LABELS[status]}</h2>
+            <div className="space-y-3 rounded-lg border border-border/60 bg-muted/10 p-3" key={column.key}>
+              <h2 className="text-sm font-semibold">{column.label}</h2>
               {items.map((application) => {
                 const job = jobsById[application.jobId];
                 const jobDetails = resolveApplicationJobDetails(application, jobsById);
+                const workflow = getApplicationWorkflow(application);
 
                 return (
                   <article className="space-y-2 rounded-md border border-border/60 bg-background p-3" key={application.id}>
@@ -117,6 +161,9 @@ export default function JobHunterApplicationsPage() {
                     <div className="flex flex-wrap items-center gap-2 text-xs">
                       {selectedJobIds.includes(application.jobId) ? (
                         <span className="rounded-full bg-blue-100 px-2 py-0.5 text-blue-800">In apply queue</span>
+                      ) : null}
+                      {workflow.finalExternalSubmitConfirmed ? (
+                        <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-emerald-800">Submission confirmed</span>
                       ) : null}
                       {application.status === "applied" ? (
                         <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-emerald-800">Applied</span>
@@ -157,10 +204,11 @@ export default function JobHunterApplicationsPage() {
                     </div>
 
                     <div className="flex flex-wrap gap-2">
-                      <Button onClick={() => setStatus(application.jobId, "applied")} size="sm" type="button" variant="ghost">Mark applied</Button>
-                      <Button onClick={() => setStatus(application.jobId, "interview")} size="sm" type="button" variant="ghost">Interview</Button>
-                      <Button onClick={() => setStatus(application.jobId, "offer")} size="sm" type="button" variant="ghost">Offer</Button>
-                      <Button onClick={() => setStatus(application.jobId, "rejected")} size="sm" type="button" variant="ghost">Reject</Button>
+                      {APPLICATION_STATUSES.map((status) => (
+                        <Button key={status} onClick={() => setStatus(application.jobId, status)} size="sm" type="button" variant="ghost">
+                          {STATUS_LABELS[status]}
+                        </Button>
+                      ))}
                     </div>
 
                     <label className="block text-xs text-foreground/70">

--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
@@ -6,8 +6,8 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { EmptyState } from "@/components/job-hunter/EmptyState";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { applicationReducer, createApplicationFromJob, getApplicationChecklist } from "@/lib/job-hunter/applications";
-import { buildApplyPacket } from "@/lib/job-hunter/applyPacket";
+import { applicationReducer, createApplicationFromJob, getApplicationChecklist, getApplicationWorkflow } from "@/lib/job-hunter/applications";
+import { buildApplyPacket, buildApplyPrepItems } from "@/lib/job-hunter/applyPacket";
 import { normalizePreferences } from "@/lib/job-hunter/preferences";
 import { masterResume } from "@/lib/job-hunter/resume/masterResume";
 import { generateTailoringPacket } from "@/lib/job-hunter/resume/tailor";
@@ -42,6 +42,13 @@ export default function JobDetailPage({ params }: PageProps) {
   );
   const application = job ? applicationById[job.id] : undefined;
   const checklist = application ? getApplicationChecklist(application) : null;
+  const workflow = application ? getApplicationWorkflow(application) : null;
+  const prepItems = useMemo(() => {
+    if (!job || !applyPacket || !tailoringPacket) {
+      return [];
+    }
+    return buildApplyPrepItems(job, applyPacket, tailoringPacket, store.resumeProfile);
+  }, [applyPacket, job, store.resumeProfile, tailoringPacket]);
 
   const saveApplications = useCallback((next: typeof applicationById) => {
     setApplicationById(next);
@@ -70,6 +77,14 @@ export default function JobDetailPage({ params }: PageProps) {
       [job.id]: createApplicationFromJob(job, new Date().toISOString()),
     });
   }, [applicationById, job, saveApplications]);
+
+  useEffect(() => {
+    if (!job || !store.selectedJobIds.includes(job.id) || workflow?.selectedForApply) {
+      return;
+    }
+
+    saveApplications(applicationReducer(applicationById, { type: "setWorkflowItem", jobId: job.id, item: "selectedForApply", value: true }));
+  }, [applicationById, job, saveApplications, store.selectedJobIds, workflow?.selectedForApply]);
 
   const handleDownloadMarkdown = () => {
     if (!tailoringPacket || !job) {
@@ -132,9 +147,9 @@ export default function JobDetailPage({ params }: PageProps) {
     void navigator.clipboard.writeText(text);
   };
 
-  const setChecklistItem = (item: keyof NonNullable<typeof checklist>, value: boolean) => {
+  const setWorkflowItem = (item: keyof NonNullable<typeof workflow>, value: boolean) => {
     if (!job) return;
-    saveApplications(applicationReducer(applicationById, { type: "setChecklistItem", jobId: job.id, item, value }));
+    saveApplications(applicationReducer(applicationById, { type: "setWorkflowItem", jobId: job.id, item, value }));
   };
 
   const setNotes = (notes: string) => {
@@ -144,7 +159,13 @@ export default function JobDetailPage({ params }: PageProps) {
 
   const markApplied = () => {
     if (!job) return;
-    const withSnapshot = applicationReducer(applicationById, { type: "ensureSnapshotFromJob", jobId: job.id, job });
+    const withWorkflow = applicationReducer(applicationById, {
+      type: "setWorkflowItem",
+      jobId: job.id,
+      item: "finalExternalSubmitConfirmed",
+      value: true,
+    });
+    const withSnapshot = applicationReducer(withWorkflow, { type: "ensureSnapshotFromJob", jobId: job.id, job });
     const withApplied = applicationReducer(withSnapshot, { type: "setStatus", jobId: job.id, status: "applied" });
     saveApplications(withApplied);
     setWorkspaceMessage("Application marked as applied and snapshot saved.");
@@ -271,16 +292,48 @@ export default function JobDetailPage({ params }: PageProps) {
               <Button onClick={() => copyText(applyPacket.screenerAnswersText)} size="sm" type="button" variant="secondary">Copy Screener Answers</Button>
             </div>
 
+            <section className="space-y-2 rounded-md border border-border/60 p-3">
+              <h3 className="font-medium">Quick apply prep actions</h3>
+              <div className="grid gap-2 md:grid-cols-2">
+                {prepItems.map((item) => (
+                  <Button key={item.key} onClick={() => copyText(item.value)} size="sm" type="button" variant="secondary">
+                    Copy {item.label}
+                  </Button>
+                ))}
+                {job.sourceUrl ? (
+                  <Button
+                    onClick={() => {
+                      window.open(job.sourceUrl, "_blank", "noopener,noreferrer");
+                      setWorkflowItem("externalApplicationOpened", true);
+                    }}
+                    size="sm"
+                    type="button"
+                  >
+                    Open external application
+                  </Button>
+                ) : null}
+              </div>
+            </section>
+
             <section className="space-y-3 rounded-md border border-border/60 p-3">
-              <h3 className="font-medium">Apply Checklist</h3>
-              {checklist ? (
+              <h3 className="font-medium">Guided apply workflow</h3>
+              {workflow ? (
                 <div className="grid gap-2 md:grid-cols-2">
-                  <label className="flex items-center gap-2"><input checked={checklist.resumeReviewed} onChange={(e) => setChecklistItem("resumeReviewed", e.target.checked)} type="checkbox" />Resume reviewed</label>
-                  <label className="flex items-center gap-2"><input checked={checklist.coverLetterReviewed} onChange={(e) => setChecklistItem("coverLetterReviewed", e.target.checked)} type="checkbox" />Cover letter reviewed</label>
-                  <label className="flex items-center gap-2"><input checked={checklist.screenerAnswersReviewed} onChange={(e) => setChecklistItem("screenerAnswersReviewed", e.target.checked)} type="checkbox" />Screener answers reviewed</label>
-                  <label className="flex items-center gap-2"><input checked={checklist.appliedExternally} onChange={(e) => setChecklistItem("appliedExternally", e.target.checked)} type="checkbox" />Applied externally</label>
-                  <label className="flex items-center gap-2"><input checked={checklist.followUpScheduled} onChange={(e) => setChecklistItem("followUpScheduled", e.target.checked)} type="checkbox" />Follow-up scheduled</label>
+                  <label className="flex items-center gap-2"><input checked={workflow.selectedForApply} onChange={(e) => setWorkflowItem("selectedForApply", e.target.checked)} type="checkbox" />Selected for apply</label>
+                  <label className="flex items-center gap-2"><input checked={workflow.tailoredResumeReady} onChange={(e) => setWorkflowItem("tailoredResumeReady", e.target.checked)} type="checkbox" />Tailored resume ready</label>
+                  <label className="flex items-center gap-2"><input checked={workflow.coverLetterReady} onChange={(e) => setWorkflowItem("coverLetterReady", e.target.checked)} type="checkbox" />Cover letter ready</label>
+                  <label className="flex items-center gap-2"><input checked={workflow.screenerAnswersReady} onChange={(e) => setWorkflowItem("screenerAnswersReady", e.target.checked)} type="checkbox" />Screener answers ready</label>
+                  <label className="flex items-center gap-2"><input checked={workflow.externalApplicationOpened} onChange={(e) => setWorkflowItem("externalApplicationOpened", e.target.checked)} type="checkbox" />External application opened</label>
+                  <label className="flex items-center gap-2"><input checked={workflow.tailoredResumeUploaded} onChange={(e) => setWorkflowItem("tailoredResumeUploaded", e.target.checked)} type="checkbox" />Tailored resume uploaded</label>
+                  <label className="flex items-center gap-2"><input checked={workflow.customQuestionsCompleted} onChange={(e) => setWorkflowItem("customQuestionsCompleted", e.target.checked)} type="checkbox" />Custom questions completed</label>
+                  <label className="flex items-center gap-2"><input checked={workflow.finalExternalSubmitConfirmed} onChange={(e) => setWorkflowItem("finalExternalSubmitConfirmed", e.target.checked)} type="checkbox" />Final external submit confirmed</label>
+                  <label className="flex items-center gap-2"><input checked={workflow.followUpScheduled} onChange={(e) => setWorkflowItem("followUpScheduled", e.target.checked)} type="checkbox" />Follow-up scheduled</label>
                 </div>
+              ) : null}
+              {checklist ? (
+                <p className="text-xs text-foreground/70">
+                  Legacy checklist mirror: resume {String(checklist.resumeReviewed)}, cover letter {String(checklist.coverLetterReviewed)}, screener {String(checklist.screenerAnswersReviewed)}.
+                </p>
               ) : null}
               <label className="block text-xs text-foreground/70">
                 Notes

--- a/ui/partner-hub/lib/job-hunter/applications.test.ts
+++ b/ui/partner-hub/lib/job-hunter/applications.test.ts
@@ -6,6 +6,8 @@ import {
   buildFollowUpEmail,
   createApplicationFromJob,
   exportApplicationsCsv,
+  getApplicationQueueStage,
+  getApplicationWorkflow,
   resolveApplicationJobDetails,
   toJobSnapshot,
 } from "./applications";
@@ -66,7 +68,56 @@ describe("job hunter application reducer", () => {
     });
 
     assert.equal(withNotes[job.id].checklist?.resumeReviewed, true);
+    assert.equal(withNotes[job.id].workflow?.tailoredResumeReady, true);
     assert.equal(withNotes[job.id].notes, "Submitted tailored resume and letter.");
+  });
+
+  it("supports guided apply workflow transitions", () => {
+    const initial = { [job.id]: createApplicationFromJob(job, "2024-03-01T10:00:00.000Z") };
+
+    const selected = applicationReducer(initial, {
+      type: "setWorkflowItem",
+      jobId: job.id,
+      item: "selectedForApply",
+      value: true,
+      now: "2024-03-02T10:00:00.000Z",
+    });
+    const prepared = applicationReducer(selected, {
+      type: "setWorkflowItem",
+      jobId: job.id,
+      item: "tailoredResumeReady",
+      value: true,
+    });
+    const ready = applicationReducer(prepared, {
+      type: "setWorkflowItem",
+      jobId: job.id,
+      item: "coverLetterReady",
+      value: true,
+    });
+    const withScreener = applicationReducer(ready, {
+      type: "setWorkflowItem",
+      jobId: job.id,
+      item: "screenerAnswersReady",
+      value: true,
+    });
+    const inProgress = applicationReducer(withScreener, {
+      type: "setWorkflowItem",
+      jobId: job.id,
+      item: "externalApplicationOpened",
+      value: true,
+    });
+    const applied = applicationReducer(inProgress, {
+      type: "setStatus",
+      jobId: job.id,
+      status: "applied",
+      now: "2024-03-03T10:00:00.000Z",
+    });
+
+    assert.equal(getApplicationQueueStage(selected[job.id]), "selected");
+    assert.equal(getApplicationQueueStage(withScreener[job.id]), "prepared");
+    assert.equal(getApplicationQueueStage(inProgress[job.id]), "in-progress");
+    assert.equal(getApplicationQueueStage(applied[job.id]), "applied");
+    assert.equal(getApplicationWorkflow(applied[job.id]).finalExternalSubmitConfirmed, true);
   });
 
   it("captures immutable snapshot when requested", () => {

--- a/ui/partner-hub/lib/job-hunter/applications.ts
+++ b/ui/partner-hub/lib/job-hunter/applications.ts
@@ -1,4 +1,12 @@
-import type { Application, ApplicationStatus, ApplyChecklist, ApplicationJobSnapshot, JobPosting, ResumeProfile } from "./types";
+import type {
+  Application,
+  ApplicationStatus,
+  ApplyChecklist,
+  ApplicationJobSnapshot,
+  GuidedApplyWorkflow,
+  JobPosting,
+  ResumeProfile,
+} from "./types";
 
 export const APPLICATION_STATUSES: ApplicationStatus[] = ["prepared", "applied", "interview", "rejected", "offer"];
 
@@ -18,7 +26,22 @@ export const DEFAULT_APPLY_CHECKLIST: ApplyChecklist = {
   followUpScheduled: false,
 };
 
+export const DEFAULT_GUIDED_APPLY_WORKFLOW: GuidedApplyWorkflow = {
+  selectedForApply: false,
+  tailoredResumeReady: false,
+  coverLetterReady: false,
+  screenerAnswersReady: false,
+  externalApplicationOpened: false,
+  tailoredResumeUploaded: false,
+  customQuestionsCompleted: false,
+  finalExternalSubmitConfirmed: false,
+  followUpScheduled: false,
+};
+
 export type ChecklistKey = keyof ApplyChecklist;
+export type WorkflowKey = keyof GuidedApplyWorkflow;
+
+export type ApplicationQueueStage = "selected" | "prepared" | "in-progress" | "applied";
 
 export type ApplicationAction =
   | { type: "upsertFromJob"; job: JobPosting; now?: string }
@@ -26,6 +49,7 @@ export type ApplicationAction =
   | { type: "setReminder"; jobId: string; reminderAt?: string; now?: string }
   | { type: "setNotes"; jobId: string; notes?: string; now?: string }
   | { type: "setChecklistItem"; jobId: string; item: ChecklistKey; value: boolean; now?: string }
+  | { type: "setWorkflowItem"; jobId: string; item: WorkflowKey; value: boolean; now?: string }
   | { type: "ensureSnapshotFromJob"; jobId: string; job: JobPosting; now?: string };
 
 export const buildFollowUpEmail = (job: JobPosting, profile?: ResumeProfile) => {
@@ -69,6 +93,7 @@ export const createApplicationFromJob = (job: JobPosting, now: string): Applicat
   jobId: job.id,
   status: "prepared",
   checklist: { ...DEFAULT_APPLY_CHECKLIST },
+  workflow: { ...DEFAULT_GUIDED_APPLY_WORKFLOW },
   createdAt: now,
   updatedAt: now,
 });
@@ -77,6 +102,49 @@ export const getApplicationChecklist = (application: Application): ApplyChecklis
   ...DEFAULT_APPLY_CHECKLIST,
   ...(application.checklist ?? {}),
 });
+
+export const getApplicationWorkflow = (application: Application): GuidedApplyWorkflow => {
+  const checklist = getApplicationChecklist(application);
+  const workflow = {
+    ...DEFAULT_GUIDED_APPLY_WORKFLOW,
+    ...(application.workflow ?? {}),
+  };
+
+  return {
+    ...workflow,
+    tailoredResumeReady: workflow.tailoredResumeReady || checklist.resumeReviewed,
+    coverLetterReady: workflow.coverLetterReady || checklist.coverLetterReviewed,
+    screenerAnswersReady: workflow.screenerAnswersReady || checklist.screenerAnswersReviewed,
+    finalExternalSubmitConfirmed: workflow.finalExternalSubmitConfirmed || checklist.appliedExternally,
+    followUpScheduled: workflow.followUpScheduled || checklist.followUpScheduled,
+  };
+};
+
+export const getApplicationQueueStage = (application: Application): ApplicationQueueStage => {
+  if (application.status === "applied" || application.status === "interview" || application.status === "offer" || application.status === "rejected") {
+    return "applied";
+  }
+
+  const workflow = getApplicationWorkflow(application);
+  if (!workflow.selectedForApply) {
+    return "selected";
+  }
+
+  if (
+    workflow.tailoredResumeReady &&
+    workflow.coverLetterReady &&
+    workflow.screenerAnswersReady &&
+    !workflow.externalApplicationOpened
+  ) {
+    return "prepared";
+  }
+
+  if (workflow.externalApplicationOpened || workflow.tailoredResumeUploaded || workflow.customQuestionsCompleted) {
+    return "in-progress";
+  }
+
+  return "selected";
+};
 
 export const resolveApplicationJobDetails = (application: Application, jobsById: Record<string, JobPosting>) => {
   const liveJob = jobsById[application.jobId];
@@ -135,6 +203,10 @@ export const applicationReducer = (
       updatedAt: now,
       ...statusTimestampPatch(action.status, now),
       checklist: getApplicationChecklist(existing),
+      workflow: {
+        ...getApplicationWorkflow(existing),
+        finalExternalSubmitConfirmed: action.status === "applied" ? true : getApplicationWorkflow(existing).finalExternalSubmitConfirmed,
+      },
     };
 
     return {
@@ -150,6 +222,7 @@ export const applicationReducer = (
         ...existing,
         reminderAt: action.reminderAt,
         checklist: getApplicationChecklist(existing),
+        workflow: getApplicationWorkflow(existing),
         updatedAt: now,
       },
     };
@@ -162,6 +235,7 @@ export const applicationReducer = (
         ...existing,
         notes: action.notes,
         checklist: getApplicationChecklist(existing),
+        workflow: getApplicationWorkflow(existing),
         updatedAt: now,
       },
     };
@@ -174,6 +248,36 @@ export const applicationReducer = (
         ...existing,
         checklist: {
           ...getApplicationChecklist(existing),
+          [action.item]: action.value,
+        },
+        workflow: {
+          ...getApplicationWorkflow(existing),
+          ...(action.item === "resumeReviewed" ? { tailoredResumeReady: action.value } : {}),
+          ...(action.item === "coverLetterReviewed" ? { coverLetterReady: action.value } : {}),
+          ...(action.item === "screenerAnswersReviewed" ? { screenerAnswersReady: action.value } : {}),
+          ...(action.item === "appliedExternally" ? { finalExternalSubmitConfirmed: action.value } : {}),
+          ...(action.item === "followUpScheduled" ? { followUpScheduled: action.value } : {}),
+        },
+        updatedAt: now,
+      },
+    };
+  }
+
+  if (action.type === "setWorkflowItem") {
+    return {
+      ...state,
+      [action.jobId]: {
+        ...existing,
+        checklist: {
+          ...getApplicationChecklist(existing),
+          ...(action.item === "tailoredResumeReady" ? { resumeReviewed: action.value } : {}),
+          ...(action.item === "coverLetterReady" ? { coverLetterReviewed: action.value } : {}),
+          ...(action.item === "screenerAnswersReady" ? { screenerAnswersReviewed: action.value } : {}),
+          ...(action.item === "finalExternalSubmitConfirmed" ? { appliedExternally: action.value } : {}),
+          ...(action.item === "followUpScheduled" ? { followUpScheduled: action.value } : {}),
+        },
+        workflow: {
+          ...getApplicationWorkflow(existing),
           [action.item]: action.value,
         },
         updatedAt: now,
@@ -191,6 +295,7 @@ export const applicationReducer = (
       [action.jobId]: {
         ...existing,
         checklist: getApplicationChecklist(existing),
+        workflow: getApplicationWorkflow(existing),
         jobSnapshot: toJobSnapshot(action.job),
         updatedAt: now,
       },

--- a/ui/partner-hub/lib/job-hunter/applyPacket.test.ts
+++ b/ui/partner-hub/lib/job-hunter/applyPacket.test.ts
@@ -2,7 +2,7 @@ import * as assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { generateTailoringPacket } from "./resume/tailor";
-import { buildApplyPacket } from "./applyPacket";
+import { buildApplyPacket, buildApplyPrepItems } from "./applyPacket";
 import type { JobPosting, ResumeProfile } from "./types";
 
 const profile: ResumeProfile = {
@@ -83,5 +83,26 @@ describe("buildApplyPacket", () => {
     assert.ok(packet.fullPacketMarkdown.includes("## Cover Letter"));
     assert.ok(packet.fullPacketMarkdown.includes("## Screener Answers"));
     assert.ok(packet.fullPacketMarkdown.includes("## Follow-up Email"));
+  });
+
+  it("builds reusable prep helpers for guided apply", () => {
+    const job: JobPosting = {
+      id: "job-404",
+      title: "Solutions Architect",
+      company: "Contoso",
+      source: "company-site",
+      sourceUrl: "https://contoso.example/jobs/404",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    };
+
+    const tailoringPacket = generateTailoringPacket(job, profile);
+    const packet = buildApplyPacket(job, tailoringPacket, profile);
+    const prepItems = buildApplyPrepItems(job, packet, tailoringPacket, profile);
+
+    assert.equal(prepItems.length, 9);
+    assert.equal(prepItems[0].key, "candidateContact");
+    assert.ok(prepItems.find((item) => item.key === "linkedinUrl")?.value.includes("linkedin.com/in/james"));
+    assert.equal(prepItems.find((item) => item.key === "sourceApplicationLink")?.value, "https://contoso.example/jobs/404");
   });
 });

--- a/ui/partner-hub/lib/job-hunter/applyPacket.ts
+++ b/ui/partner-hub/lib/job-hunter/applyPacket.ts
@@ -13,6 +13,21 @@ export type ApplyPacket = {
   fullPacketMarkdown: string;
 };
 
+export type ApplyPrepItem = {
+  key:
+    | "candidateContact"
+    | "linkedinUrl"
+    | "workAuthorization"
+    | "professionalSummary"
+    | "tailoredResumeMarkdown"
+    | "tailoredResumeText"
+    | "coverLetter"
+    | "screenerAnswers"
+    | "sourceApplicationLink";
+  label: string;
+  value: string;
+};
+
 const normalizeForFileName = (value: string) => {
   const normalized = value
     .normalize("NFKD")
@@ -93,4 +108,61 @@ export const buildApplyPacket = (job: JobPosting, tailoringPacket: TailoringPack
     followUpEmailText,
     fullPacketMarkdown,
   };
+};
+
+export const buildApplyPrepItems = (job: JobPosting, applyPacket: ApplyPacket, tailoringPacket: TailoringPacket, profile?: ResumeProfile): ApplyPrepItem[] => {
+  const candidateContact = [
+    profile?.fullName?.trim() || "Candidate Name",
+    profile?.email?.trim() || "candidate@example.com",
+    profile?.phone?.trim() || "(000) 000-0000",
+    profile?.cityState?.trim() || "City, ST",
+  ].join("\n");
+
+  return [
+    {
+      key: "candidateContact",
+      label: "Candidate contact block",
+      value: candidateContact,
+    },
+    {
+      key: "linkedinUrl",
+      label: "LinkedIn URL",
+      value: profile?.linkedinUrl?.trim() || "Add LinkedIn URL",
+    },
+    {
+      key: "workAuthorization",
+      label: "Work authorization note",
+      value: profile?.workAuthorizationNote?.trim() || "Add work authorization note",
+    },
+    {
+      key: "professionalSummary",
+      label: "Professional summary / headline",
+      value: [profile?.headline?.trim(), tailoringPacket.tailoredSummary].filter(Boolean).join("\n"),
+    },
+    {
+      key: "tailoredResumeMarkdown",
+      label: "Tailored resume (markdown)",
+      value: tailoringPacket.tailoredResumeVariant.markdown,
+    },
+    {
+      key: "tailoredResumeText",
+      label: "Tailored resume (plain text)",
+      value: tailoringPacket.tailoredResumeVariant.plainText,
+    },
+    {
+      key: "coverLetter",
+      label: "Cover letter",
+      value: applyPacket.coverLetterMarkdown,
+    },
+    {
+      key: "screenerAnswers",
+      label: "Screener answers",
+      value: applyPacket.screenerAnswersText,
+    },
+    {
+      key: "sourceApplicationLink",
+      label: "Source application link",
+      value: job.sourceUrl ?? "Add external application URL",
+    },
+  ];
 };

--- a/ui/partner-hub/lib/job-hunter/storage.test.ts
+++ b/ui/partner-hub/lib/job-hunter/storage.test.ts
@@ -89,6 +89,88 @@ describe("job hunter storage", () => {
     assert.equal(loaded.applicationsById["job-legacy"].notes, "legacy note");
     assert.equal(loaded.applicationsById["job-legacy"].checklist?.resumeReviewed, false);
     assert.equal(loaded.applicationsById["job-legacy"].checklist?.followUpScheduled, false);
+    assert.equal(loaded.applicationsById["job-legacy"].workflow?.selectedForApply, false);
+
+    Object.defineProperty(globalThis, "window", {
+      value: previousWindow,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it("persists guided apply workflow state", () => {
+    const storage = new MemoryStorage();
+    const previousWindow = globalThis.window;
+    Object.defineProperty(globalThis, "window", {
+      value: { localStorage: storage },
+      configurable: true,
+      writable: true,
+    });
+
+    saveJobHunterStore({
+      jobs: [],
+      jobsById: {},
+      applications: [
+        {
+          id: "job-22",
+          jobId: "job-22",
+          status: "prepared",
+          checklist: {
+            resumeReviewed: false,
+            coverLetterReviewed: false,
+            screenerAnswersReviewed: false,
+            appliedExternally: false,
+            followUpScheduled: false,
+          },
+          workflow: {
+            selectedForApply: true,
+            tailoredResumeReady: true,
+            coverLetterReady: true,
+            screenerAnswersReady: true,
+            externalApplicationOpened: true,
+            tailoredResumeUploaded: true,
+            customQuestionsCompleted: false,
+            finalExternalSubmitConfirmed: false,
+            followUpScheduled: false,
+          },
+          createdAt: "2024-03-01T10:00:00.000Z",
+          updatedAt: "2024-03-01T10:00:00.000Z",
+        },
+      ],
+      applicationsById: {
+        "job-22": {
+          id: "job-22",
+          jobId: "job-22",
+          status: "prepared",
+          checklist: {
+            resumeReviewed: false,
+            coverLetterReviewed: false,
+            screenerAnswersReviewed: false,
+            appliedExternally: false,
+            followUpScheduled: false,
+          },
+          workflow: {
+            selectedForApply: true,
+            tailoredResumeReady: true,
+            coverLetterReady: true,
+            screenerAnswersReady: true,
+            externalApplicationOpened: true,
+            tailoredResumeUploaded: true,
+            customQuestionsCompleted: false,
+            finalExternalSubmitConfirmed: false,
+            followUpScheduled: false,
+          },
+          createdAt: "2024-03-01T10:00:00.000Z",
+          updatedAt: "2024-03-01T10:00:00.000Z",
+        },
+      },
+      selectedJobIds: [],
+      sources: [],
+    });
+
+    const loaded = loadJobHunterStore();
+    assert.equal(loaded.applicationsById["job-22"].workflow?.externalApplicationOpened, true);
+    assert.equal(loaded.applicationsById["job-22"].workflow?.tailoredResumeUploaded, true);
 
     Object.defineProperty(globalThis, "window", {
       value: previousWindow,

--- a/ui/partner-hub/lib/job-hunter/storage.ts
+++ b/ui/partner-hub/lib/job-hunter/storage.ts
@@ -1,7 +1,7 @@
-import { DEFAULT_APPLY_CHECKLIST, getApplicationChecklist } from "./applications";
+import { DEFAULT_APPLY_CHECKLIST, DEFAULT_GUIDED_APPLY_WORKFLOW, getApplicationChecklist, getApplicationWorkflow } from "./applications";
 import { getDefaultPreferences, normalizePreferences } from "./preferences";
 import { normalizeResumeProfile } from "./resumeProfile";
-import type { Application, ApplyChecklist, BoardType, JobHunterStore, JobSourceConfig } from "./types";
+import type { Application, ApplyChecklist, BoardType, GuidedApplyWorkflow, JobHunterStore, JobSourceConfig } from "./types";
 
 export const JOB_HUNTER_STORAGE_KEY = "partner-hub:job-hunter:v1";
 
@@ -43,6 +43,13 @@ const normalizeChecklist = (value: unknown): ApplyChecklist => {
 const normalizeApplication = (value: Application): Application => ({
   ...value,
   checklist: normalizeChecklist(value.checklist),
+  workflow:
+    value.workflow && typeof value.workflow === "object" && !Array.isArray(value.workflow)
+      ? {
+          ...DEFAULT_GUIDED_APPLY_WORKFLOW,
+          ...(value.workflow as Partial<GuidedApplyWorkflow>),
+        }
+      : { ...DEFAULT_GUIDED_APPLY_WORKFLOW },
   jobSnapshot:
     value.jobSnapshot && typeof value.jobSnapshot === "object"
       ? {
@@ -124,6 +131,7 @@ export const loadJobHunterStore = (): JobHunterStore => {
       acc[jobId] = {
         ...normalized,
         checklist: getApplicationChecklist(normalized),
+        workflow: getApplicationWorkflow(normalized),
       };
       return acc;
     }, {});
@@ -154,6 +162,7 @@ export const saveJobHunterStore = (store: JobHunterStore) => {
     acc[jobId] = {
       ...application,
       checklist: getApplicationChecklist(application),
+      workflow: getApplicationWorkflow(application),
     };
     return acc;
   }, {});

--- a/ui/partner-hub/lib/job-hunter/types.ts
+++ b/ui/partner-hub/lib/job-hunter/types.ts
@@ -28,6 +28,18 @@ export type ApplyChecklist = {
   followUpScheduled: boolean;
 };
 
+export type GuidedApplyWorkflow = {
+  selectedForApply: boolean;
+  tailoredResumeReady: boolean;
+  coverLetterReady: boolean;
+  screenerAnswersReady: boolean;
+  externalApplicationOpened: boolean;
+  tailoredResumeUploaded: boolean;
+  customQuestionsCompleted: boolean;
+  finalExternalSubmitConfirmed: boolean;
+  followUpScheduled: boolean;
+};
+
 export type JobPosting = {
   id: string;
   title: string;
@@ -58,6 +70,7 @@ export type Application = {
   rejectedAt?: string;
   notes?: string;
   checklist?: ApplyChecklist;
+  workflow?: GuidedApplyWorkflow;
   jobSnapshot?: ApplicationJobSnapshot;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
### Motivation
- Reduce manual work during Job Hunter applications by staging tailored resume variants and other artifacts while keeping the user in control of final submission.
- Persist a lightweight guided-apply session per tracked application so state (selected -> prepared -> in-progress -> applied) survives syncs and missing live postings.
- Provide reusable one-click prep helpers (copy / download / open link) to streamline filling external application forms without performing any blind auto-submit or login automation.

### Description
- Introduced a `GuidedApplyWorkflow` model and wire it into `Application` with a default (`DEFAULT_GUIDED_APPLY_WORKFLOW`) and accessors `getApplicationWorkflow` and `getApplicationQueueStage` to derive pipeline columns; core types updated in `ui/partner-hub/lib/job-hunter/types.ts` and domain logic in `ui/partner-hub/lib/job-hunter/applications.ts`.
- Extended the reducer to accept `setWorkflowItem` actions that update workflow and mirror legacy checklist fields, and ensure workflow state is preserved when creating snapshots on apply; added queue-stage semantics (`selected`, `prepared`, `in-progress`, `applied`).
- Persisted workflow state through the same local-store payload and normalization path (`ui/partner-hub/lib/job-hunter/storage.ts`) and added `buildApplyPrepItems` prep helpers to `ui/partner-hub/lib/job-hunter/applyPacket.ts` for candidate contact, LinkedIn, authorization note, tailored resume (md/txt), cover letter, screener answers, and source link.
- Upgraded the UI: the Job detail Apply tab now shows tailored resume preview, one-click copy/download buttons, quick prep actions and an explicit "Open external application" handoff, plus a guided workflow checklist and an explicit human-controlled "Mark as Applied" that records a snapshot; the Applications page now displays pipeline columns (Selected / Ready to Apply / In Progress / Applied / Interview / Offer / Rejected) and surfaces submission confirmation without changing existing status semantics. Files changed include UI pages and the tests noted below.

### Testing
- Ran `cd ui/partner-hub && npm run lint` and observed `✔ No ESLint warnings or errors` (lint passed).
- Ran `cd ui/partner-hub && npm run typecheck` which executed `tsc --noEmit` and completed with no type errors (typecheck passed).
- Ran `cd ui/partner-hub && npm run test` and observed the full test suite pass with summary: `# tests 97`, `# suites 29`, `# pass 97`, `# fail 0` (all automated tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b08f1fd9248330aec785a765e565a8)