### PR TITLE
Align Job Hunter apply companion runtime heuristics with tested provider logic

### DIFF
--- a/ui/partner-hub/extensions/job-hunter-apply-companion/content.js
+++ b/ui/partner-hub/extensions/job-hunter-apply-companion/content.js
@@ -1,29 +1,13 @@
 (() => {
-  const detectProvider = () => {
-    const url = window.location.href;
-    if (/greenhouse\.io/i.test(url)) return "greenhouse";
-    if (/lever\.co/i.test(url)) return "lever";
-    if (/ashbyhq\.com/i.test(url)) return "ashby";
-    if (/smartrecruiters\.com/i.test(url)) return "smartrecruiters";
-    return null;
-  };
+  const heuristics = globalThis.JobHunterApplyCompanionHeuristics;
 
-  const tokensByKey = {
-    fullName: ["full name", "fullname", "candidate name", "name"],
-    firstName: ["first name", "firstname", "given name", "first_name"],
-    lastName: ["last name", "lastname", "family name", "surname", "last_name"],
-    email: ["email", "e-mail"],
-    phone: ["phone", "mobile", "telephone"],
-    location: ["city", "state", "location", "address"],
-    linkedinUrl: ["linkedin"],
-    websiteUrl: ["website", "portfolio", "github", "personal site", "url"],
-    workAuthorizationNote: ["work authorization", "authorized", "sponsorship", "visa", "employment eligibility"],
-    coverLetterText: ["cover letter", "why this role", "additional information"]
-  };
+  const detectProvider = () => heuristics?.detectProviderFromUrl(window.location.href) ?? null;
 
-  const fieldValue = (session, key) => {
+  const fieldValue = (session, key, signal) => {
     if (key === "coverLetterText") return session?.tailored?.coverLetterText || "";
-    if (key === "location") return session?.candidate?.cityState || "";
+    if (key === "location") {
+      return heuristics?.selectLocationValue({ cityState: session?.candidate?.cityState || "", signal }) || "";
+    }
     return session?.candidate?.[key] || "";
   };
 
@@ -32,32 +16,21 @@
     return [el.id, el.name, el.placeholder, el.getAttribute("aria-label"), label].filter(Boolean).join(" ").toLowerCase();
   };
 
-  const matchKey = (el) => {
-    const signal = getSignal(el);
-    if (!signal.trim()) return null;
-
-    const rank = ["firstName", "lastName", "email", "phone", "linkedinUrl", "websiteUrl", "workAuthorizationNote", "coverLetterText", "location", "fullName"];
-    for (const key of rank) {
-      if (key === "coverLetterText" && el.tagName.toLowerCase() !== "textarea") continue;
-      if (tokensByKey[key].some((token) => signal.includes(token))) {
-        if (key === "fullName" && (signal.includes("first") || signal.includes("last"))) continue;
-        if (key === "location" && signal.includes("relocation")) continue;
-        return key;
-      }
-    }
-    return null;
-  };
+  const matchKey = (el, provider) =>
+    heuristics?.matchKeyFromSignal({ signal: getSignal(el), tagName: el.tagName, provider }) ?? null;
 
   const fillBasicFields = (session) => {
     const filled = [];
     const manual = [];
     const inputs = Array.from(document.querySelectorAll("input, textarea"));
+    const provider = detectProvider();
 
     for (const el of inputs) {
       if (el.disabled || el.readOnly) continue;
-      const key = matchKey(el);
+      const signal = getSignal(el);
+      const key = matchKey(el, provider);
       if (!key) continue;
-      const value = fieldValue(session, key);
+      const value = fieldValue(session, key, signal);
       if (!value || String(value).trim() === "") {
         manual.push(`${key} (missing in session)`);
         continue;

--- a/ui/partner-hub/extensions/job-hunter-apply-companion/heuristics.js
+++ b/ui/partner-hub/extensions/job-hunter-apply-companion/heuristics.js
@@ -1,0 +1,106 @@
+(() => {
+  const providerPatterns = {
+    greenhouse: [/greenhouse\.io/i],
+    lever: [/lever\.co/i, /jobs\.lever\.co/i],
+    ashby: [/ashbyhq\.com/i],
+    smartrecruiters: [/smartrecruiters\.com/i],
+  };
+
+  const commonTokensByKey = {
+    fullName: ["full name", "fullname", "candidate name", "name"],
+    firstName: ["first name", "firstname", "given name"],
+    lastName: ["last name", "lastname", "family name", "surname"],
+    email: ["email", "e-mail"],
+    phone: ["phone", "mobile", "telephone"],
+    location: ["city", "state", "location", "address"],
+    linkedinUrl: ["linkedin"],
+    websiteUrl: ["website", "portfolio", "github", "personal site", "url"],
+    workAuthorizationNote: ["work authorization", "authorized", "sponsorship", "visa", "employment eligibility"],
+    coverLetterText: ["cover letter", "why this role", "why do you want", "additional information"],
+  };
+
+  const providerExtraTokensByKey = {
+    greenhouse: {
+      firstName: ["first_name"],
+      lastName: ["last_name"],
+      linkedinUrl: ["linkedin_url"],
+    },
+    lever: {
+      fullName: ["name"],
+      phone: ["phone number"],
+    },
+    ashby: {
+      linkedinUrl: ["linkedin profile"],
+    },
+    smartrecruiters: {
+      workAuthorizationNote: ["work permit", "authorized to work"],
+    },
+  };
+
+  const rank = [
+    "firstName",
+    "lastName",
+    "email",
+    "phone",
+    "linkedinUrl",
+    "websiteUrl",
+    "workAuthorizationNote",
+    "coverLetterText",
+    "location",
+    "fullName",
+  ];
+
+  const detectProviderFromUrl = (url) => {
+    for (const [provider, patterns] of Object.entries(providerPatterns)) {
+      if (patterns.some((pattern) => pattern.test(url))) {
+        return provider;
+      }
+    }
+    return null;
+  };
+
+  const matchKeyFromSignal = ({ signal, tagName, provider }) => {
+    const loweredSignal = String(signal || "").toLowerCase();
+    if (!loweredSignal.trim()) return null;
+
+    const isTextarea = String(tagName || "").toLowerCase() === "textarea";
+
+    for (const key of rank) {
+      if (key === "coverLetterText" && !isTextarea) continue;
+
+      const providerTokens = provider ? providerExtraTokensByKey[provider]?.[key] || [] : [];
+      const tokens = [...commonTokensByKey[key], ...providerTokens];
+
+      if (!tokens.some((token) => loweredSignal.includes(token))) continue;
+      if (key === "fullName" && (loweredSignal.includes("first") || loweredSignal.includes("last"))) continue;
+      if (key === "location" && loweredSignal.includes("relocation")) continue;
+
+      return key;
+    }
+
+    return null;
+  };
+
+  const selectLocationValue = ({ cityState, signal }) => {
+    const source = String(cityState || "");
+    const loweredSignal = String(signal || "").toLowerCase();
+    const [city, stateRaw] = source.split(",");
+    const state = stateRaw?.trim() || "";
+
+    if (loweredSignal.includes("city") && !loweredSignal.includes("state")) {
+      return city?.trim() || source;
+    }
+
+    if (loweredSignal.includes("state") && !loweredSignal.includes("city")) {
+      return state || source;
+    }
+
+    return source;
+  };
+
+  globalThis.JobHunterApplyCompanionHeuristics = {
+    detectProviderFromUrl,
+    matchKeyFromSignal,
+    selectLocationValue,
+  };
+})();

--- a/ui/partner-hub/extensions/job-hunter-apply-companion/manifest.json
+++ b/ui/partner-hub/extensions/job-hunter-apply-companion/manifest.json
@@ -3,7 +3,12 @@
   "name": "Job Hunter Apply Companion",
   "version": "0.1.0",
   "description": "Paste a Job Hunter apply-session JSON and conservatively prefill common ATS fields.",
-  "permissions": ["activeTab", "scripting", "tabs", "storage"],
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "tabs",
+    "storage"
+  ],
   "host_permissions": [
     "*://*.greenhouse.io/*",
     "*://*.lever.co/*",
@@ -22,7 +27,10 @@
         "*://*.ashbyhq.com/*",
         "*://*.smartrecruiters.com/*"
       ],
-      "js": ["content.js"],
+      "js": [
+        "heuristics.js",
+        "content.js"
+      ],
       "run_at": "document_idle"
     }
   ]

--- a/ui/partner-hub/lib/job-hunter/applyCompanion.test.ts
+++ b/ui/partner-hub/lib/job-hunter/applyCompanion.test.ts
@@ -1,7 +1,15 @@
 import * as assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, it } from "node:test";
+import * as vm from "node:vm";
 
-import { detectApplyProviderFromUrl, getFieldValueForKey, matchBasicFieldKey } from "./applyCompanion";
+import {
+  detectApplyProviderFromUrl,
+  getFieldValueForKey,
+  matchBasicFieldKey,
+  type CompanionFieldCandidate,
+} from "./applyCompanion";
 import type { ApplySessionPayload } from "./applySession";
 
 const session: ApplySessionPayload = {
@@ -66,5 +74,47 @@ describe("apply companion field matching heuristics", () => {
     assert.equal(getFieldValueForKey("fullName", session), "James Wang");
     assert.equal(getFieldValueForKey("websiteUrl", session), "https://james.dev");
     assert.equal(getFieldValueForKey("coverLetterText", session), "Dear Hiring Team");
+  });
+
+  it("keeps extension runtime heuristics aligned with tested helper behavior", () => {
+    const scriptPath = join(process.cwd(), "extensions/job-hunter-apply-companion/heuristics.js");
+    const runtimeSource = readFileSync(scriptPath, "utf8");
+    const sandbox: { globalThis: { JobHunterApplyCompanionHeuristics?: any } } = { globalThis: {} };
+    vm.runInNewContext(runtimeSource, sandbox);
+    const runtime = sandbox.globalThis.JobHunterApplyCompanionHeuristics;
+
+    assert.ok(runtime);
+
+    const providers = ["greenhouse", "lever", "ashby", "smartrecruiters"] as const;
+    const fields: CompanionFieldCandidate[] = [
+      { tagName: "input", name: "first_name" },
+      { tagName: "input", name: "last_name" },
+      { tagName: "input", ariaLabel: "Email address" },
+      { tagName: "input", labelText: "Phone number" },
+      { tagName: "input", labelText: "LinkedIn profile" },
+      { tagName: "input", labelText: "Personal website URL" },
+      { tagName: "textarea", labelText: "Cover letter" },
+      { tagName: "input", labelText: "Relocation support needed?" },
+      { tagName: "input", labelText: "Candidate name" },
+      { tagName: "input", labelText: "City" },
+      { tagName: "input", labelText: "State" },
+    ];
+
+    for (const provider of providers) {
+      for (const field of fields) {
+        const signal = [field.id, field.name, field.placeholder, field.ariaLabel, field.labelText]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        assert.equal(
+          runtime.matchKeyFromSignal({ signal, tagName: field.tagName, provider }),
+          matchBasicFieldKey(field, provider),
+        );
+      }
+    }
+
+    assert.equal(runtime.selectLocationValue({ cityState: "Austin, TX", signal: "City" }), "Austin");
+    assert.equal(runtime.selectLocationValue({ cityState: "Austin, TX", signal: "State" }), "TX");
+    assert.equal(runtime.selectLocationValue({ cityState: "Austin, TX", signal: "Location" }), "Austin, TX");
   });
 });


