### PR TITLE
Fix Job Hunter apply queue stage semantics and workflow sync

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/applications/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/applications/page.tsx
@@ -15,6 +15,8 @@ import {
   getApplicationQueueStage,
   getApplicationWorkflow,
   resolveApplicationJobDetails,
+  shouldShowInApplicationsPipeline,
+  syncWorkflowSelectionWithQueue,
 } from "@/lib/job-hunter/applications";
 import { loadJobHunterStore, saveJobHunterStore } from "@/lib/job-hunter/storage";
 import type { Application, ApplicationStatus, JobPosting } from "@/lib/job-hunter/types";
@@ -77,19 +79,8 @@ export default function JobHunterApplicationsPage() {
   };
 
   useEffect(() => {
-    let next = applicationsById;
-    let changed = false;
-
-    selectedJobIds.forEach((jobId) => {
-      if (!next[jobId] || getApplicationWorkflow(next[jobId]).selectedForApply) {
-        return;
-      }
-
-      next = applicationReducer(next, { type: "setWorkflowItem", jobId, item: "selectedForApply", value: true });
-      changed = true;
-    });
-
-    if (changed) {
+    const next = syncWorkflowSelectionWithQueue(applicationsById, selectedJobIds);
+    if (next !== applicationsById) {
       save(next);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -136,6 +127,7 @@ export default function JobHunterApplicationsPage() {
       <section className="grid gap-4 lg:grid-cols-7">
         {PIPELINE_COLUMNS.map((column) => {
           const items = applications
+            .filter((application) => shouldShowInApplicationsPipeline(application))
             .filter((application) => matchesColumn(application, column.key))
             .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
 

--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { EmptyState } from "@/components/job-hunter/EmptyState";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { applicationReducer, createApplicationFromJob, getApplicationChecklist, getApplicationWorkflow } from "@/lib/job-hunter/applications";
+import { applicationReducer, createApplicationFromJob, getApplicationChecklist, getApplicationWorkflow, syncWorkflowSelectionWithQueue } from "@/lib/job-hunter/applications";
 import { buildApplyPacket, buildApplyPrepItems } from "@/lib/job-hunter/applyPacket";
 import { normalizePreferences } from "@/lib/job-hunter/preferences";
 import { masterResume } from "@/lib/job-hunter/resume/masterResume";
@@ -79,12 +79,11 @@ export default function JobDetailPage({ params }: PageProps) {
   }, [applicationById, job, saveApplications]);
 
   useEffect(() => {
-    if (!job || !store.selectedJobIds.includes(job.id) || workflow?.selectedForApply) {
-      return;
+    const next = syncWorkflowSelectionWithQueue(applicationById, store.selectedJobIds);
+    if (next !== applicationById) {
+      saveApplications(next);
     }
-
-    saveApplications(applicationReducer(applicationById, { type: "setWorkflowItem", jobId: job.id, item: "selectedForApply", value: true }));
-  }, [applicationById, job, saveApplications, store.selectedJobIds, workflow?.selectedForApply]);
+  }, [applicationById, saveApplications, store.selectedJobIds]);
 
   const handleDownloadMarkdown = () => {
     if (!tailoringPacket || !job) {

--- a/ui/partner-hub/lib/job-hunter/applications.test.ts
+++ b/ui/partner-hub/lib/job-hunter/applications.test.ts
@@ -9,6 +9,8 @@ import {
   getApplicationQueueStage,
   getApplicationWorkflow,
   resolveApplicationJobDetails,
+  shouldShowInApplicationsPipeline,
+  syncWorkflowSelectionWithQueue,
   toJobSnapshot,
 } from "./applications";
 import type { JobPosting } from "./types";
@@ -70,6 +72,41 @@ describe("job hunter application reducer", () => {
     assert.equal(withNotes[job.id].checklist?.resumeReviewed, true);
     assert.equal(withNotes[job.id].workflow?.tailoredResumeReady, true);
     assert.equal(withNotes[job.id].notes, "Submitted tailored resume and letter.");
+  });
+
+
+  it("does not classify unselected jobs as selected", () => {
+    const initial = { [job.id]: createApplicationFromJob(job, "2024-03-01T10:00:00.000Z") };
+
+    assert.equal(getApplicationQueueStage(initial[job.id]), "untracked");
+    assert.equal(shouldShowInApplicationsPipeline(initial[job.id]), false);
+  });
+
+  it("syncs workflow selection both directions with apply queue", () => {
+    const initial = { [job.id]: createApplicationFromJob(job, "2024-03-01T10:00:00.000Z") };
+
+    const addedToQueue = syncWorkflowSelectionWithQueue(initial, [job.id], "2024-03-02T10:00:00.000Z");
+    assert.equal(getApplicationWorkflow(addedToQueue[job.id]).selectedForApply, true);
+
+    const removedFromQueue = syncWorkflowSelectionWithQueue(addedToQueue, [], "2024-03-03T10:00:00.000Z");
+    assert.equal(getApplicationWorkflow(removedFromQueue[job.id]).selectedForApply, false);
+  });
+
+  it("preserves workflow selection when removed from queue after in-progress signals", () => {
+    const initial = { [job.id]: createApplicationFromJob(job, "2024-03-01T10:00:00.000Z") };
+    const selected = syncWorkflowSelectionWithQueue(initial, [job.id], "2024-03-02T10:00:00.000Z");
+    const inProgress = applicationReducer(selected, {
+      type: "setWorkflowItem",
+      jobId: job.id,
+      item: "externalApplicationOpened",
+      value: true,
+      now: "2024-03-03T10:00:00.000Z",
+    });
+
+    const removedFromQueue = syncWorkflowSelectionWithQueue(inProgress, [], "2024-03-04T10:00:00.000Z");
+    assert.equal(getApplicationWorkflow(removedFromQueue[job.id]).selectedForApply, true);
+    assert.equal(getApplicationQueueStage(removedFromQueue[job.id]), "in-progress");
+    assert.equal(shouldShowInApplicationsPipeline(removedFromQueue[job.id]), true);
   });
 
   it("supports guided apply workflow transitions", () => {

--- a/ui/partner-hub/lib/job-hunter/applications.ts
+++ b/ui/partner-hub/lib/job-hunter/applications.ts
@@ -41,7 +41,7 @@ export const DEFAULT_GUIDED_APPLY_WORKFLOW: GuidedApplyWorkflow = {
 export type ChecklistKey = keyof ApplyChecklist;
 export type WorkflowKey = keyof GuidedApplyWorkflow;
 
-export type ApplicationQueueStage = "selected" | "prepared" | "in-progress" | "applied";
+export type ApplicationQueueStage = "untracked" | "selected" | "prepared" | "in-progress" | "applied";
 
 export type ApplicationAction =
   | { type: "upsertFromJob"; job: JobPosting; now?: string }
@@ -127,7 +127,7 @@ export const getApplicationQueueStage = (application: Application): ApplicationQ
 
   const workflow = getApplicationWorkflow(application);
   if (!workflow.selectedForApply) {
-    return "selected";
+    return "untracked";
   }
 
   if (
@@ -144,6 +144,58 @@ export const getApplicationQueueStage = (application: Application): ApplicationQ
   }
 
   return "selected";
+};
+
+const hasInProgressWorkflowSignals = (workflow: GuidedApplyWorkflow) =>
+  workflow.externalApplicationOpened ||
+  workflow.tailoredResumeUploaded ||
+  workflow.customQuestionsCompleted ||
+  workflow.finalExternalSubmitConfirmed;
+
+export const shouldPreserveWorkflowSelection = (application: Application) => {
+  if (application.status === "applied" || application.status === "interview" || application.status === "offer" || application.status === "rejected") {
+    return true;
+  }
+
+  return hasInProgressWorkflowSignals(getApplicationWorkflow(application));
+};
+
+export const shouldShowInApplicationsPipeline = (application: Application) => {
+  if (application.status === "applied" || application.status === "interview" || application.status === "offer" || application.status === "rejected") {
+    return true;
+  }
+
+  const workflow = getApplicationWorkflow(application);
+  return workflow.selectedForApply || hasInProgressWorkflowSignals(workflow);
+};
+
+export const syncWorkflowSelectionWithQueue = (
+  applicationsById: Record<string, Application>,
+  selectedJobIds: string[],
+  now?: string,
+) => {
+  const selectedSet = new Set(selectedJobIds);
+  let next = applicationsById;
+
+  Object.values(applicationsById).forEach((application) => {
+    const workflow = getApplicationWorkflow(application);
+    const inQueue = selectedSet.has(application.jobId);
+    const desiredSelectedForApply = inQueue || (!inQueue && workflow.selectedForApply && shouldPreserveWorkflowSelection(application));
+
+    if (desiredSelectedForApply === workflow.selectedForApply) {
+      return;
+    }
+
+    next = applicationReducer(next, {
+      type: "setWorkflowItem",
+      jobId: application.jobId,
+      item: "selectedForApply",
+      value: desiredSelectedForApply,
+      now,
+    });
+  });
+
+  return next;
 };
 
 export const resolveApplicationJobDetails = (application: Application, jobsById: Record<string, JobPosting>) => {


### PR DESCRIPTION
### Motivation
- Prevent unselected/untouched seeded jobs from being shown as `Selected` in the Applications pipeline by tightening queue-stage fallback semantics. 
- Ensure `workflow.selectedForApply` cannot drift from the actual apply queue so the guided-apply workflow reflects real queue membership in both directions. 
- Reduce noise on the Applications page so it surfaces only true pipeline items (selected, in-progress, or terminal statuses) while preserving existing behavior for prepared/in-progress/applied flows.

### Description
- Add a new `untracked` queue stage and update `getApplicationQueueStage()` so jobs are only considered `selected` when actually selected for apply. 
- Add deterministic helpers: `syncWorkflowSelectionWithQueue()`, `shouldShowInApplicationsPipeline()`, and `shouldPreserveWorkflowSelection()` (and an internal `hasInProgressWorkflowSignals`) to express sync and visibility rules. 
- Replace one-way selection hydration effects on the Applications page and Job detail page with `syncWorkflowSelectionWithQueue()` so workflow and `selectedJobIds` stay in sync both ways. 
- Filter Applications pipeline cards via `shouldShowInApplicationsPipeline()` so unselected/untouched jobs no longer flood the Selected column. 
- Add tests that assert: non-selected jobs are not classified as selected, queue additions/removals sync workflow selection both ways, and in-progress jobs preserve selection when removed from the queue. 
- Changed files: `ui/partner-hub/lib/job-hunter/applications.ts`, `ui/partner-hub/app/(routes)/job-hunter/applications/page.tsx`, `ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx`, `ui/partner-hub/lib/job-hunter/applications.test.ts`.

### Testing
- `cd ui/partner-hub && npm run lint` — ✔ No ESLint warnings or errors. 
- `cd ui/partner-hub && npm run typecheck` — ✔ Type check completed with no errors. 
- `cd ui/partner-hub && npm run test` — ✔ All tests passed (`# tests 100`, `# pass 100`, `# fail 0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b092f8825483309c77466e4fe2b928)