### PR TITLE
Pivot Job Hunter to discovery-first workflow and demote manual source setup

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/jobs/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { EmptyState } from "@/components/job-hunter/EmptyState";
 import { JobList } from "@/components/job-hunter/JobList";
@@ -14,6 +14,8 @@ import {
 } from "@/lib/job-hunter/discoveryAutomation";
 import { getDefaultPreferences, normalizePreferences } from "@/lib/job-hunter/preferences";
 import { toggleJobSelection } from "@/lib/job-hunter/queue";
+import { buildDiscoverySourcesFromPreferences } from "@/lib/job-hunter/sourceCatalog";
+import { toUserFacingSourceError } from "@/lib/job-hunter/sourceSettings";
 import { loadJobHunterStore, saveJobHunterStore } from "@/lib/job-hunter/storage";
 import type { JobHunterAutomationSettings, JobHunterPreferences, JobPosting, JobSourceSyncDiagnostic } from "@/lib/job-hunter/types";
 
@@ -40,7 +42,6 @@ export default function JobHunterJobsPage() {
   const syncInFlight = useRef(false);
 
   const jobs = useMemo(() => Object.values(jobsById), [jobsById]);
-
   const rankedJobs = useMemo(() => rankJobsForReview(jobs, preferences), [jobs, preferences]);
 
   const filteredJobs = useMemo(() => {
@@ -48,10 +49,7 @@ export default function JobHunterJobsPage() {
 
     return rankedJobs
       .filter(({ job, score, excluded }) => {
-        const matchesQuery =
-          query.length === 0 ||
-          job.title.toLowerCase().includes(query) ||
-          job.company.toLowerCase().includes(query);
+        const matchesQuery = query.length === 0 || job.title.toLowerCase().includes(query) || job.company.toLowerCase().includes(query);
         const minScoreThreshold = Math.max(0, Math.min(100, minScore));
         const matchesScore = excluded && !hideExcluded ? true : score >= minScoreThreshold;
         const jobDate = (job.postedAt ?? job.updatedAt).slice(0, 10);
@@ -97,17 +95,19 @@ export default function JobHunterJobsPage() {
     });
   };
 
-  const handleSync = async (trigger: "manual" | "automatic" = "manual") => {
+  const handleSync = useCallback(async (trigger: "manual" | "automatic" | "discovery" = "manual") => {
     if (syncInFlight.current) {
       return;
     }
 
     setError(null);
-
     const currentStore = loadJobHunterStore();
-    if (currentStore.sources.length === 0) {
+    const discovery = buildDiscoverySourcesFromPreferences(preferences, currentStore.sources);
+    const sourcesForSync = trigger === "manual" ? currentStore.sources : discovery.sources;
+
+    if (sourcesForSync.length === 0) {
       if (trigger === "manual") {
-        setError("Add at least one job source in Settings before syncing.");
+        setError("No advanced sources configured. Use Find jobs from my preferences for discovery-first results.");
       }
       return;
     }
@@ -122,10 +122,11 @@ export default function JobHunterJobsPage() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          sources: currentStore.sources,
+          sources: sourcesForSync,
         }),
       });
-      const payload = (await response.json()) as {
+
+      const payload = (await response.json().catch(() => ({}))) as {
         error?: string;
         jobsById?: Record<string, JobPosting>;
         diagnostics?: JobSourceSyncDiagnostic[];
@@ -135,16 +136,25 @@ export default function JobHunterJobsPage() {
       setSyncDiagnostics(payload.diagnostics ?? []);
 
       if (!payload.jobsById) {
-        throw new Error(payload.error ?? "Sync failed.");
+        throw new Error(toUserFacingSourceError(payload.error, "Discovery refresh failed."));
       }
 
       if (!response.ok && Object.keys(payload.jobsById).length === 0) {
-        throw new Error(payload.error ?? "Sync failed.");
+        throw new Error(toUserFacingSourceError(payload.error, "Discovery refresh failed."));
       }
 
       setJobsById(payload.jobsById);
       setLastSyncedAt(payload.lastSyncedAt);
-      setSyncMessage(trigger === "automatic" ? "Auto-sync ran because your jobs feed was stale." : null);
+
+      if (trigger === "automatic") {
+        setSyncMessage("Auto-discovery ran because your jobs feed was stale.");
+      } else if (trigger === "discovery") {
+        setSyncMessage(
+          `Discovery refreshed using a maintained ATS source catalog (${discovery.packIds.length} pack${discovery.packIds.length === 1 ? "" : "s"}; ${discovery.addedCount} source${discovery.addedCount === 1 ? "" : "s"} added).`,
+        );
+      } else {
+        setSyncMessage("Advanced source sync completed.");
+      }
 
       saveJobHunterStore({
         ...currentStore,
@@ -153,12 +163,12 @@ export default function JobHunterJobsPage() {
         lastSyncedAt: payload.lastSyncedAt,
       });
     } catch (syncError) {
-      setError(syncError instanceof Error ? syncError.message : "Unable to sync jobs.");
+      setError(toUserFacingSourceError(syncError instanceof Error ? syncError.message : undefined, "Unable to refresh jobs."));
     } finally {
       setIsSyncing(false);
       syncInFlight.current = false;
     }
-  };
+  }, [preferences]);
 
   useEffect(() => {
     if (autoSyncAttempted.current) {
@@ -166,8 +176,9 @@ export default function JobHunterJobsPage() {
     }
 
     const currentStore = loadJobHunterStore();
+    const discovery = buildDiscoverySourcesFromPreferences(preferences, currentStore.sources);
     const shouldSync = shouldAutoSyncOnJobsOpen({
-      sourcesCount: currentStore.sources.length,
+      sourcesCount: discovery.sources.length,
       lastSyncedAt: currentStore.lastSyncedAt,
       automation,
     });
@@ -176,27 +187,38 @@ export default function JobHunterJobsPage() {
     if (shouldSync) {
       void handleSync("automatic");
     }
-  }, [automation]);
+  }, [automation, handleSync, preferences]);
 
   return (
     <main className="mx-auto max-w-5xl space-y-6 p-6">
       <header className="space-y-2">
-        <h1 className="text-2xl font-semibold">Jobs</h1>
-        <p className="text-sm text-foreground/70">Automatically sync configured Greenhouse, Lever, Ashby, and SmartRecruiters boards each run.</p>
+        <h1 className="text-2xl font-semibold">Jobs Discovery</h1>
+        <p className="text-sm text-foreground/70">Primary workflow: preferences → discover → choose jobs → tailor resume → apply.</p>
       </header>
 
-      <section className="space-y-2 rounded-lg border border-border/60 p-4">
-        <div className="flex items-center justify-between gap-3">
-          <p className="text-xs text-foreground/70">Last sync: {lastSyncedAt ? new Date(lastSyncedAt).toLocaleString() : "Never"}</p>
-          <Button disabled={isSyncing} onClick={() => void handleSync()} type="button">
-            {isSyncing ? "Syncing..." : "Sync Jobs"}
-          </Button>
+      <section className="space-y-3 rounded-lg border border-border/60 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-xs text-foreground/70">Last discovery refresh: {lastSyncedAt ? new Date(lastSyncedAt).toLocaleString() : "Never"}</p>
+          <div className="flex flex-wrap gap-2">
+            <Button disabled={isSyncing} onClick={() => void handleSync("discovery")} type="button">
+              {isSyncing ? "Refreshing..." : "Find jobs from my preferences"}
+            </Button>
+            <Button disabled={isSyncing} onClick={() => void handleSync()} type="button" variant="secondary">
+              Refresh advanced sources
+            </Button>
+          </div>
         </div>
+        <p className="text-xs text-foreground/70">
+          Discovery uses a maintained ATS source catalog matched to your preferences. Advanced source setup is optional.
+          <Link className="ml-1 text-blue-600 hover:underline" href="/job-hunter/settings">
+            Open Advanced Sources
+          </Link>
+        </p>
         {syncMessage ? <p className="text-xs text-blue-700">{syncMessage}</p> : null}
         {error ? <p className="text-xs text-red-600">{error}</p> : null}
         {syncDiagnostics.length > 0 ? (
           <div className="space-y-1 rounded-md border border-border/40 bg-muted/20 p-2 text-xs">
-            <p className="font-medium">Source sync results</p>
+            <p className="font-medium">Discovery/source refresh results</p>
             <ul className="space-y-1">
               {syncDiagnostics.map((item) => (
                 <li key={item.sourceId}>
@@ -208,7 +230,6 @@ export default function JobHunterJobsPage() {
             </ul>
           </div>
         ) : null}
-
       </section>
 
       <section className="space-y-2 rounded-lg border border-border/60 p-4">
@@ -233,9 +254,7 @@ export default function JobHunterJobsPage() {
 
       <section className="space-y-2">
         <h2 className="text-sm font-semibold">Top Matches Review Queue</h2>
-        <p className="text-xs text-foreground/70">
-          Automatically surfaced using your current ranking and preference rules. Jobs are not auto-selected for apply.
-        </p>
+        <p className="text-xs text-foreground/70">Automatically surfaced using your current ranking and preference rules. Jobs are not auto-selected for apply.</p>
         {topMatches.length > 0 ? (
           <JobList onToggleSelectedJob={handleToggleSelectedJob} rows={topMatches} selectedJobIds={selectedJobIds} title="Top matches" />
         ) : (
@@ -244,31 +263,14 @@ export default function JobHunterJobsPage() {
       </section>
 
       <section className="grid gap-3 rounded-lg border border-border/60 p-4 md:grid-cols-2">
-        <input
-          className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
-          onChange={(event) => setSearch(event.target.value)}
-          placeholder="Search title or company"
-          value={search}
-        />
-        <input
-          className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
-          onChange={(event) => setMinDate(event.target.value)}
-          type="date"
-          value={minDate}
-        />
+        <input className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm" onChange={(event) => setSearch(event.target.value)} placeholder="Search title or company" value={search} />
+        <input className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm" onChange={(event) => setMinDate(event.target.value)} type="date" value={minDate} />
       </section>
 
       <section className="grid gap-3 rounded-lg border border-border/60 p-4 md:grid-cols-3">
         <label className="space-y-1 text-sm">
           <span className="text-xs text-foreground/70">Minimum score</span>
-          <input
-            className="w-full rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
-            max={100}
-            min={0}
-            onChange={(event) => setMinScore(Number(event.target.value))}
-            type="number"
-            value={minScore}
-          />
+          <input className="w-full rounded-md border border-border/60 bg-background px-3 py-2 text-sm" max={100} min={0} onChange={(event) => setMinScore(Number(event.target.value))} type="number" value={minScore} />
         </label>
         <label className="flex items-center gap-2 text-sm">
           <input checked={hideExcluded} onChange={(event) => setHideExcluded(event.target.checked)} type="checkbox" />
@@ -280,9 +282,7 @@ export default function JobHunterJobsPage() {
       </section>
 
       {!hideExcluded && excludedVisible > 0 ? (
-        <section className="rounded-lg border border-amber-500/30 bg-amber-50/40 p-3 text-xs text-amber-900">
-          Showing {excludedVisible} excluded job(s). Reasons are based on your targeting preferences.
-        </section>
+        <section className="rounded-lg border border-amber-500/30 bg-amber-50/40 p-3 text-xs text-amber-900">Showing {excludedVisible} excluded job(s). Reasons are based on your targeting preferences.</section>
       ) : null}
 
       {filteredJobs.length > 0 ? (
@@ -302,7 +302,7 @@ export default function JobHunterJobsPage() {
           ) : null}
         </>
       ) : (
-        <EmptyState title="No jobs yet" description="Configure sources and click Sync Jobs to pull postings." />
+        <EmptyState title="No jobs yet" description="Use “Find jobs from my preferences” to run discovery without manual source setup." />
       )}
     </main>
   );

--- a/ui/partner-hub/app/(routes)/job-hunter/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/page.tsx
@@ -4,9 +4,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 const sections = [
   {
-    title: "Jobs",
-    description: "Track saved roles and opportunities in one place.",
+    title: "Find Jobs",
+    description: "Run discovery from your preferences and review top matches.",
     href: "/job-hunter/jobs",
+  },
+  {
+    title: "Preferences",
+    description: "Set targeting rules that drive discovery and ranking.",
+    href: "/job-hunter/preferences",
   },
   {
     title: "Applications",
@@ -15,17 +20,12 @@ const sections = [
   },
   {
     title: "Resume",
-    description: "Edit resume profile data used for tailoring output.",
+    description: "Edit resume profile data used for minimal-delta tailoring output.",
     href: "/job-hunter/resume",
   },
   {
-    title: "Preferences",
-    description: "Set personalized targeting rules for scoring and filtering.",
-    href: "/job-hunter/preferences",
-  },
-  {
-    title: "Settings",
-    description: "Manage source boards for job syncing.",
+    title: "Advanced Sources",
+    description: "Optional manual provider/token setup for power users.",
     href: "/job-hunter/settings",
   },
 ];
@@ -35,8 +35,18 @@ export default function JobHunterPage() {
     <main className="mx-auto max-w-5xl space-y-6 p-6">
       <header className="space-y-2">
         <h1 className="text-2xl font-semibold">Job Hunter</h1>
-        <p className="text-sm text-foreground/70">Manage saved jobs and applications.</p>
+        <p className="text-sm text-foreground/70">Use preferences-first discovery to find jobs, then choose, tailor, and apply.</p>
       </header>
+
+      <section className="rounded-lg border border-border/60 bg-muted/20 p-4 text-sm">
+        <ol className="list-decimal space-y-1 pl-5 text-foreground/80">
+          <li>Set preferences</li>
+          <li>Find jobs from preferences</li>
+          <li>Select jobs to pursue</li>
+          <li>Tailor resume variants minimally</li>
+          <li>Complete guided apply workflow</li>
+        </ol>
+      </section>
 
       <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
         {sections.map((section) => (

--- a/ui/partner-hub/app/(routes)/job-hunter/settings/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/settings/page.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { detectSourceFromUrl } from "@/lib/job-hunter/sourceDetection";
+import { parseBulkSourceInput, toUserFacingSourceError } from "@/lib/job-hunter/sourceSettings";
 import { loadJobHunterStore, saveJobHunterStore } from "@/lib/job-hunter/storage";
 import { BOARD_TYPE_OPTIONS, getSourceValidationMessage, truncateBoardToken } from "@/lib/job-hunter/sourceSettings";
 import type { BoardType, JobSourceSyncDiagnostic } from "@/lib/job-hunter/types";
@@ -18,6 +19,8 @@ export default function JobHunterSettingsPage() {
   const [store, setStore] = useState(loadJobHunterStore());
   const [form, setForm] = useState(DEFAULT_FORM);
   const [detectionUrl, setDetectionUrl] = useState("");
+  const [bulkInput, setBulkInput] = useState("");
+  const [bulkProvider, setBulkProvider] = useState<BoardType>("greenhouse");
   const [validationMessage, setValidationMessage] = useState<string | null>(null);
   const [detectionMessage, setDetectionMessage] = useState<string | null>(null);
   const [testResult, setTestResult] = useState<JobSourceSyncDiagnostic | null>(null);
@@ -37,12 +40,11 @@ export default function JobHunterSettingsPage() {
       boardToken: detected.boardToken,
       company: detected.company ?? prev.company,
     }));
-    setDetectionMessage(`Detected ${detected.boardType} source with token \"${detected.boardToken}\".`);
+    setDetectionMessage(`Detected ${detected.boardType} source with token "${detected.boardToken}".`);
     setValidationMessage(null);
     setTestResult(null);
     setTestError(null);
   };
-
 
   const testSource = async () => {
     const message = getSourceValidationMessage(form, []);
@@ -70,22 +72,22 @@ export default function JobHunterSettingsPage() {
         }),
       });
 
-      const payload = (await response.json()) as {
+      const payload = (await response.json().catch(() => ({}))) as {
         success?: boolean;
         error?: string;
         result?: JobSourceSyncDiagnostic;
       };
 
       if (!payload.result) {
-        throw new Error(payload.error ?? "Source test failed.");
+        throw new Error(toUserFacingSourceError(payload.error, "Source test failed."));
       }
 
       setTestResult(payload.result);
       if (!response.ok || !payload.success || !payload.result.success) {
-        setTestError(payload.result.error ?? payload.error ?? "Source test failed.");
+        setTestError(toUserFacingSourceError(payload.result.error ?? payload.error, "Source test failed."));
       }
     } catch (error) {
-      setTestError(error instanceof Error ? error.message : "Source test failed.");
+      setTestError(toUserFacingSourceError(error instanceof Error ? error.message : undefined, "Source test failed."));
     } finally {
       setIsTesting(false);
     }
@@ -123,6 +125,32 @@ export default function JobHunterSettingsPage() {
     setTestError(null);
   };
 
+  const addBulkSources = () => {
+    const parsedSources = parseBulkSourceInput(bulkInput, bulkProvider);
+    if (parsedSources.length === 0) {
+      setValidationMessage("No valid bulk entries found. Use one source per line in Company|token format.");
+      return;
+    }
+
+    const existingIds = new Set(store.sources.map((source) => `${source.boardType}:${source.boardToken.toLowerCase()}`));
+    const deduped = parsedSources.filter((source) => !existingIds.has(`${source.boardType}:${source.boardToken.toLowerCase()}`));
+
+    if (deduped.length === 0) {
+      setValidationMessage("All bulk entries already exist in advanced sources.");
+      return;
+    }
+
+    const nextStore = {
+      ...store,
+      sources: [...store.sources, ...deduped],
+    };
+
+    saveJobHunterStore(nextStore);
+    setStore(nextStore);
+    setBulkInput("");
+    setValidationMessage(`Added ${deduped.length} advanced source${deduped.length === 1 ? "" : "s"}.`);
+  };
+
   const deleteSource = (index: number) => {
     const nextStore = {
       ...store,
@@ -136,14 +164,20 @@ export default function JobHunterSettingsPage() {
   return (
     <main className="mx-auto max-w-5xl space-y-6 p-6">
       <header className="space-y-2">
-        <h1 className="text-2xl font-semibold">Job Source Settings</h1>
-        <p className="text-sm text-foreground/70">Manage Greenhouse, Lever, Ashby, and SmartRecruiters boards used by Sync Jobs.</p>
+        <h1 className="text-2xl font-semibold">Advanced Sources</h1>
+        <p className="text-sm text-foreground/70">Optional manual ATS setup. Most users should discover jobs from the Jobs page without configuring sources here.</p>
       </header>
 
+      <section className="rounded-lg border border-border/60 bg-muted/20 p-4 text-xs text-foreground/80">
+        <p>
+          Recommended path: set preferences → find jobs → choose jobs → tailor resume → apply. Use Advanced Sources only when you need explicit provider/token control.
+        </p>
+      </section>
+
       <section className="space-y-3 rounded-lg border border-border/60 p-4">
-        <h2 className="text-sm font-semibold">Configured Sources</h2>
+        <h2 className="text-sm font-semibold">Configured Advanced Sources</h2>
         {store.sources.length === 0 ? (
-          <p className="text-sm text-foreground/70">No sources configured yet.</p>
+          <p className="text-sm text-foreground/70">No advanced sources configured yet.</p>
         ) : (
           <ul className="space-y-2">
             {store.sources.map((source, index) => (
@@ -158,6 +192,29 @@ export default function JobHunterSettingsPage() {
             ))}
           </ul>
         )}
+      </section>
+
+      <section className="space-y-3 rounded-lg border border-border/60 p-4">
+        <h2 className="text-sm font-semibold">Bulk Add Advanced Sources</h2>
+        <p className="text-xs text-foreground/70">Paste one source per line as Company|token, then choose a provider.</p>
+        <div className="grid gap-3 md:grid-cols-[200px_1fr_auto]">
+          <select className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm" onChange={(event) => setBulkProvider(event.target.value as BoardType)} value={bulkProvider}>
+            {BOARD_TYPE_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+          <textarea
+            className="min-h-24 rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
+            onChange={(event) => setBulkInput(event.target.value)}
+            placeholder={"Acme|acme\nContoso|contoso"}
+            value={bulkInput}
+          />
+          <Button className="md:self-start" onClick={addBulkSources} type="button" variant="secondary">
+            Bulk Add
+          </Button>
+        </div>
       </section>
 
       <section className="space-y-3 rounded-lg border border-border/60 p-4">
@@ -177,7 +234,7 @@ export default function JobHunterSettingsPage() {
       </section>
 
       <section className="space-y-3 rounded-lg border border-border/60 p-4">
-        <h2 className="text-sm font-semibold">Add Source</h2>
+        <h2 className="text-sm font-semibold">Add Individual Advanced Source</h2>
         <form className="grid gap-3 md:grid-cols-3" onSubmit={addSource}>
           <input
             className="rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
@@ -214,7 +271,7 @@ export default function JobHunterSettingsPage() {
             {testResult ? (
               <p className={testResult.success ? "mt-2 text-sm text-emerald-700" : "mt-2 text-sm text-foreground/80"}>
                 {testResult.success ? "Success" : "Failed"} · {testResult.provider} · {testResult.token} · {testResult.jobsFetched} job(s)
-                {testResult.error ? ` · ${testResult.error}` : ""}
+                {testResult.error ? ` · ${toUserFacingSourceError(testResult.error)}` : ""}
               </p>
             ) : null}
           </div>

--- a/ui/partner-hub/lib/job-hunter/sourceCatalog.test.ts
+++ b/ui/partner-hub/lib/job-hunter/sourceCatalog.test.ts
@@ -1,0 +1,45 @@
+import * as assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { getDefaultPreferences } from "./preferences";
+import { buildDiscoverySourcesFromPreferences, selectCatalogPacksForPreferences } from "./sourceCatalog";
+
+describe("job hunter source catalog discovery", () => {
+  it("selects role-matched packs when preferences include matching targets", () => {
+    const packs = selectCatalogPacksForPreferences({
+      ...getDefaultPreferences(),
+      targetRoles: ["Senior Product Manager"],
+      targetKeywords: ["UX"],
+    });
+
+    assert.equal(packs.some((pack) => pack.id === "product-design"), true);
+  });
+
+  it("falls back to engineering pack when no role signals match", () => {
+    const packs = selectCatalogPacksForPreferences({
+      ...getDefaultPreferences(),
+      targetRoles: ["Astronaut"],
+      targetKeywords: ["orbital"],
+    });
+
+    assert.equal(packs.length, 1);
+    assert.equal(packs[0].id, "engineering-platform");
+  });
+
+  it("builds discovery sources by merging catalog with existing manual sources", () => {
+    const existing = [{ company: "Custom Co", boardType: "lever", boardToken: "customco" }] as const;
+
+    const discovery = buildDiscoverySourcesFromPreferences(
+      {
+        ...getDefaultPreferences(),
+        targetRoles: ["Sales Engineer"],
+        targetKeywords: ["customer"],
+      },
+      [...existing],
+    );
+
+    assert.equal(discovery.packIds.includes("sales-customer-success"), true);
+    assert.equal(discovery.sources.some((source) => source.boardToken === "customco"), true);
+    assert.equal(discovery.addedCount > 0, true);
+  });
+});

--- a/ui/partner-hub/lib/job-hunter/sourceCatalog.ts
+++ b/ui/partner-hub/lib/job-hunter/sourceCatalog.ts
@@ -1,0 +1,93 @@
+import { normalizePreferences } from "./preferences";
+import type { JobHunterPreferences, JobSourceConfig } from "./types";
+
+export type CatalogSourcePack = {
+  id: string;
+  label: string;
+  description: string;
+  sources: JobSourceConfig[];
+  roleKeywords: string[];
+};
+
+const slugify = (value: string) =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+export const JOB_SOURCE_PACKS: CatalogSourcePack[] = [
+  {
+    id: "engineering-platform",
+    label: "Engineering + Platform",
+    description: "Maintained ATS source catalog focused on engineering and platform teams.",
+    roleKeywords: ["engineer", "developer", "platform", "infrastructure", "backend", "frontend", "full stack", "devops"],
+    sources: [
+      { company: "Stripe", boardType: "greenhouse", boardToken: "stripe" },
+      { company: "Cloudflare", boardType: "lever", boardToken: "cloudflare" },
+      { company: "Notion", boardType: "ashby", boardToken: "notion" },
+      { company: "Datadog", boardType: "greenhouse", boardToken: "datadog" },
+    ],
+  },
+  {
+    id: "product-design",
+    label: "Product + Design",
+    description: "Maintained ATS source catalog focused on product, UX, and design hiring.",
+    roleKeywords: ["product", "pm", "designer", "ux", "ui", "research"],
+    sources: [
+      { company: "Figma", boardType: "greenhouse", boardToken: "figma" },
+      { company: "Canva", boardType: "lever", boardToken: "canva" },
+      { company: "Miro", boardType: "greenhouse", boardToken: "miro" },
+    ],
+  },
+  {
+    id: "sales-customer-success",
+    label: "Sales + Customer Success",
+    description: "Maintained ATS source catalog focused on GTM, partnerships, and customer roles.",
+    roleKeywords: ["sales", "account", "customer", "success", "partnership", "solutions", "pre-sales"],
+    sources: [
+      { company: "HubSpot", boardType: "greenhouse", boardToken: "hubspot" },
+      { company: "Snowflake", boardType: "lever", boardToken: "snowflake" },
+      { company: "Asana", boardType: "greenhouse", boardToken: "asana" },
+    ],
+  },
+];
+
+const toSourceId = (source: JobSourceConfig) => `${source.boardType}:${source.boardToken.trim().toLowerCase()}`;
+
+export const selectCatalogPacksForPreferences = (preferences: JobHunterPreferences): CatalogSourcePack[] => {
+  const normalized = normalizePreferences(preferences);
+  const roleSignals = [...normalized.targetRoles, ...normalized.targetKeywords]
+    .join(" ")
+    .toLowerCase();
+
+  const matches = JOB_SOURCE_PACKS.filter((pack) => pack.roleKeywords.some((keyword) => roleSignals.includes(keyword)));
+
+  return matches.length > 0 ? matches : [JOB_SOURCE_PACKS[0]];
+};
+
+export const buildDiscoverySourcesFromPreferences = (
+  preferences: JobHunterPreferences,
+  existingSources: JobSourceConfig[],
+): { sources: JobSourceConfig[]; packIds: string[]; addedCount: number } => {
+  const packs = selectCatalogPacksForPreferences(preferences);
+  const sourceMap = new Map<string, JobSourceConfig>();
+
+  existingSources.forEach((source) => {
+    sourceMap.set(toSourceId(source), source);
+  });
+
+  const beforeCount = sourceMap.size;
+
+  packs.forEach((pack) => {
+    pack.sources.forEach((source) => {
+      sourceMap.set(toSourceId(source), source);
+    });
+  });
+
+  return {
+    sources: Array.from(sourceMap.values()),
+    packIds: packs.map((pack) => pack.id),
+    addedCount: sourceMap.size - beforeCount,
+  };
+};

--- a/ui/partner-hub/lib/job-hunter/sourceSettings.test.ts
+++ b/ui/partner-hub/lib/job-hunter/sourceSettings.test.ts
@@ -1,0 +1,20 @@
+import * as assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { parseBulkSourceInput, toUserFacingSourceError } from "./sourceSettings";
+
+describe("job hunter source settings helpers", () => {
+  it("parses bulk source entries from company|token lines", () => {
+    const parsed = parseBulkSourceInput("Acme|acme\nBeta|beta\nBadLine", "greenhouse");
+
+    assert.equal(parsed.length, 2);
+    assert.deepEqual(parsed[0], { company: "Acme", boardType: "greenhouse", boardToken: "acme" });
+  });
+
+  it("sanitizes raw parser errors for source testing", () => {
+    assert.equal(
+      toUserFacingSourceError("Unexpected token '<', \"<!doctype \"... is not valid JSON"),
+      "The source response was not readable. Please verify the URL or try another source.",
+    );
+  });
+});

--- a/ui/partner-hub/lib/job-hunter/sourceSettings.ts
+++ b/ui/partner-hub/lib/job-hunter/sourceSettings.ts
@@ -31,3 +31,45 @@ export const getSourceValidationMessage = (form: SourceForm, sources: JobSourceC
 
   return null;
 };
+
+export const toUserFacingSourceError = (message: string | undefined, fallback = "We could not complete that source request.") => {
+  if (!message) {
+    return fallback;
+  }
+
+  const normalized = message.trim();
+  if (/Unexpected token\s*['"]?</i.test(normalized)) {
+    return "The source response was not readable. Please verify the URL or try another source.";
+  }
+
+  return normalized;
+};
+
+export const parseBulkSourceInput = (value: string, boardType: BoardType): JobSourceConfig[] => {
+  const lines = value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const deduped = new Map<string, JobSourceConfig>();
+
+  lines.forEach((line) => {
+    const parts = line.split("|").map((part) => part.trim());
+    if (parts.length < 2) {
+      return;
+    }
+
+    const [company, token] = parts;
+    if (!company || !token) {
+      return;
+    }
+
+    deduped.set(`${boardType}:${token.toLowerCase()}`, {
+      company,
+      boardType,
+      boardToken: token,
+    });
+  });
+
+  return Array.from(deduped.values());
+};


### PR DESCRIPTION
### Motivation
- The Job Hunter UI and architecture drifted toward manual ATS source management instead of driving discovery from user preferences, making the product feel like a board watcher instead of a discovery engine. 
- The product's primary flow must be `preferences -> discover -> choose -> tailor -> apply`, so discovery must be the default entry path while preserving existing apply and tailoring strengths. 
- When a true market-wide search API is not feasible in a single patch, introduce a pragmatic discovery layer that minimizes manual per-source setup while being honest about its scope.

### Description
- Promoted discovery-first UX: updated the landing and jobs UI so the Jobs surface is now `Jobs Discovery` with a primary CTA `Find jobs from my preferences` and a secondary `Refresh advanced sources` action, plus discovery-focused copy that explains the intended workflow. 
- Added a maintained source-catalog abstraction in `ui/partner-hub/lib/job-hunter/sourceCatalog.ts` that selects role-matched source packs and merges them with any existing manual sources via `buildDiscoverySourcesFromPreferences`, so discovery runs without requiring one-by-one provider/token entry. 
- Demoted manual ATS plumbing into an `Advanced Sources` settings page and improved robustness with bulk onboarding (`Company|token`), deduping helpers, and sanitized user-facing errors via `toUserFacingSourceError` in `sourceSettings.ts`. 
- Added deterministic tests for the new helpers: `sourceCatalog.test.ts` and `sourceSettings.test.ts`, and wired the discovery flow in `jobs/page.tsx` to use the catalog while preserving ranking, apply-queue, tailoring, and sync integrations.

### Testing
- Ran `cd ui/partner-hub && npm run lint` and it passed with `✔ No ESLint warnings or errors`. 
- Ran `cd ui/partner-hub && npm run typecheck` and it passed (`tsc --noEmit` completed). 
- Ran `cd ui/partner-hub && npm run test` and the suite passed (`136 passed, 0 failed`). 
- Ran `cd ui/partner-hub && npm run build` and the Next.js production build completed successfully (static/SSG routes generated without error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b880e0bcf483308a7644ab3e82e543)