### PR TITLE
Finish Steam Trains phase 2 station stop and UX polish

### DIFF
--- a/ui/partner-hub/components/steam-trains/steam-trains-tool.tsx
+++ b/ui/partner-hub/components/steam-trains/steam-trains-tool.tsx
@@ -14,9 +14,11 @@ import {
 } from "@/lib/steam-trains/engine";
 import { STEAM_TRAINS_LEVELS } from "@/lib/steam-trains/levels";
 import {
+  clampUnlockedLevel,
   getHighestUnlockedAfterCompletion,
   getLevelByOrder,
   getNextLevelOrder,
+  getValidSelectedLevelOrder,
   isLevelUnlocked,
 } from "@/lib/steam-trains/progression";
 import { renderScene } from "@/lib/steam-trains/renderer";
@@ -55,10 +57,15 @@ export function SteamTrainsTool() {
       return;
     }
     const loaded = loadSteamTrainsPreferences(window.localStorage);
-    setPreferences(loaded);
-    setMode(loaded.lastMode);
-    setSelectedLevelOrder(Math.min(loaded.highestUnlockedLevel, STEAM_TRAINS_LEVELS.length));
-    setState(createState(loaded.lastMode, Math.min(loaded.highestUnlockedLevel, STEAM_TRAINS_LEVELS.length)));
+    const highestUnlockedLevel = clampUnlockedLevel(loaded.highestUnlockedLevel);
+    const normalizedPreferences = { ...loaded, highestUnlockedLevel };
+    const nextMode = loaded.lastMode;
+    const nextSelectedLevel = getValidSelectedLevelOrder(highestUnlockedLevel, nextMode, highestUnlockedLevel);
+
+    setPreferences(normalizedPreferences);
+    setMode(nextMode);
+    setSelectedLevelOrder(nextSelectedLevel);
+    setState(createState(nextMode, nextSelectedLevel));
     lastInteractionRef.current = performance.now();
   }, []);
 
