### PR TITLE
Harden Steam Trains phase 3 train selection

### DIFF
--- a/ui/partner-hub/components/steam-trains/train-selector.tsx
+++ b/ui/partner-hub/components/steam-trains/train-selector.tsx
@@ -7,6 +7,22 @@ type TrainSelectorProps = {
 
 const previewWidth = 220;
 const baseY = 98;
+const previewPadding = 8;
+const locomotiveToTenderGap = 20;
+const carGap = 10;
+
+const getTrainRole = (trainId: string): string => {
+  if (trainId.includes("switcher")) {
+    return "Switcher";
+  }
+  if (trainId.includes("passenger")) {
+    return "Passenger";
+  }
+  if (trainId.includes("freight")) {
+    return "Freight";
+  }
+  return "Steam";
+};
 
 export function TrainSelector({ selectedTrainId, onSelectTrain }: TrainSelectorProps) {
   return (
@@ -16,8 +32,22 @@ export function TrainSelector({ selectedTrainId, onSelectTrain }: TrainSelectorP
         {STEAM_TRAIN_CATALOG.map((train) => {
           const selected = train.id === selectedTrainId;
           const loco = train.locomotive;
-          const scale = Math.min(0.65, previewWidth / (loco.bodyLength + (train.tender?.length ?? 0) + 100));
-          const tenderStart = (loco.bodyLength + 20) * scale;
+          const tenderLength = train.tender?.length ?? 0;
+          const rollingStockLength = train.rollingStock.reduce((total, car) => total + car.length, 0);
+          const rollingStockSpacing = Math.max(0, train.rollingStock.length - 1) * carGap;
+          const fullConsistLength =
+            loco.bodyLength +
+            (train.tender ? locomotiveToTenderGap + tenderLength : 0) +
+            (train.rollingStock.length > 0 ? locomotiveToTenderGap : 0) +
+            rollingStockLength +
+            rollingStockSpacing;
+
+          const usablePreviewWidth = previewWidth - previewPadding * 2;
+          const scale = Math.min(0.65, usablePreviewWidth / Math.max(1, fullConsistLength));
+          const locomotiveStart = previewPadding;
+          const tenderStart = locomotiveStart + (loco.bodyLength + locomotiveToTenderGap) * scale;
+          const rollingStockStart =
+            tenderStart + (train.tender ? train.tender.length + locomotiveToTenderGap : 0) * scale;
 
           return (
             <button
@@ -33,9 +63,15 @@ export function TrainSelector({ selectedTrainId, onSelectTrain }: TrainSelectorP
                 <svg viewBox={`0 0 ${previewWidth} 110`} role="img" aria-label={train.displayName} className="h-28 w-full">
                   <rect x="0" y="96" width={previewWidth} height="8" fill="#64748b" />
                   <rect x="0" y="102" width={previewWidth} height="4" fill="#475569" />
-                  <rect x="8" y={baseY - loco.bodyHeight * 0.35 * scale} width={loco.bodyLength * 0.66 * scale} height={loco.bodyHeight * 0.35 * scale} fill={loco.color} />
+                  <rect
+                    x={locomotiveStart}
+                    y={baseY - loco.bodyHeight * 0.35 * scale}
+                    width={loco.bodyLength * 0.66 * scale}
+                    height={loco.bodyHeight * 0.35 * scale}
+                    fill={loco.color}
+                  />
                   <ellipse
-                    cx={18 + loco.bodyLength * 0.38 * scale}
+                    cx={locomotiveStart + 10 + loco.bodyLength * 0.38 * scale}
                     cy={baseY - loco.bodyHeight * 0.52 * scale}
                     rx={loco.bodyLength * 0.35 * scale}
                     ry={loco.bodyHeight * 0.32 * scale}
@@ -44,14 +80,14 @@ export function TrainSelector({ selectedTrainId, onSelectTrain }: TrainSelectorP
                   {loco.stack && (
                     <>
                       <rect
-                        x={8 + loco.stack.offsetX * scale}
+                        x={locomotiveStart + loco.stack.offsetX * scale}
                         y={baseY + loco.stack.offsetY * scale}
                         width={loco.stack.width * scale}
                         height={loco.stack.height * scale}
                         fill="#0f172a"
                       />
                       <rect
-                        x={8 + (loco.stack.offsetX - (loco.stack.flareWidth - loco.stack.width) / 2) * scale}
+                        x={locomotiveStart + (loco.stack.offsetX - (loco.stack.flareWidth - loco.stack.width) / 2) * scale}
                         y={baseY + (loco.stack.offsetY - loco.stack.flareHeight) * scale}
                         width={loco.stack.flareWidth * scale}
                         height={loco.stack.flareHeight * scale}
@@ -61,7 +97,7 @@ export function TrainSelector({ selectedTrainId, onSelectTrain }: TrainSelectorP
                   )}
                   {loco.cab && (
                     <rect
-                      x={8 + loco.cab.offsetX * scale}
+                      x={locomotiveStart + loco.cab.offsetX * scale}
                       y={baseY - (loco.cab.height + 8) * scale}
                       width={loco.cab.width * scale}
                       height={loco.cab.height * scale}
@@ -71,7 +107,10 @@ export function TrainSelector({ selectedTrainId, onSelectTrain }: TrainSelectorP
                   {Array.from({ length: loco.wheelSet.count }).map((_, wheelIndex) => (
                     <circle
                       key={`${train.id}-wheel-${wheelIndex}`}
-                      cx={8 + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing) * scale}
+                      cx={
+                        locomotiveStart +
+                        (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing) * scale
+                      }
                       cy={baseY}
                       r={loco.wheelSet.radius * scale}
                       fill="#111827"
@@ -79,7 +118,7 @@ export function TrainSelector({ selectedTrainId, onSelectTrain }: TrainSelectorP
                   ))}
                   {train.tender && (
                     <rect
-                      x={8 + tenderStart}
+                      x={tenderStart}
                       y={baseY - train.tender.height * scale}
                       width={train.tender.length * scale}
                       height={train.tender.height * scale}
@@ -87,7 +126,7 @@ export function TrainSelector({ selectedTrainId, onSelectTrain }: TrainSelectorP
                     />
                   )}
                   {train.rollingStock.map((car, carIndex) => {
-                    const x = 8 + tenderStart + ((train.tender?.length ?? 0) + 14 + carIndex * (car.length + 10)) * scale;
+                    const x = rollingStockStart + carIndex * (car.length + carGap) * scale;
                     return (
                       <rect
                         key={car.id}
@@ -102,6 +141,9 @@ export function TrainSelector({ selectedTrainId, onSelectTrain }: TrainSelectorP
                 </svg>
               </div>
               <p className="mt-2 text-lg font-semibold">{train.displayName}</p>
+              <p className="text-sm text-muted-foreground">
+                {getTrainRole(train.id)} • {train.locomotive.wheelArrangement}
+              </p>
             </button>
           );
         })}

--- a/ui/partner-hub/lib/steam-trains/engine.test.ts
+++ b/ui/partner-hub/lib/steam-trains/engine.test.ts
@@ -9,7 +9,7 @@ import {
   triggerSteamPuff,
 } from "./engine";
 import { getLevelDefinition } from "./levels";
-import { DEFAULT_STEAM_TRAIN_ID, getTrainDefinition } from "./trainCatalog";
+import { DEFAULT_STEAM_TRAIN_ID, STEAM_TRAIN_CATALOG, getTrainDefinition } from "./trainCatalog";
 
 const createLevelState = (levelId: string, mode: "levels" | "free-play" = "levels") =>
   createSimulation(getTrainDefinition(DEFAULT_STEAM_TRAIN_ID), getLevelDefinition(levelId), mode);
@@ -68,6 +68,34 @@ describe("steam trains engine", () => {
 
     assert.equal(state.playState, "running");
     assert.equal(state.mode, "free-play");
+  });
+
+  it("supports every stock train across create/advance/puff/restart in both modes", () => {
+    const level = getLevelDefinition("level-1-switch-start");
+
+    STEAM_TRAIN_CATALOG.forEach((train) => {
+      (["levels", "free-play"] as const).forEach((mode) => {
+        const created = createSimulation(train, level, mode);
+
+        assert.equal(created.train.definition.id, train.id);
+        assert.equal(created.mode, mode);
+
+        const advanced = advanceSimulation(created, 32);
+        assert.equal(advanced.train.x > created.train.x, true, `${train.id}:${mode} x movement`);
+        assert.equal(
+          advanced.train.wheelRotationRad > created.train.wheelRotationRad,
+          true,
+          `${train.id}:${mode} wheel rotation`,
+        );
+
+        const puffed = triggerSteamPuff(advanced);
+        assert.equal(puffed.particles.length > advanced.particles.length, true, `${train.id}:${mode} puff`);
+
+        const restarted = restartSimulation({ ...puffed, playState: "completed" });
+        assert.equal(restarted.train.definition.id, train.id, `${train.id}:${mode} restart train`);
+        assert.equal(restarted.mode, mode, `${train.id}:${mode} restart mode`);
+      });
+    });
   });
 
   it("supports steam puff bursts and manual restart", () => {

--- a/ui/partner-hub/lib/steam-trains/storage.test.ts
+++ b/ui/partner-hub/lib/steam-trains/storage.test.ts
@@ -2,10 +2,15 @@ import * as assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  DEFAULT_STEAM_TRAIN_ID,
+  STEAM_TRAIN_CATALOG,
+} from "./trainCatalog";
+import {
   STEAM_TRAINS_STORAGE_KEY,
   getDefaultSteamTrainsPreferences,
   loadSteamTrainsPreferences,
   saveSteamTrainsPreferences,
+  sanitizePreferences,
 } from "./storage";
 
 class MemoryStorage {
@@ -43,6 +48,23 @@ describe("steam trains storage", () => {
     assert.notEqual(storage.getItem(STEAM_TRAINS_STORAGE_KEY), null);
   });
 
+  it("round-trips every stock train id through sanitize/load/save", () => {
+    STEAM_TRAIN_CATALOG.forEach((train) => {
+      const storage = new MemoryStorage();
+      const sanitized = sanitizePreferences({ selectedTrainId: train.id });
+
+      assert.equal(sanitized.selectedTrainId, train.id, `${train.id}: sanitize`);
+
+      saveSteamTrainsPreferences(storage, {
+        ...getDefaultSteamTrainsPreferences(),
+        selectedTrainId: train.id,
+      });
+
+      const loaded = loadSteamTrainsPreferences(storage);
+      assert.equal(loaded.selectedTrainId, train.id, `${train.id}: load/save`);
+    });
+  });
+
   it("falls back for malformed stored values", () => {
     const storage = new MemoryStorage();
     storage.setItem(
@@ -54,6 +76,6 @@ describe("steam trains storage", () => {
     assert.equal(loaded.highestUnlockedLevel, 1);
     assert.equal(loaded.helperMode, true);
     assert.equal(loaded.lastMode, "levels");
-    assert.equal(loaded.selectedTrainId, "copper-creek-switcher");
+    assert.equal(loaded.selectedTrainId, DEFAULT_STEAM_TRAIN_ID);
   });
 });


### PR DESCRIPTION
### Motivation
- Finish remaining Phase 3 hardening so Steam Trains selection and runtime behavior are robust before Phase 4 work. 
- Fix visual clipping in train selector previews so every stock train fits the SVG card cleanly. 
- Add lightweight, deterministic runtime and persistence smoke tests that exercise every stock train to prevent regressions.

### Description
- Update `ui/partner-hub/components/steam-trains/train-selector.tsx` to compute a full-consist preview scale (locomotive + tender + rolling stock + spacing) and add small preview padding and consistent gaps so cards never clip, while keeping large tappable cards and child-friendly silhouettes. 
- Add a minimal secondary label (`role • wheel arrangement`) on selector cards to visually distinguish switcher/passenger/freight without cluttering the UI. 
- Add a table-driven smoke test in `ui/partner-hub/lib/steam-trains/engine.test.ts` that iterates `STEAM_TRAIN_CATALOG` and verifies `createSimulation`, `advanceSimulation` (movement and wheel rotation), `triggerSteamPuff`, and `restartSimulation` for both `levels` and `free-play` modes. 
- Add a focused round-trip persistence test in `ui/partner-hub/lib/steam-trains/storage.test.ts` that sanitizes and verifies each stock `selectedTrainId` survives `sanitize -> save -> load`, and use `DEFAULT_STEAM_TRAIN_ID` for invalid-id fallback verification. 
- Files changed: `train-selector.tsx` (preview scaling, padding/gaps, small label), `engine.test.ts` (per-train runtime coverage), `storage.test.ts` (per-train persistence round-trip and sanitize usage).

### Testing
- Ran `cd ui/partner-hub && npm test` and all tests passed: `# tests 169`, `# suites 49`, `# pass 169`, `# fail 0`. 
- Ran `cd ui/partner-hub && npm run typecheck` and `tsc` completed without errors. 
- Ran `cd ui/partner-hub && npm run build` and the Next.js production build completed successfully with `Compiled successfully` and static pages generated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c705105f3083308e4c8281c9d819af)