### PR TITLE
Harden Job Hunter DOCX export compatibility

### DIFF
--- a/ui/partner-hub/lib/job-hunter/docExports.test.ts
+++ b/ui/partner-hub/lib/job-hunter/docExports.test.ts
@@ -88,10 +88,23 @@ describe("docExports", () => {
     assert.equal(coverArtifact.fileName, "james-siejk-acme-systems-solutions-architect-cover-letter.docx");
     assert.equal(resumeArtifact.mimeType, "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
     assert.equal(coverArtifact.mimeType, "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
-    assert.ok(resumeArtifact.bytes.length > 500);
-    assert.ok(coverArtifact.bytes.length > 300);
+    assert.ok(resumeArtifact.bytes.length > 2000);
+    assert.ok(coverArtifact.bytes.length > 1500);
     assert.equal(String.fromCharCode(...resumeArtifact.bytes.slice(0, 2)), "PK");
     assert.equal(String.fromCharCode(...coverArtifact.bytes.slice(0, 2)), "PK");
+
+    const resumeDocxRaw = Buffer.from(resumeArtifact.bytes).toString("latin1");
+    assert.ok(resumeDocxRaw.includes("[Content_Types].xml"));
+    assert.ok(resumeDocxRaw.includes("docProps/core.xml"));
+    assert.ok(resumeDocxRaw.includes("word/styles.xml"));
+    assert.ok(resumeDocxRaw.includes("word/fontTable.xml"));
+    assert.ok(resumeDocxRaw.includes("word/theme/theme1.xml"));
+    assert.ok(resumeDocxRaw.includes("James Siejk"));
+    assert.ok(resumeDocxRaw.includes("TAILORING DELTA (THIS JOB VARIANT ONLY)"));
+
+    const coverDocxRaw = Buffer.from(coverArtifact.bytes).toString("latin1");
+    assert.ok(coverDocxRaw.includes("Dear Hiring Team,"));
+    assert.ok(coverDocxRaw.includes("Sincerely,"));
   });
 
   it("preserves deterministic cover-letter line mapping", () => {

--- a/ui/partner-hub/lib/job-hunter/docExports.ts
+++ b/ui/partner-hub/lib/job-hunter/docExports.ts
@@ -73,6 +73,9 @@ const crc32 = (buffer: Uint8Array) => {
   return (current ^ 0xffffffff) >>> 0;
 };
 
+const FIXED_DOS_TIME = 0;
+const FIXED_DOS_DATE = (1 << 5) | 1;
+
 const createStoredZip = (entries: ZipEntry[]) => {
   const chunks: number[] = [];
   const centralDirectory: number[] = [];
@@ -88,8 +91,8 @@ const createStoredZip = (entries: ZipEntry[]) => {
       ...u16(20),
       ...u16(0),
       ...u16(0),
-      ...u16(0),
-      ...u16(0),
+      ...u16(FIXED_DOS_TIME),
+      ...u16(FIXED_DOS_DATE),
       ...u32(checksum),
       ...u32(data.length),
       ...u32(data.length),
@@ -106,8 +109,8 @@ const createStoredZip = (entries: ZipEntry[]) => {
       ...u16(20),
       ...u16(0),
       ...u16(0),
-      ...u16(0),
-      ...u16(0),
+      ...u16(FIXED_DOS_TIME),
+      ...u16(FIXED_DOS_DATE),
       ...u32(checksum),
       ...u32(data.length),
       ...u32(data.length),
@@ -146,10 +149,10 @@ const createStoredZip = (entries: ZipEntry[]) => {
 const toDocxBytes = (paragraphs: string[]) => {
   const documentXml = [
     '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
-    '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">',
+    '<w:document xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" mc:Ignorable="w14 wp14">',
     '<w:body>',
     ...paragraphs.map(toParagraphXml),
-    '<w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>',
+    '<w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/><w:docGrid w:linePitch="360"/></w:sectPr>',
     '</w:body>',
     '</w:document>',
   ].join("");
@@ -162,7 +165,13 @@ const toDocxBytes = (paragraphs: string[]) => {
           '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
           '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
           '<Default Extension="xml" ContentType="application/xml"/>' +
+          '<Override PartName="/docProps/app.xml" ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml"/>' +
+          '<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>' +
           '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+          '<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>' +
+          '<Override PartName="/word/settings.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml"/>' +
+          '<Override PartName="/word/fontTable.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.fontTable+xml"/>' +
+          '<Override PartName="/word/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>' +
           "</Types>",
       ),
     },
@@ -172,12 +181,94 @@ const toDocxBytes = (paragraphs: string[]) => {
         '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
           '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
           '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+          '<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>' +
+          '<Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties" Target="docProps/app.xml"/>' +
           "</Relationships>",
+      ),
+    },
+    {
+      path: "docProps/core.xml",
+      data: textEncoder.encode(
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+          '<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+          "<dc:title>Job Hunter Export</dc:title>" +
+          "<dc:creator>Partner Hub Job Hunter</dc:creator>" +
+          "<cp:lastModifiedBy>Partner Hub Job Hunter</cp:lastModifiedBy>" +
+          '<dcterms:created xsi:type="dcterms:W3CDTF">2024-01-01T00:00:00Z</dcterms:created>' +
+          '<dcterms:modified xsi:type="dcterms:W3CDTF">2024-01-01T00:00:00Z</dcterms:modified>' +
+          "</cp:coreProperties>",
+      ),
+    },
+    {
+      path: "docProps/app.xml",
+      data: textEncoder.encode(
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+          '<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">' +
+          "<Application>Partner Hub Job Hunter</Application>" +
+          "<DocSecurity>0</DocSecurity>" +
+          "<ScaleCrop>false</ScaleCrop>" +
+          "<Company></Company>" +
+          "<LinksUpToDate>false</LinksUpToDate>" +
+          "<SharedDoc>false</SharedDoc>" +
+          "<HyperlinksChanged>false</HyperlinksChanged>" +
+          "<AppVersion>1.0</AppVersion>" +
+          "</Properties>",
       ),
     },
     {
       path: "word/document.xml",
       data: textEncoder.encode(documentXml),
+    },
+    {
+      path: "word/_rels/document.xml.rels",
+      data: textEncoder.encode(
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+          '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+          '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>' +
+          '<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings" Target="settings.xml"/>' +
+          '<Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable" Target="fontTable.xml"/>' +
+          '<Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="theme/theme1.xml"/>' +
+          "</Relationships>",
+      ),
+    },
+    {
+      path: "word/styles.xml",
+      data: textEncoder.encode(
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+          '<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
+          '<w:docDefaults><w:rPrDefault><w:rPr><w:rFonts w:ascii="Calibri" w:hAnsi="Calibri" w:eastAsia="Calibri" w:cs="Calibri"/><w:sz w:val="22"/><w:szCs w:val="22"/></w:rPr></w:rPrDefault><w:pPrDefault/></w:docDefaults>' +
+          '<w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>' +
+          "</w:styles>",
+      ),
+    },
+    {
+      path: "word/settings.xml",
+      data: textEncoder.encode(
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+          '<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
+          '<w:zoom w:percent="100"/>' +
+          '<w:defaultTabStop w:val="720"/>' +
+          '<w:compat><w:compatSetting w:name="compatibilityMode" w:uri="http://schemas.microsoft.com/office/word" w:val="15"/></w:compat>' +
+          "</w:settings>",
+      ),
+    },
+    {
+      path: "word/fontTable.xml",
+      data: textEncoder.encode(
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+          '<w:fonts xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
+          '<w:font w:name="Calibri"><w:panose1 w:val="020F0502020204030204"/><w:charset w:val="00"/><w:family w:val="swiss"/><w:pitch w:val="variable"/></w:font>' +
+          "</w:fonts>",
+      ),
+    },
+    {
+      path: "word/theme/theme1.xml",
+      data: textEncoder.encode(
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+          '<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme">' +
+          '<a:themeElements><a:clrScheme name="Office"><a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1><a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1></a:clrScheme><a:fontScheme name="Office"><a:majorFont><a:latin typeface="Calibri"/></a:majorFont><a:minorFont><a:latin typeface="Calibri"/></a:minorFont></a:fontScheme><a:fmtScheme name="Office"><a:fillStyleLst/><a:lnStyleLst/><a:effectStyleLst/><a:bgFillStyleLst/></a:fmtScheme></a:themeElements>' +
+          "</a:theme>",
+      ),
     },
   ];
 


### PR DESCRIPTION
### Motivation
- Improve real-world interoperability of Job Hunter tailored resume and cover-letter DOCX exports so they open cleanly in Microsoft Word, Google Docs, and ATS upload flows. 
- The existing minimal, handwritten DOCX/ZIP builder is workable but missing common OpenXML parts and metadata that many parsers expect, so compatibility should be hardened before building further apply-handoff features.

### Description
- Hardened the in-repo DOCX package builder by adding standard OpenXML package parts, relationships, and richer document metadata (added `docProps/core.xml`, `docProps/app.xml`, `word/_rels/document.xml.rels`, `word/styles.xml`, `word/settings.xml`, `word/fontTable.xml`, and `word/theme/theme1.xml`) and updated `[Content_Types].xml` and root rels to reference them. 
- Stabilized ZIP metadata used in the central directory by setting fixed DOS date/time fields to produce deterministic, more-compatible archives. 
- Preserved the public artifact interface and deterministic content (kept `DocExportArtifact` shape: `fileName`, `mimeType`, `bytes`) and did not change resume/cover-letter content flow or ATS-safe filename logic. 
- Added compatibility-focused assertions to `docExports` tests to verify key package parts are present inside the produced DOCX bytes and strengthened size checks; no new dependency was introduced because an attempt to install `docx` was blocked in this environment. 
- Changed files: `ui/partner-hub/lib/job-hunter/docExports.ts`, `ui/partner-hub/lib/job-hunter/docExports.test.ts`.

### Testing
- Ran `cd ui/partner-hub && npm run lint` which returned (abridged):
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> partner-hub@0.0.1 lint
> next lint

`next lint` is deprecated and will be removed in Next.js 16.
...
✔ No ESLint warnings or errors
```
- Ran `cd ui/partner-hub && npm run typecheck` which executed `tsc --noEmit` and completed with no type errors (command completed successfully; no tsc diagnostics were emitted). 
- Ran `cd ui/partner-hub && npm run test` and the test suite passed; relevant summary (abridged) shows:
```
TAP version 13
...
# tests 120
# suites 36
# pass 120
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 2835.19881
```
- Note: I attempted to swap to a maintained `docx` library but `npm install docx` failed with a `403 Forbidden` from the registry in this environment, so the patch hardens the existing builder without adding new deps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8555cbdb08330b6ec4c6dac5b200f)