### PR DESCRIPTION
### Motivation
- Remove heuristic drift between the tested provider-aware matcher and the extension runtime so runtime behavior matches what tests validate.
- Ensure runtime field matching honors provider-specific tokens for Greenhouse, Lever, Ashby, and SmartRecruiters so ATS-specific heuristics are actually used at runtime.
- Keep the human-in-the-loop MVP unchanged while tightening one small location-field behavior to avoid overfilling ambiguous city/state fields.

### Description
- Add a browser-safe shared heuristic module `ui/partner-hub/extensions/job-hunter-apply-companion/heuristics.js` that implements provider detection, common + provider-specific matching tokens, ranked key matching, and conservative location value selection.
- Update `ui/partner-hub/extensions/job-hunter-apply-companion/content.js` to consume the shared heuristics via `globalThis.JobHunterApplyCompanionHeuristics` for `detectProvider`, `matchKey`, and `selectLocationValue`, and to pass the element signal into value selection.
- Update `ui/partner-hub/extensions/job-hunter-apply-companion/manifest.json` to load `heuristics.js` before `content.js` so the runtime uses the shared heuristic module on page load.
- Add a deterministic alignment test in `ui/partner-hub/lib/job-hunter/applyCompanion.test.ts` that loads `heuristics.js` into a `vm` sandbox and asserts `matchKeyFromSignal` and `selectLocationValue` match the tested helper `matchBasicFieldKey` behavior across providers and representative fields.
- Keep the existing MVP flows intact: provider detection, apply-session JSON paste/import, Fill Basic Fields, filled/upload/manual summary, upload field highlighting, no auto-submit, and no login automation.

### Testing
- Ran `cd ui/partner-hub && npm run lint` which completed successfully and reported: `✔ No ESLint warnings or errors` (exit code 0).
- Ran `cd ui/partner-hub && npm run typecheck` which completed with no TypeScript errors (exit code 0).
- Ran `cd ui/partner-hub && npm run test` which executed the full test suite and succeeded with summary: `# tests 134`, `# pass 134`, `# fail 0` (exit code 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b876652a8483309828113b6ea6b810)