@@ -177,22 +184,40 @@ export function SteamTrainsTool() {
 
   const changeMode = (nextMode: GameMode) => {
     bumpInteraction();
+    const nextSelectedLevel = getValidSelectedLevelOrder(selectedLevelOrder, nextMode, preferences.highestUnlockedLevel);
     setMode(nextMode);
     setPreferences((prev) => ({ ...prev, lastMode: nextMode }));
-    setState(createState(nextMode, selectedLevelOrder));
+    setSelectedLevelOrder(nextSelectedLevel);
+    setState(createState(nextMode, nextSelectedLevel));
   };
 
   const changeLevel = (order: number) => {
     bumpInteraction();
-    setSelectedLevelOrder(order);
-    setState(createState(mode, order));
+    const nextSelectedLevel = getValidSelectedLevelOrder(order, mode, preferences.highestUnlockedLevel);
+    setSelectedLevelOrder(nextSelectedLevel);
+    setState(createState(mode, nextSelectedLevel));
   };
 
   const handleNextLevel = () => {
-    const nextLevelOrder = getNextLevelOrder(selectedLevelOrder);
+    bumpInteraction();
+    const nextLevelOrder = getValidSelectedLevelOrder(
+      getNextLevelOrder(selectedLevelOrder),
+      mode,
+      preferences.highestUnlockedLevel,
+    );
     setSelectedLevelOrder(nextLevelOrder);
     setState(createState(mode, nextLevelOrder));
   };
+
+  useEffect(() => {
+    const nextSelectedLevel = getValidSelectedLevelOrder(selectedLevelOrder, mode, preferences.highestUnlockedLevel);
+    if (nextSelectedLevel !== selectedLevelOrder) {
+      setSelectedLevelOrder(nextSelectedLevel);
+      setState(createState(mode, nextSelectedLevel));
+    }
+  }, [mode, preferences.highestUnlockedLevel, selectedLevelOrder]);
+
+  const isSwitchDisabled = state.playState !== "running";
 
   return (
     <Card className="mx-auto w-full max-w-6xl">
@@ -221,7 +246,10 @@ export function SteamTrainsTool() {
             type="button"
             className="h-14 text-lg font-bold"
             variant={preferences.helperMode ? "primary" : "secondary"}
-            onClick={() => setPreferences((prev) => ({ ...prev, helperMode: !prev.helperMode }))}
+            onClick={() => {
+              bumpInteraction();
+              setPreferences((prev) => ({ ...prev, helperMode: !prev.helperMode }));
+            }}
           >
             Helper {preferences.helperMode ? "On" : "Off"}
           </Button>
@@ -272,16 +300,18 @@ export function SteamTrainsTool() {
           <Button
             type="button"
             className="h-24 text-2xl font-bold"
-            variant={state.switchState === "main" ? "primary" : "secondary"}
+            variant={state.switchState === "main" && !isSwitchDisabled ? "primary" : "secondary"}
             onClick={() => handleSwitch("main")}
+            disabled={isSwitchDisabled}
           >
             Main Track
           </Button>
           <Button
             type="button"
             className="h-24 text-2xl font-bold"
-            variant={state.switchState === "siding" ? "primary" : "secondary"}
+            variant={state.switchState === "siding" && !isSwitchDisabled ? "primary" : "secondary"}
             onClick={() => handleSwitch("siding")}
+            disabled={isSwitchDisabled}
           >
             Side Track
           </Button>

--- a/ui/partner-hub/lib/steam-trains/engine.test.ts
+++ b/ui/partner-hub/lib/steam-trains/engine.test.ts
@@ -82,6 +82,45 @@ describe("steam trains engine", () => {
     assert.equal(restarted.particles.length, 0);
   });
 
+  it("stops briefly at the level 3 station, then resumes automatically", () => {
+    let state = createLevelState("level-3-station-stop");
+
+    for (let i = 0; i < 280 && !state.stationStopCompleted; i += 1) {
+      state = advanceSimulation(state, 40);
+    }
+
+    assert.equal(state.stationStopCompleted, true);
+    assert.equal(state.train.speed, 0);
+    assert.equal(state.stationStopUntilMs !== null, true);
+
+    const pausedX = state.train.x;
+    for (let i = 0; i < 10; i += 1) {
+      state = advanceSimulation(state, 40);
+    }
+    assert.equal(state.train.x, pausedX);
+
+    for (let i = 0; i < 60 && state.train.speed === 0; i += 1) {
+      state = advanceSimulation(state, 40);
+    }
+
+    assert.equal(state.train.speed > 0, true);
+    assert.equal(state.stationStopUntilMs, null);
+  });
+
+  it("requires the correct post-station switch choice on level 3", () => {
+    let state = setSwitchState(createLevelState("level-3-station-stop"), "siding");
+    let stopped = false;
+
+    for (let i = 0; i < 420 && state.playState === "running"; i += 1) {
+      state = advanceSimulation(state, 40);
+      stopped ||= state.stationStopCompleted;
+    }
+
+    assert.equal(stopped, true);
+    assert.equal(state.playState, "crashed");
+    assert.deepEqual(state.checkpointDecisions, ["siding"]);
+  });
+
   it("handles multiple switches in level 5", () => {
     let state = createLevelState("level-5-fast-switches");
     state = setSwitchState(state, "main");
@@ -98,5 +137,19 @@ describe("steam trains engine", () => {
 
     assert.equal(state.playState, "completed");
     assert.deepEqual(state.checkpointDecisions, ["main", "siding"]);
+  });
+
+  it("ignores switch changes when run is not running", () => {
+    const crashedState = {
+      ...createLevelState("level-1-switch-start"),
+      playState: "crashed" as const,
+      switchState: "main" as const,
+    };
+    const rewindingState = { ...crashedState, playState: "rewinding" as const };
+    const completedState = { ...crashedState, playState: "completed" as const };
+
+    assert.equal(setSwitchState(crashedState, "siding").switchState, "main");
+    assert.equal(setSwitchState(rewindingState, "siding").switchState, "main");
+    assert.equal(setSwitchState(completedState, "siding").switchState, "main");
   });
 });

--- a/ui/partner-hub/lib/steam-trains/engine.ts
+++ b/ui/partner-hub/lib/steam-trains/engine.ts
@@ -39,6 +39,8 @@ const createRunningState = (
   whistleAtMs: null,
   particles: [],
   nextParticleId: 1,
+  stationStopCompleted: false,
+  stationStopUntilMs: null,
 });
 
 export const createSimulation = (
@@ -190,6 +192,27 @@ export const advanceSimulation = (
     return nextState;
   }
 
+  if (nextState.stationStopUntilMs !== null) {
+    if (elapsedMs < nextState.stationStopUntilMs) {
+      return {
+        ...nextState,
+        train: {
+          ...nextState.train,
+          speed: 0,
+        },
+      };
+    }
+
+    nextState = {
+      ...nextState,
+      stationStopUntilMs: null,
+      train: {
+        ...nextState.train,
+        speed: getSpeed(nextState.train.definition, nextState.level),
+      },
+    };
+  }
+
   const movement = (nextState.train.speed * dtMs) / 1000;
   const wheelRadius = nextState.train.definition.locomotive.wheelSet.radius;
   const wheelRotationDelta = movement / Math.max(8, wheelRadius);
@@ -203,6 +226,20 @@ export const advanceSimulation = (
       wheelRotationRad: nextState.train.wheelRotationRad + wheelRotationDelta,
     },
   };
+
+  const stationStop = resolvedState.level.stationStop;
+  if (stationStop && !resolvedState.stationStopCompleted && resolvedState.train.x >= stationStop.x) {
+    return {
+      ...resolvedState,
+      stationStopCompleted: true,
+      stationStopUntilMs: elapsedMs + stationStop.pauseMs,
+      train: {
+        ...resolvedState.train,
+        x: stationStop.x,
+        speed: 0,
+      },
+    };
+  }
 
   while (resolvedState.nextCheckpointIndex < resolvedState.level.checkpoints.length) {
     const checkpoint = resolvedState.level.checkpoints[resolvedState.nextCheckpointIndex];

--- a/ui/partner-hub/lib/steam-trains/levels.ts
+++ b/ui/partner-hub/lib/steam-trains/levels.ts
@@ -39,12 +39,16 @@ export const STEAM_TRAINS_LEVELS: LevelDefinition[] = [
     startX: 110,
     destinationX: 1030,
     forkLength: 200,
-    checkpoints: [{ id: "station-switch", x: 530, safeBranch: "main", promptIcon: "station" }],
+    checkpoints: [{ id: "station-switch", x: 700, safeBranch: "main", promptIcon: "switch" }],
     baseSpeedMultiplier: 1,
-    tutorialCue: "Pass the station and pick the right track.",
+    tutorialCue: "Stop at the station, then pick the right track.",
     scene: "station",
     crashPauseMs: 330,
     rewindDurationMs: 380,
+    stationStop: {
+      x: 530,
+      pauseMs: 1200,
+    },
   },
   {
     id: "level-4-bridge-tunnel",

--- a/ui/partner-hub/lib/steam-trains/progression.test.ts
+++ b/ui/partner-hub/lib/steam-trains/progression.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 import { STEAM_TRAINS_LEVELS } from "./levels";
 import {
   clampUnlockedLevel,
+  getValidSelectedLevelOrder,
   getHighestUnlockedAfterCompletion,
   getLevelByOrder,
   getNextLevelOrder,
@@ -31,5 +32,11 @@ describe("steam trains progression", () => {
     assert.equal(getLevelByOrder(3)?.id, "level-3-station-stop");
     assert.equal(getNextLevelOrder(1), 2);
     assert.equal(getNextLevelOrder(STEAM_TRAINS_LEVELS.length), STEAM_TRAINS_LEVELS.length);
+  });
+
+  it("clamps selected level order based on mode and unlocks", () => {
+    assert.equal(getValidSelectedLevelOrder(0, "levels", 3), 1);
+    assert.equal(getValidSelectedLevelOrder(5, "levels", 2), 2);
+    assert.equal(getValidSelectedLevelOrder(5, "free-play", 2), 5);
   });
 });

--- a/ui/partner-hub/lib/steam-trains/progression.ts
+++ b/ui/partner-hub/lib/steam-trains/progression.ts
@@ -1,7 +1,10 @@
 import { STEAM_TRAINS_LEVELS } from "./levels";
+import type { GameMode } from "./types";
 
 export const clampUnlockedLevel = (highestUnlockedLevel: number) =>
   Math.min(Math.max(highestUnlockedLevel, 1), STEAM_TRAINS_LEVELS.length);
+
+export const clampLevelOrder = (order: number) => Math.min(Math.max(order, 1), STEAM_TRAINS_LEVELS.length);
 
 export const isLevelUnlocked = (levelOrder: number, highestUnlockedLevel: number) =>
   levelOrder <= clampUnlockedLevel(highestUnlockedLevel);
@@ -15,3 +18,16 @@ export const getLevelByOrder = (order: number) => STEAM_TRAINS_LEVELS.find((leve
 
 export const getNextLevelOrder = (currentOrder: number) =>
   Math.min(currentOrder + 1, STEAM_TRAINS_LEVELS.length);
+
+export const getValidSelectedLevelOrder = (
+  requestedOrder: number,
+  mode: GameMode,
+  highestUnlockedLevel: number,
+) => {
+  const clampedOrder = clampLevelOrder(requestedOrder);
+  if (mode === "free-play") {
+    return clampedOrder;
+  }
+
+  return Math.min(clampedOrder, clampUnlockedLevel(highestUnlockedLevel));
+};

--- a/ui/partner-hub/lib/steam-trains/types.ts
+++ b/ui/partner-hub/lib/steam-trains/types.ts
@@ -137,6 +137,10 @@ export type LevelDefinition = {
   scene: LevelScene;
   crashPauseMs: number;
   rewindDurationMs: number;
+  stationStop?: {
+    x: number;
+    pauseMs: number;
+  };
 };
 
 export type SteamParticle = {
@@ -178,4 +182,6 @@ export type SteamTrainsSimulationState = {
   whistleAtMs: number | null;
   particles: SteamParticle[];
   nextParticleId: number;
+  stationStopCompleted: boolean;
+  stationStopUntilMs: number | null;
 };


### PR DESCRIPTION
### Motivation
- Close remaining Phase 2 gaps for Steam Trains by adding a genuine station-stop mechanic and tightening UX around non-running states. 
- Keep the implementation small, production-safe, and limited to Phase 2 (no multi-train or builder features). 
- Harden level/mode selection and ensure user interactions reset the inactivity helper consistently.

### Description
- Engine/state: add `stationStop` to `LevelDefinition` and `stationStopCompleted` / `stationStopUntilMs` to `SteamTrainsSimulationState`, and implement pause/resume in `advanceSimulation` so trains genuinely stop at the station and automatically resume; file: `ui/partner-hub/lib/steam-trains/engine.ts`.
- Levels: move Level 3 checkpoint after the station and add `stationStop` metadata (`x` + `pauseMs`) so Level 3 is themed and functional; file: `ui/partner-hub/lib/steam-trains/levels.ts`.
- UI/UX: disable Main/Side Track buttons visually and functionally when the simulation is not `running`, and add `bumpInteraction` calls for Helper toggle and Next Level flows; file: `ui/partner-hub/components/steam-trains/steam-trains-tool.tsx`.
- Progression & selection safety: add `getValidSelectedLevelOrder` and `clampLevelOrder` to centralize clamping of requested level order against unlocks and mode rules, plus hydration/normalization of preferences during load to avoid stale selectedLevelOrder; files: `ui/partner-hub/lib/steam-trains/progression.ts` and updates in `steam-trains-tool.tsx`.
- Tests: add focused engine tests covering Level 3 station stop and resume, post-stop switch requirement, and protection against switch changes when the run is not running, and add progression test for selected-order clamping; files: `ui/partner-hub/lib/steam-trains/engine.test.ts` and `ui/partner-hub/lib/steam-trains/progression.test.ts`.
- Files changed (summary): `steam-trains/types.ts` (add stationStop + runtime flags); `steam-trains/levels.ts` (level-3 stationStop + checkpoint reorder + tutorial cue); `steam-trains/engine.ts` (station-stop logic + state defaults); `steam-trains/engine.test.ts` (new station-stop and non-running tests); `steam-trains/progression.ts` (clamping + helper func); `steam-trains/progression.test.ts` (clamping tests); `components/steam-trains/steam-trains-tool.tsx` (UX polish, interaction bumps, mode/level clamping, disable buttons).

### Testing
- Ran the full test suite: `cd ui/partner-hub && npm test` with final TAP summary:
```
1..48
# tests 165
# suites 48
# pass 165
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 5150.284922
```
- Typecheck: `cd ui/partner-hub && npm run typecheck` output:
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> partner-hub@0.0.1 typecheck
> tsc --noEmit
```
- Production build: `cd ui/partner-hub && npm run build` (tail of output):
```
✓ Compiled successfully in 20.3s
  Linting and checking validity of types ...
  Collecting page data ...
  Generating static pages (0/22) ...
  Generating static pages (5/22) 
  Generating static pages (10/22) 
  Generating static pages (16/22) 
✓ Generating static pages (22/22)
  Finalizing page optimization ...
  Collecting build traces ...
```

All automated checks passed and the focused Phase 2 goals requested here are implemented without introducing Phase 3 scope; Phase 2 is complete and ready for Phase 3 when you are.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6fec8b5048330ba297f8a5585bfcc)