### PR TITLE
Tighten Job Hunter arrangement matching and exclusion summaries

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx
@@ -7,7 +7,7 @@ import { EmptyState } from "@/components/job-hunter/EmptyState";
 import { JobList, type JobListRow } from "@/components/job-hunter/JobList";
 import { Button } from "@/components/ui/button";
 import { getDefaultPreferences, jobMatchesPreferences, normalizePreferences } from "@/lib/job-hunter/preferences";
-import { scoreJobFit } from "@/lib/job-hunter/scoring";
+import { scoreJobFit, summarizeJobReason } from "@/lib/job-hunter/scoring";
 import { toggleJobSelection } from "@/lib/job-hunter/queue";
 import { loadJobHunterStore, saveJobHunterStore } from "@/lib/job-hunter/storage";
 import type { JobHunterPreferences, JobPosting } from "@/lib/job-hunter/types";
@@ -43,9 +43,11 @@ export default function JobHunterJobsPage() {
           excluded: exclusion.excluded,
           exclusionReasons: exclusion.reasons,
           arrangement: exclusion.arrangement,
-          reasonSummary:
-            fit.preferenceSignals[0] ??
-            (exclusion.reasons.length > 0 ? `Excluded: ${exclusion.reasons.join(", ")}` : "No preference signal"),
+          reasonSummary: summarizeJobReason({
+            excluded: exclusion.excluded,
+            exclusionReasons: exclusion.reasons,
+            preferenceSignals: fit.preferenceSignals,
+          }),
         };
       })
       .filter(({ job, score, excluded }) => {

--- a/ui/partner-hub/lib/job-hunter/preferences.test.ts
+++ b/ui/partner-hub/lib/job-hunter/preferences.test.ts
@@ -68,4 +68,35 @@ describe("preferences", () => {
     assert.equal(onsiteMatch.excluded, true);
     assert.ok(onsiteMatch.reasons.includes("Onsite roles disabled"));
   });
+
+  it("matches hybrid Philly and remote US when preference signal exists in notes", () => {
+    const hybridPreferences = {
+      ...getDefaultPreferences(),
+      preferredHybridLocations: ["Philadelphia"],
+    };
+    const remotePreferences = {
+      ...getDefaultPreferences(),
+      preferredRemoteRegions: ["United States"],
+    };
+
+    const hybridMatch = jobMatchesPreferences(
+      {
+        ...baseJob,
+        location: "Pennsylvania",
+        notes: "Hybrid schedule with 2 days/week in our Philadelphia office",
+      },
+      hybridPreferences,
+    );
+    const remoteMatch = jobMatchesPreferences(
+      {
+        ...baseJob,
+        location: "Remote",
+        notes: "Fully remote role; candidates must be based in the United States",
+      },
+      remotePreferences,
+    );
+
+    assert.equal(hybridMatch.excluded, false);
+    assert.equal(remoteMatch.excluded, false);
+  });
 });

--- a/ui/partner-hub/lib/job-hunter/preferences.ts
+++ b/ui/partner-hub/lib/job-hunter/preferences.ts
@@ -139,8 +139,11 @@ const matchesLocationPreference = (value: string | undefined, terms: string[]) =
   return includesAny(value, terms);
 };
 
