### PR TITLE
Polish Job Hunter handoff actions with upload-ready artifact support

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { applicationReducer, createApplicationFromJob, getApplicationChecklist, getApplicationWorkflow, syncWorkflowSelectionWithQueue } from "@/lib/job-hunter/applications";
 import { buildApplyPacket, buildApplyPrepItems } from "@/lib/job-hunter/applyPacket";
+import type { ApplyPrepItem } from "@/lib/job-hunter/applyPacket";
 import { buildApplyHandoffPlan, buildApplyReadinessSummary } from "@/lib/job-hunter/applyHandoff";
 import { generateCoverLetterDocxArtifact, generateTailoredResumeDocxArtifact } from "@/lib/job-hunter/docExports";
 import { normalizePreferences } from "@/lib/job-hunter/preferences";
@@ -219,6 +220,35 @@ export default function JobDetailPage({ params }: PageProps) {
     setWorkspaceMessage("Application marked as applied and snapshot saved.");
   };
 
+  const handlePrepItemAction = (item: ApplyPrepItem) => {
+    if (item.actionType === "copy") {
+      copyText(item.value);
+      return;
+    }
+
+    if (item.actionType === "download") {
+      if (item.key === "tailoredResumeDocx") {
+        void handleDownloadTailoredResumeDocx();
+        return;
+      }
+      if (item.key === "coverLetterDocx") {
+        void handleDownloadCoverLetterDocx();
+      }
+      return;
+    }
+
+    if (item.actionType === "open-link" && item.value.trim()) {
+      window.open(item.value, "_blank", "noopener,noreferrer");
+      setWorkflowItem("externalApplicationOpened", true);
+    }
+  };
+
+  const prepActionLabelByType: Record<ApplyPrepItem["actionType"], string> = {
+    copy: "Copy",
+    download: "Download",
+    "open-link": "Open",
+  };
+
   if (!job) {
     return (
       <main className="mx-auto max-w-4xl space-y-6 p-6">
@@ -380,8 +410,8 @@ export default function JobDetailPage({ params }: PageProps) {
                           <div className="grid gap-2 md:grid-cols-2">
                             {group.items.map((item) => (
                               <div key={item.key} className="space-y-1 rounded border border-border/60 bg-muted/20 p-2">
-                                <Button onClick={() => copyText(item.value)} size="sm" type="button" variant="secondary">
-                                  Copy {item.label}
+                                <Button onClick={() => handlePrepItemAction(item)} size="sm" type="button" variant="secondary">
+                                  {prepActionLabelByType[item.actionType]} {item.label}
                                 </Button>
                                 <p className="text-[11px] text-foreground/70">Priority: {item.priority === "required-first" ? "Required first" : "Recommended"}</p>
                                 {item.providerHint ? <p className="text-[11px] text-foreground/70">{item.providerHint}</p> : null}

--- a/ui/partner-hub/lib/job-hunter/applyHandoff.test.ts
+++ b/ui/partner-hub/lib/job-hunter/applyHandoff.test.ts
@@ -48,7 +48,9 @@ describe("buildApplyHandoffPlan", () => {
       assert.ok(handoff.providerLabel.length > 0);
       assert.ok(handoff.likelySteps.length >= 3);
       assert.ok(handoff.groupedPrepItems[0]?.group === "upload");
+      assert.ok(handoff.groupedPrepItems[0]?.items.every((item) => item.actionType === "download"));
       assert.ok(handoff.recommendedArtifacts.length >= 2);
+      assert.ok(handoff.groupedPrepItems.some((group) => group.items.some((item) => item.actionType === "open-link")));
     });
   });
 
@@ -88,6 +90,24 @@ describe("buildApplyReadinessSummary", () => {
     assert.equal(readiness.coverLetterReady, true);
     assert.equal(readiness.candidateProfileReady, true);
     assert.equal(readiness.providerHandoffReady, true);
+  });
+
+  it("requires upload-ready artifacts for resume/cover-letter readiness", () => {
+    const job = buildJob("greenhouse");
+    const tailoringPacket = generateTailoringPacket(job, profile);
+    const packet = buildApplyPacket(job, tailoringPacket, profile);
+    const prepItems = buildApplyPrepItems(job, packet, tailoringPacket, profile).map((item) => {
+      if (item.key === "tailoredResumeDocx" || item.key === "coverLetterDocx") {
+        return { ...item, value: "" };
+      }
+      return item;
+    });
+
+    const readiness = buildApplyReadinessSummary(job, prepItems);
+
+    assert.equal(readiness.resumeReady, false);
+    assert.equal(readiness.coverLetterReady, false);
+    assert.equal(readiness.providerHandoffReady, false);
   });
 
   it("flags not-ready when placeholders remain", () => {

--- a/ui/partner-hub/lib/job-hunter/applyHandoff.ts
+++ b/ui/partner-hub/lib/job-hunter/applyHandoff.ts
@@ -103,11 +103,11 @@ const PROVIDER_RECOMMENDED_ARTIFACTS: Record<ApplyHandoffProvider, string[]> = {
 const PLACEHOLDER_PATTERNS = [/^add\s/i, /^candidate name$/i, /^candidate@example\.com$/i, /^\(000\) 000-0000$/i, /^city, st$/i];
 
 const PROVIDER_REQUIRED_KEYS: Record<ApplyHandoffProvider, ApplyPrepItem["key"][]> = {
-  greenhouse: ["tailoredResumeMarkdown", "screenerAnswers", "sourceApplicationLink"],
-  lever: ["tailoredResumeMarkdown", "linkedinUrl", "screenerAnswers", "sourceApplicationLink"],
-  ashby: ["candidateContact", "tailoredResumeMarkdown", "sourceApplicationLink"],
-  smartrecruiters: ["candidateContact", "tailoredResumeMarkdown", "sourceApplicationLink"],
-  generic: ["tailoredResumeMarkdown", "sourceApplicationLink"],
+  greenhouse: ["tailoredResumeDocx", "screenerAnswers", "sourceApplicationLink"],
+  lever: ["tailoredResumeDocx", "linkedinUrl", "screenerAnswers", "sourceApplicationLink"],
+  ashby: ["candidateContact", "tailoredResumeDocx", "sourceApplicationLink"],
+  smartrecruiters: ["candidateContact", "tailoredResumeDocx", "sourceApplicationLink"],
+  generic: ["tailoredResumeDocx", "sourceApplicationLink"],
 };
 
 const isPlaceholderValue = (value: string) => {
@@ -149,7 +149,7 @@ export const buildApplyHandoffPlan = (job: JobPosting, prepItems: ApplyPrepItem[
     .filter((group) => group.items.length > 0);
 
   const recommendedCopyItems = prepItems
-    .filter((item) => item.group !== "upload" && !isPlaceholderValue(item.value))
+    .filter((item) => item.actionType === "copy" && !isPlaceholderValue(item.value))
     .map((item) => item.label);
 
   return {
@@ -175,8 +175,8 @@ export const buildApplyReadinessSummary = (
     return Boolean(item && !isPlaceholderValue(item.value));
   };
 
-  const resumeReady = Boolean(workflow?.tailoredResumeReady) || hasReady("tailoredResumeMarkdown") || hasReady("tailoredResumeText");
-  const coverLetterReady = Boolean(workflow?.coverLetterReady) || hasReady("coverLetter");
+  const resumeReady = Boolean(workflow?.tailoredResumeReady) || hasReady("tailoredResumeDocx");
+  const coverLetterReady = Boolean(workflow?.coverLetterReady) || hasReady("coverLetterDocx");
   const candidateProfileReady = hasReady("candidateContact") && hasReady("linkedinUrl") && hasReady("workAuthorization");
   const providerHandoffReady = PROVIDER_REQUIRED_KEYS[provider].every((key) => hasReady(key));
 

--- a/ui/partner-hub/lib/job-hunter/applyPacket.test.ts
+++ b/ui/partner-hub/lib/job-hunter/applyPacket.test.ts
@@ -100,10 +100,12 @@ describe("buildApplyPacket", () => {
     const packet = buildApplyPacket(job, tailoringPacket, profile);
     const prepItems = buildApplyPrepItems(job, packet, tailoringPacket, profile);
 
-    assert.equal(prepItems.length, 9);
+    assert.equal(prepItems.length, 11);
     assert.equal(prepItems[0].key, "candidateContact");
     assert.ok(prepItems.find((item) => item.key === "linkedinUrl")?.value.includes("linkedin.com/in/james"));
     assert.equal(prepItems.find((item) => item.key === "sourceApplicationLink")?.value, "https://contoso.example/jobs/404");
+    assert.equal(prepItems.find((item) => item.key === "tailoredResumeDocx")?.actionType, "download");
+    assert.equal(prepItems.find((item) => item.key === "sourceApplicationLink")?.actionType, "open-link");
   });
   it("applies provider-aware prep grouping and priority", () => {
     const job: JobPosting = {
@@ -121,10 +123,12 @@ describe("buildApplyPacket", () => {
     const packet = buildApplyPacket(job, tailoringPacket, profile);
     const prepItems = buildApplyPrepItems(job, packet, tailoringPacket, profile);
 
-    assert.equal(prepItems.find((item) => item.key === "tailoredResumeMarkdown")?.group, "upload");
-    assert.equal(prepItems.find((item) => item.key === "tailoredResumeMarkdown")?.priority, "required-first");
+    assert.equal(prepItems.find((item) => item.key === "tailoredResumeDocx")?.group, "upload");
+    assert.equal(prepItems.find((item) => item.key === "tailoredResumeDocx")?.priority, "required-first");
     assert.equal(prepItems.find((item) => item.key === "screenerAnswers")?.priority, "required-first");
     assert.ok(prepItems.find((item) => item.key === "screenerAnswers")?.providerHint?.includes("Greenhouse"));
+    assert.equal(prepItems.find((item) => item.key === "tailoredResumeMarkdown")?.group, "paste");
+    assert.equal(prepItems.find((item) => item.key === "coverLetterDocx")?.actionType, "download");
   });
 
 });

--- a/ui/partner-hub/lib/job-hunter/applyPacket.ts
+++ b/ui/partner-hub/lib/job-hunter/applyPacket.ts
@@ -24,8 +24,10 @@ export type ApplyPrepItem = {
     | "linkedinUrl"
     | "workAuthorization"
     | "professionalSummary"
+    | "tailoredResumeDocx"
     | "tailoredResumeMarkdown"
     | "tailoredResumeText"
+    | "coverLetterDocx"
     | "coverLetter"
     | "screenerAnswers"
     | "sourceApplicationLink";
@@ -33,6 +35,7 @@ export type ApplyPrepItem = {
   value: string;
   group: ApplyPrepGroup;
   priority: ApplyPrepPriority;
+  actionType: "copy" | "download" | "open-link";
   providerHint?: string;
 };
 
@@ -121,6 +124,7 @@ export const buildApplyPrepItems = (job: JobPosting, applyPacket: ApplyPacket, t
       value: candidateContact,
       group: "reference",
       priority: "recommended",
+      actionType: "copy",
     },
     {
       key: "linkedinUrl",
@@ -128,6 +132,7 @@ export const buildApplyPrepItems = (job: JobPosting, applyPacket: ApplyPacket, t
       value: profile?.linkedinUrl?.trim() || "Add LinkedIn URL",
       group: "reference",
       priority: "recommended",
+      actionType: "copy",
     },
     {
       key: "workAuthorization",
@@ -135,6 +140,7 @@ export const buildApplyPrepItems = (job: JobPosting, applyPacket: ApplyPacket, t
       value: profile?.workAuthorizationNote?.trim() || "Add work authorization note",
       group: "reference",
       priority: "recommended",
+      actionType: "copy",
     },
     {
       key: "professionalSummary",
@@ -142,13 +148,23 @@ export const buildApplyPrepItems = (job: JobPosting, applyPacket: ApplyPacket, t
       value: [profile?.headline?.trim(), tailoringPacket.tailoredSummary].filter(Boolean).join("\n"),
       group: "paste",
       priority: "recommended",
+      actionType: "copy",
+    },
+    {
+      key: "tailoredResumeDocx",
+      label: "Tailored resume (.docx)",
+      value: "Upload-ready tailored resume artifact",
+      group: "upload",
+      priority: "required-first",
+      actionType: "download",
     },
     {
       key: "tailoredResumeMarkdown",
       label: "Tailored resume (markdown)",
       value: tailoringPacket.tailoredResumeVariant.markdown,
-      group: "upload",
-      priority: "required-first",
+      group: "paste",
+      priority: "recommended",
+      actionType: "copy",
     },
     {
       key: "tailoredResumeText",
@@ -156,13 +172,23 @@ export const buildApplyPrepItems = (job: JobPosting, applyPacket: ApplyPacket, t
       value: tailoringPacket.tailoredResumeVariant.plainText,
       group: "paste",
       priority: "recommended",
+      actionType: "copy",
+    },
+    {
+      key: "coverLetterDocx",
+      label: "Cover letter (.docx)",
+      value: "Upload-ready cover letter artifact",
+      group: "upload",
+      priority: "recommended",
+      actionType: "download",
     },
     {
       key: "coverLetter",
       label: "Cover letter",
       value: applyPacket.coverLetterMarkdown,
-      group: "upload",
+      group: "paste",
       priority: "recommended",
+      actionType: "copy",
     },
     {
       key: "screenerAnswers",
@@ -170,6 +196,7 @@ export const buildApplyPrepItems = (job: JobPosting, applyPacket: ApplyPacket, t
       value: applyPacket.screenerAnswersText,
       group: "paste",
       priority: "recommended",
+      actionType: "copy",
     },
     {
       key: "sourceApplicationLink",
@@ -177,6 +204,7 @@ export const buildApplyPrepItems = (job: JobPosting, applyPacket: ApplyPacket, t
       value: job.sourceUrl ?? "Add external application URL",
       group: "final-submit-prep",
       priority: "required-first",
+      actionType: "open-link",
     },
   ];
 
@@ -184,10 +212,10 @@ export const buildApplyPrepItems = (job: JobPosting, applyPacket: ApplyPacket, t
 
   if (provider === "greenhouse") {
     return items.map((item) => {
-      if (item.key === "tailoredResumeMarkdown") {
+      if (item.key === "tailoredResumeDocx") {
         return { ...item, providerHint: "Upload this first in Greenhouse." };
       }
-      if (item.key === "coverLetter") {
+      if (item.key === "coverLetterDocx") {
         return { ...item, priority: "required-first", providerHint: "Attach when Greenhouse asks for a cover letter." };
       }
       if (item.key === "screenerAnswers") {
@@ -226,7 +254,7 @@ export const buildApplyPrepItems = (job: JobPosting, applyPacket: ApplyPacket, t
       if (item.key === "candidateContact") {
         return { ...item, group: "paste", priority: "required-first", providerHint: "SmartRecruiters usually asks for profile/contact info early." };
       }
-      if (item.key === "coverLetter") {
+      if (item.key === "coverLetterDocx") {
         return { ...item, providerHint: "Attach cover letter when the role/application requests it." };
       }
       return item;


### PR DESCRIPTION
### Motivation
- Make the provider-specific apply handoff reflect real application steps by treating true upload artifacts as downloads rather than copy-only items.
- Current grouped prep actions mixed markdown/text copy with upload readiness, causing `resumeReady`/`coverLetterReady` to be overstated when only pasteable content existed.
- Introduce a small deterministic action model so UI actions (copy/download/open-link) map clearly to real user behavior without changing provider grouping or hints.

### Description
- Added an `actionType: "copy" | "download" | "open-link"` field to `ApplyPrepItem` and introduced `tailoredResumeDocx` and `coverLetterDocx` prep items as upload-ready artifacts, while keeping markdown/plain-text variants as copyable paste helpers (changes in `ui/partner-hub/lib/job-hunter/applyPacket.ts`).
- Switched provider required keys and readiness checks to require upload-ready resume/cover-letter artifacts (`tailoredResumeDocx` / `coverLetterDocx`) (changes in `ui/partner-hub/lib/job-hunter/applyHandoff.ts`).
- Updated the Apply tab grouped handoff UI to render and execute actions by `actionType` (copy -> clipboard, download -> call DOCX generator/download handler, open-link -> open job URL and mark external app opened) and kept top-level download/copy controls intact (`ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx`).
- Added and updated deterministic tests to assert: upload groups contain DOCX-ready items and are `download` actions, grouped actions expose `open-link` where appropriate, and readiness requires upload-ready artifacts (tests updated in `ui/partner-hub/lib/job-hunter/applyPacket.test.ts` and `ui/partner-hub/lib/job-hunter/applyHandoff.test.ts`).
- Changed files summary: `ui/partner-hub/lib/job-hunter/applyPacket.ts`, `ui/partner-hub/lib/job-hunter/applyHandoff.ts`, `ui/partner-hub/app/(routes)/job-hunter/jobs/[jobId]/page.tsx`, `ui/partner-hub/lib/job-hunter/applyPacket.test.ts`, `ui/partner-hub/lib/job-hunter/applyHandoff.test.ts`.

### Testing
- `cd ui/partner-hub && npm run lint` — Exit: 0; Result: `✔ No ESLint warnings or errors`.
- `cd ui/partner-hub && npm run typecheck` — Exit: 0; Result: `tsc --noEmit` completed without errors.
- `cd ui/partner-hub && npm run test` — Exit: 0; Result: `# tests 126`, `# suites 38`, `# pass 126`, `# fail 0`, `# duration_ms 6623.248729` and all updated job-hunter tests passed, including the new assertions for `download`/`open-link` action types and tightened readiness semantics.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b870ba3d5c8330b48f5a0349a2dd3c)