### PR TITLE
Finalize Steam Trains phase 1 switch lock UX

### DIFF
--- a/ui/partner-hub/components/steam-trains/steam-trains-tool.tsx
+++ b/ui/partner-hub/components/steam-trains/steam-trains-tool.tsx
@@ -48,6 +48,14 @@ export function SteamTrainsTool() {
   }, []);
 
   useEffect(() => {
+    return () => {
+      if (audioContextRef.current) {
+        void audioContextRef.current.close();
+      }
+    };
+  }, []);
+
+  useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) {
       return;
@@ -99,6 +107,9 @@ export function SteamTrainsTool() {
     setState((prev) => restartAfterCrash(prev));
   };
 
+  const effectiveSwitchState = state.turnoutDecision ?? state.switchState;
+  const isSwitchLocked = state.turnoutDecision !== null;
+
   return (
     <Card className="mx-auto w-full max-w-6xl">
       <CardHeader>
@@ -133,16 +144,18 @@ export function SteamTrainsTool() {
           <Button
             type="button"
             className="h-20 text-lg font-bold"
-            variant={state.switchState === "main" ? "primary" : "secondary"}
+            variant={effectiveSwitchState === "main" ? "primary" : "secondary"}
             onClick={() => handleSwitch("main")}
+            disabled={isSwitchLocked}
           >
             Main Track
           </Button>
           <Button
             type="button"
             className="h-20 text-lg font-bold"
-            variant={state.switchState === "siding" ? "primary" : "secondary"}
+            variant={effectiveSwitchState === "siding" ? "primary" : "secondary"}
             onClick={() => handleSwitch("siding")}
+            disabled={isSwitchLocked}
           >
             Side Track
           </Button>

--- a/ui/partner-hub/lib/steam-trains/engine.test.ts
+++ b/ui/partner-hub/lib/steam-trains/engine.test.ts
@@ -67,4 +67,31 @@ describe("steam trains engine", () => {
     assert.equal(restarted.train.x, restarted.level.startX);
     assert.equal(restarted.particles.length, 0);
   });
+
+  it("ignores switch updates after turnout decision is locked", () => {
+    let state = setSwitchState(buildState(), "main");
+
+    for (let i = 0; i < 260 && state.turnoutDecision === null; i += 1) {
+      state = advanceSimulation(state, 40);
+    }
+
+    assert.equal(state.turnoutDecision, "main");
+
+    const afterLockedTap = setSwitchState(state, "siding");
+    assert.equal(afterLockedTap.switchState, state.switchState);
+    assert.equal(afterLockedTap.turnoutDecision, "main");
+  });
+
+  it("ignores switch updates once run is no longer running", () => {
+    let state = setSwitchState(buildState(), "siding");
+    for (let i = 0; i < 220 && state.playState === "running"; i += 1) {
+      state = advanceSimulation(state, 40);
+    }
+
+    assert.equal(state.playState, "crashed");
+    assert.equal(state.switchState, "siding");
+
+    const afterCrashTap = setSwitchState(state, "main");
+    assert.equal(afterCrashTap.switchState, "siding");
+  });
 });

--- a/ui/partner-hub/lib/steam-trains/engine.ts
+++ b/ui/partner-hub/lib/steam-trains/engine.ts
@@ -48,10 +48,16 @@ export const createSimulation = (
 export const setSwitchState = (
   state: SteamTrainsSimulationState,
   switchState: TrackSwitchState,
-): SteamTrainsSimulationState => ({
-  ...state,
-  switchState,
-});
+): SteamTrainsSimulationState => {
+  if (state.turnoutDecision !== null || state.playState !== "running") {
+    return state;
+  }
+
+  return {
+    ...state,
+    switchState,
+  };
+};
 
 export const triggerWhistle = (state: SteamTrainsSimulationState): SteamTrainsSimulationState => ({
   ...state,


### PR DESCRIPTION
### Motivation
- Make switch locking behavior consistent so once a turnout decision is committed it is the effective switch for the rest of the run and later UI taps cannot create misleading visuals.
- Improve the switch button UX to reflect the effective (locked) state and disable buttons when locked, and ensure audio resources are cleaned up on unmount.

### Description
- Make `setSwitchState` a guarded no-op when `turnoutDecision !== null` or `playState !== "running"`, preventing late UI taps from mutating the effective routing. (`ui/partner-hub/lib/steam-trains/engine.ts`)
- Compute `effectiveSwitchState = turnoutDecision ?? switchState` in the React tool and use it for button highlighting, and disable the track buttons when the turnout is locked while keeping the existing "Switch locked to …" message. (`ui/partner-hub/components/steam-trains/steam-trains-tool.tsx`)
- Close the `AudioContext` on component unmount to avoid leaving audio resources hanging. (`ui/partner-hub/components/steam-trains/steam-trains-tool.tsx`)
- Add focused tests asserting switch updates are ignored after turnout lock and after the run leaves the `running` state. (`ui/partner-hub/lib/steam-trains/engine.test.ts`)

### Testing
- Ran `npm test` from `ui/partner-hub`; tests passed. Exact summary output:
  1..46
  # tests 154
  # suites 46
  # pass 154
  # fail 0
  # cancelled 0
  # skipped 0
  # todo 0
  # duration_ms 7162.181597
- Ran `npm run typecheck`; TypeScript check completed successfully with `tsc --noEmit`.
- Ran `npm run build`; Next build completed successfully with the production build output including:
  ✓ Compiled successfully in 30.3s
  ...
  └ ○ /tools/steam-trains                             5.02 kB         107 kB
  ○  (Static)   prerendered as static content
  ●  (SSG)      prerendered as static HTML (uses generateStaticParams)
  ƒ  (Dynamic)  server-rendered on demand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6f8d64fa48330bd1bf066997d2abd)