+export const buildArrangementPreferenceText = (job: JobPosting) =>
+  [job.location, job.notes, job.employmentType, job.title].filter(Boolean).join(" ");
+
 export const classifyWorkArrangement = (job: JobPosting): JobWorkArrangement => {
-  const combinedText = [job.location, job.notes, job.title, job.employmentType].filter(Boolean).join(" ");
+  const combinedText = buildArrangementPreferenceText(job);
 
   if (includesTerm(combinedText, HYBRID_KEYWORDS)) {
     return "hybrid";
@@ -163,6 +166,7 @@ export const jobMatchesPreferences = (
 ): { excluded: boolean; reasons: string[]; arrangement: JobWorkArrangement } => {
   const reasons: string[] = [];
   const arrangement = classifyWorkArrangement(job);
+  const arrangementText = buildArrangementPreferenceText(job);
 
   if (includesAny(job.company, preferences.excludedCompanies)) {
     reasons.push("Excluded company");
@@ -175,7 +179,7 @@ export const jobMatchesPreferences = (
   if (arrangement === "remote") {
     if (!preferences.allowRemoteRoles) {
       reasons.push("Remote roles disabled");
-    } else if (!matchesLocationPreference(job.location ?? job.notes, preferences.preferredRemoteRegions)) {
+    } else if (!matchesLocationPreference(arrangementText, preferences.preferredRemoteRegions)) {
       reasons.push("Remote region not preferred");
     }
   }
@@ -183,7 +187,7 @@ export const jobMatchesPreferences = (
   if (arrangement === "hybrid") {
     if (!preferences.allowHybridRoles) {
       reasons.push("Hybrid roles disabled");
-    } else if (!matchesLocationPreference(job.location ?? job.notes, preferences.preferredHybridLocations)) {
+    } else if (!matchesLocationPreference(arrangementText, preferences.preferredHybridLocations)) {
       reasons.push("Hybrid location not preferred");
     }
   }

--- a/ui/partner-hub/lib/job-hunter/scoring.test.ts
+++ b/ui/partner-hub/lib/job-hunter/scoring.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "node:test";
 import * as assert from "node:assert/strict";
 
 import { getDefaultPreferences } from "./preferences";
-import { scoreJobFit } from "./scoring";
+import { scoreJobFit, summarizeJobReason } from "./scoring";
 import type { JobPosting } from "./types";
 
 const baseJob: JobPosting = {
@@ -23,9 +23,22 @@ describe("scoreJobFit", () => {
   });
 
   it("supports remote US and hybrid Philly preference boosts", () => {
-    const preferences = getDefaultPreferences();
-    const remoteResult = scoreJobFit({ ...baseJob, location: "Remote - United States", notes: "remote" }, preferences);
-    const hybridResult = scoreJobFit({ ...baseJob, location: "Philadelphia, PA", notes: "hybrid schedule" }, preferences);
+    const remotePreferences = {
+      ...getDefaultPreferences(),
+      preferredRemoteRegions: ["United States"],
+    };
+    const hybridPreferences = {
+      ...getDefaultPreferences(),
+      preferredHybridLocations: ["Philadelphia"],
+    };
+    const remoteResult = scoreJobFit(
+      { ...baseJob, location: "Remote", notes: "remote across the United States" },
+      remotePreferences,
+    );
+    const hybridResult = scoreJobFit(
+      { ...baseJob, location: "Pennsylvania", notes: "hybrid role with Philadelphia office days" },
+      hybridPreferences,
+    );
 
     assert.ok(remoteResult.preferenceSignals.some((signal) => signal.includes("Matched remote region")));
     assert.ok(hybridResult.preferenceSignals.some((signal) => signal.includes("Matched hybrid location")));
@@ -42,5 +55,25 @@ describe("scoreJobFit", () => {
   it("zeros score for excluded company and title", () => {
     assert.equal(scoreJobFit(baseJob, { ...getDefaultPreferences(), excludedCompanies: ["acme"] }).score, 0);
     assert.equal(scoreJobFit(baseJob, { ...getDefaultPreferences(), excludedTitles: ["architect"] }).score, 0);
+  });
+
+  it("prefers exclusion summaries for excluded rows", () => {
+    assert.equal(
+      summarizeJobReason({
+        excluded: true,
+        exclusionReasons: ["Onsite roles disabled"],
+        preferenceSignals: ["Matched target role: solutions architect"],
+      }),
+      "Excluded: Onsite roles disabled",
+    );
+
+    assert.equal(
+      summarizeJobReason({
+        excluded: false,
+        exclusionReasons: [],
+        preferenceSignals: ["Matched target role: solutions architect"],
+      }),
+      "Matched target role: solutions architect",
+    );
   });
 });

--- a/ui/partner-hub/lib/job-hunter/scoring.ts
+++ b/ui/partner-hub/lib/job-hunter/scoring.ts
@@ -1,5 +1,5 @@
 import { JOB_FIT_KEYWORDS } from "./keywordConfig";
-import { classifyWorkArrangement, getDefaultPreferences } from "./preferences";
+import { buildArrangementPreferenceText, classifyWorkArrangement, getDefaultPreferences } from "./preferences";
 import type { JobHunterPreferences, JobPosting } from "./types";
 
 export type KeywordMatch = {
@@ -13,6 +13,18 @@ export type JobFitScore = {
   matched: KeywordMatch[];
   missing: KeywordMatch[];
   preferenceSignals: string[];
+};
+
+export const summarizeJobReason = (params: {
+  excluded: boolean;
+  exclusionReasons: string[];
+  preferenceSignals: string[];
+}) => {
+  if (params.excluded && params.exclusionReasons.length > 0) {
+    return `Excluded: ${params.exclusionReasons.join(", ")}`;
+  }
+
+  return params.preferenceSignals[0] ?? "No preference signal";
 };
 
 const normalizeText = (value: string) => value.toLowerCase().replace(/[^a-z0-9\s-]/g, " ");
@@ -54,6 +66,7 @@ export const scoreJobFit = (job: JobPosting, preferences?: JobHunterPreferences)
   const appliedPreferences = preferences ?? getDefaultPreferences();
   const preferenceSignals: string[] = [];
   const arrangement = classifyWorkArrangement(job);
+  const arrangementText = buildArrangementPreferenceText(job);
 
   const matchedRole = includesAny(job.title, appliedPreferences.targetRoles);
   if (matchedRole) {
@@ -67,13 +80,13 @@ export const scoreJobFit = (job: JobPosting, preferences?: JobHunterPreferences)
     preferenceSignals.push(`Matched target keyword: ${matchedKeyword.toLowerCase()}`);
   }
 
-  const matchedHybridLocation = includesAny(job.location, appliedPreferences.preferredHybridLocations);
+  const matchedHybridLocation = includesAny(arrangementText, appliedPreferences.preferredHybridLocations);
   if (matchedHybridLocation && arrangement === "hybrid") {
     score += 6;
     preferenceSignals.push(`Matched hybrid location: ${matchedHybridLocation.toLowerCase()}`);
   }
 
-  const matchedRemoteRegion = includesAny(job.location ?? job.notes, appliedPreferences.preferredRemoteRegions);
+  const matchedRemoteRegion = includesAny(arrangementText, appliedPreferences.preferredRemoteRegions);
   if (matchedRemoteRegion && arrangement === "remote") {
     score += 6;
     preferenceSignals.push(`Matched remote region: ${matchedRemoteRegion.toLowerCase()}`);


### PR DESCRIPTION
### Motivation
- Close a quality gap where hybrid/remote preference matching used only `job.location` (or `job.location ?? job.notes`) while arrangement classification already used richer posting text, causing missed Philly-hybrid and remote-US matches when the signal lived in `notes` or other fields. 

### Description
- Added a shared helper `buildArrangementPreferenceText(job)` that composes `location`, `notes`, `employmentType`, and `title` and used it for arrangement classification and all arrangement-related preference checks. 
- Updated scoring boosts to use the same richer arrangement text for hybrid-location and remote-region matching and added `summarizeJobReason(...)` to centralize row summary behavior. 
- Changed Jobs page row generation to prefer an exclusion-first `reasonSummary` (for example, `Excluded: Onsite roles disabled`) when a job is excluded while preserving existing non-excluded fit signaling. 
- Files changed: `ui/partner-hub/lib/job-hunter/preferences.ts`, `ui/partner-hub/lib/job-hunter/scoring.ts`, `ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx`, `ui/partner-hub/lib/job-hunter/preferences.test.ts`, and `ui/partner-hub/lib/job-hunter/scoring.test.ts`. 

### Testing
- Ran `cd ui/partner-hub && npm run lint` which completed successfully with `✔ No ESLint warnings or errors`. 
- Ran `cd ui/partner-hub && npm run typecheck` which completed successfully (no type errors). 
- Ran `cd ui/partner-hub && npm run test` which completed successfully with the test runner summary showing `# pass 97` and `# fail 0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b09b20f5708330af9ee56ac37af43f)