### PR TITLE
Strengthen DOCX export tests; follow-up for DOCX library migration

### DIFF
--- a/ui/partner-hub/lib/job-hunter/docExports.test.ts
+++ b/ui/partner-hub/lib/job-hunter/docExports.test.ts
@@ -97,12 +97,15 @@ describe("docExports", () => {
     const resumeArchive = await JSZip.loadAsync(Buffer.from(resumeArtifact.bytes));
     assert.ok(Boolean(resumeArchive.file("[Content_Types].xml")));
     assert.ok(Boolean(resumeArchive.file("word/document.xml")));
+    assert.ok(Boolean(resumeArchive.file("word/styles.xml")));
+    assert.ok(Boolean(resumeArchive.file("docProps/core.xml")));
     const resumeDocumentXml = await resumeArchive.file("word/document.xml")!.async("text");
     assert.ok(resumeDocumentXml.includes("James Siejk"));
     assert.ok(resumeDocumentXml.includes("TAILORING DELTA (THIS JOB VARIANT ONLY)"));
 
     const coverArchive = await JSZip.loadAsync(Buffer.from(coverArtifact.bytes));
     assert.ok(Boolean(coverArchive.file("word/document.xml")));
+    assert.ok(Boolean(coverArchive.file("_rels/.rels")));
     const coverDocumentXml = await coverArchive.file("word/document.xml")!.async("text");
     assert.ok(coverDocumentXml.includes("Dear Hiring Team,"));
     assert.ok(coverDocumentXml.includes("Sincerely,"));


### PR DESCRIPTION
### Motivation
- Finalize hardening of Job Hunter DOCX exports by replacing fragile hand-constructed DOCX parts with a standards-based generator so documents are more compatible with Word/Docs/ATS.

### Description
- Strengthen `docExports.test.ts` to assert that generated DOCX archives include key package parts (`[Content_Types].xml`, `word/document.xml`, `word/styles.xml`, `docProps/core.xml`, and `_rels/.rels`) while preserving filename, MIME type, and deterministic content checks.
- Preserve the public export artifact shape (`fileName`, `mimeType`, `bytes`) and the existing tailoring logic and output formatting; no tailoring logic or UI wiring was changed.
- An attempted migration to a library such as `docx` was performed in a local edit but package installation was blocked by registry access (HTTP 403), so the runtime implementation was left unchanged and JSZip remains required for packaging in this environment.

### Testing
- Ran `cd ui/partner-hub && npm run lint` and it completed with no ESLint warnings or errors.
- Ran `cd ui/partner-hub && npm run typecheck` and the TypeScript check completed successfully with no errors.
- Ran `cd ui/partner-hub && npm run test` and all tests passed: `# tests 120`, `# pass 120`, `# fail 0` (full test run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b85cd5a97c833084cc11a69dec8ebc)