### PR TITLE
Bring Steam Trains workshop visuals in line with runtime

### DIFF
--- a/ui/partner-hub/components/steam-trains/train-builder.tsx
+++ b/ui/partner-hub/components/steam-trains/train-builder.tsx
@@ -8,6 +8,7 @@ import {
   type TrainBuilderSelection,
   validateTrainBuilderSelection,
 } from "@/lib/steam-trains/builder";
+import { getCarWindowColor, getLocomotiveSilhouette, getPreviewPalette, getTrainLayout } from "@/lib/steam-trains/visuals";
 import type { TrainDefinition } from "@/lib/steam-trains/types";
 
 type TrainBuilderProps = {
@@ -39,6 +40,107 @@ const cycleOption = (options: BuilderSlotOption[], currentId: string, direction:
   return options[nextIndex]?.id ?? options[0]?.id ?? currentId;
 };
 
+const previewWidth = 320;
+const previewBaseY = 96;
+const previewPadding = 10;
+const previewCarGap = 10;
+const previewPalette = getPreviewPalette();
+
+const renderPreviewLocomotive = (train: TrainDefinition, locomotiveStart: number, scale: number) => {
+  const loco = train.locomotive;
+  const silhouette = getLocomotiveSilhouette(loco);
+  const pilot = loco.pilot ?? { length: 40, height: 24, color: "#374151", ribCount: 5 };
+
+  return (
+    <g>
+      <polygon
+        points={`${locomotiveStart - pilot.length * scale},${previewBaseY} ${locomotiveStart + 4},${previewBaseY} ${locomotiveStart + 4},${previewBaseY - pilot.height * scale}`}
+        fill={pilot.color}
+      />
+      <rect
+        x={locomotiveStart + 10 * scale}
+        y={previewBaseY + silhouette.runningBoardY * scale}
+        width={(silhouette.boilerLength + 50) * scale}
+        height={train.locomotive.bodyHeight * 0.34 * scale}
+        fill={previewPalette.runningBoard}
+      />
+      <rect
+        x={locomotiveStart + 18 * scale}
+        y={previewBaseY + silhouette.boilerTop * scale}
+        width={silhouette.boilerLength * scale}
+        height={silhouette.boilerHeight * scale}
+        rx={10 * scale}
+        fill={loco.color}
+      />
+      <circle
+        cx={locomotiveStart + silhouette.smokeboxCenterX * scale}
+        cy={previewBaseY + (silhouette.boilerTop + silhouette.boilerHeight / 2) * scale}
+        r={silhouette.smokeboxRadius * scale}
+        fill={previewPalette.smokebox}
+      />
+      <rect
+        x={locomotiveStart + 22 * scale}
+        y={previewBaseY + (silhouette.boilerTop - 9) * scale}
+        width={silhouette.boilerLength * 0.58 * scale}
+        height={6 * scale}
+        fill={loco.trimColor}
+      />
+      {loco.stack && (
+        <>
+          <rect
+            x={locomotiveStart + loco.stack.offsetX * scale}
+            y={previewBaseY + loco.stack.offsetY * scale}
+            width={loco.stack.width * scale}
+            height={loco.stack.height * scale}
+            rx={2 * scale}
+            fill={previewPalette.stack}
+          />
+          <rect
+            x={locomotiveStart + (loco.stack.offsetX - (loco.stack.flareWidth - loco.stack.width) / 2) * scale}
+            y={previewBaseY + (loco.stack.offsetY - loco.stack.flareHeight) * scale}
+            width={loco.stack.flareWidth * scale}
+            height={loco.stack.flareHeight * scale}
+            rx={2 * scale}
+            fill={previewPalette.stack}
+          />
+        </>
+      )}
+      {loco.cab && (
+        <polygon
+          points={`${locomotiveStart + loco.cab.offsetX * scale},${previewBaseY - (loco.cab.height - 2) * scale} ${locomotiveStart + (loco.cab.offsetX + loco.cab.width) * scale},${previewBaseY - (loco.cab.height - 2) * scale} ${locomotiveStart + (loco.cab.offsetX + loco.cab.width) * scale},${previewBaseY - 8 * scale} ${locomotiveStart + (loco.cab.offsetX + 10) * scale},${previewBaseY - 8 * scale}`}
+          fill={loco.color}
+        />
+      )}
+      {Array.from({ length: loco.wheelSet.count }).map((_, wheelIndex) => (
+        <g key={`${train.id}-wheel-${wheelIndex}`}>
+          <circle
+            cx={locomotiveStart + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing) * scale}
+            cy={previewBaseY}
+            r={loco.wheelSet.radius * scale}
+            fill={previewPalette.wheelFill}
+          />
+          <circle
+            cx={locomotiveStart + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing) * scale}
+            cy={previewBaseY}
+            r={(loco.wheelSet.radius - 4) * scale}
+            fill="none"
+            stroke={previewPalette.wheelRim}
+            strokeWidth={1.6 * scale}
+          />
+          <line
+            x1={locomotiveStart + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing - loco.wheelSet.radius + 4) * scale}
+            y1={previewBaseY}
+            x2={locomotiveStart + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing + loco.wheelSet.radius - 4) * scale}
+            y2={previewBaseY}
+            stroke={previewPalette.wheelSpoke}
+            strokeWidth={1.2 * scale}
+          />
+        </g>
+      ))}
+    </g>
+  );
+};
+
 export function TrainBuilder({
   selection,
   onChange,
@@ -51,7 +153,10 @@ export function TrainBuilder({
 }: TrainBuilderProps) {
   const issues = validateTrainBuilderSelection(selection);
   const previewTrain = buildTrainDefinitionFromSelection(selection, "preview-custom");
-  const loco = previewTrain.locomotive;
+  const previewLayout = getTrainLayout(previewTrain, previewWidth, previewPadding, 0.62, {
+    locomotiveToTender: 18,
+    carGap: previewCarGap,
+  });
 
   return (
     <section className="space-y-4" aria-label="Train workshop">
@@ -81,17 +186,51 @@ export function TrainBuilder({
             </label>
           </div>
 
-          <div className="rounded-2xl border bg-sky-50 p-3">
+          <div className="rounded-2xl border bg-gradient-to-b from-sky-100 via-sky-50 to-green-100 p-3">
             <svg viewBox="0 0 320 128" className="h-36 w-full" role="img" aria-label="Custom train preview">
-              <rect x="0" y="108" width="320" height="8" fill="#64748b" />
-              <rect x="0" y="114" width="320" height="4" fill="#475569" />
-              <rect x="14" y={96 - loco.bodyHeight * 0.34} width={loco.bodyLength * 0.52} height={loco.bodyHeight * 0.34} fill={loco.color} />
-              <ellipse cx={94} cy={96 - loco.bodyHeight * 0.48} rx={loco.bodyLength * 0.26} ry={loco.bodyHeight * 0.28} fill={loco.color} />
-              {loco.stack && <rect x={20 + loco.stack.offsetX * 0.56} y={96 + loco.stack.offsetY * 0.56} width={loco.stack.width * 0.56} height={loco.stack.height * 0.56} fill="#0f172a" />}
-              {loco.cab && <rect x={16 + loco.cab.offsetX * 0.56} y={96 - (loco.cab.height + 8) * 0.56} width={loco.cab.width * 0.56} height={loco.cab.height * 0.56} fill={loco.color} />}
-              {Array.from({ length: loco.wheelSet.count }).map((_, index) => (
-                <circle key={index} cx={18 + (loco.wheelSet.offsetX + index * loco.wheelSet.spacing) * 0.56} cy={96} r={loco.wheelSet.radius * 0.56} fill="#111827" />
-              ))}
+              <rect x="0" y="95" width={previewWidth} height="15" fill={previewPalette.railBed} />
+              <rect x="0" y="93" width={previewWidth} height="3" fill={previewPalette.railTop} />
+              <rect x="0" y="101" width={previewWidth} height="3" fill={previewPalette.railBottom} />
+              {renderPreviewLocomotive(previewTrain, previewLayout.locomotiveStart, previewLayout.scale)}
+              {previewTrain.tender && (
+                <g>
+                  <rect
+                    x={previewLayout.tenderStart}
+                    y={previewBaseY - previewTrain.tender.height * previewLayout.scale}
+                    width={previewTrain.tender.length * previewLayout.scale}
+                    height={previewTrain.tender.height * previewLayout.scale}
+                    fill={previewTrain.tender.color}
+                  />
+                  <rect
+                    x={previewLayout.tenderStart + 8 * previewLayout.scale}
+                    y={previewBaseY - (previewTrain.tender.height + 12) * previewLayout.scale}
+                    width={(previewTrain.tender.length - 16) * previewLayout.scale}
+                    height={12 * previewLayout.scale}
+                    fill={previewPalette.runningBoard}
+                  />
+                </g>
+              )}
+              {previewTrain.rollingStock.map((car, carIndex) => {
+                const x = previewLayout.rollingStockStart + carIndex * (car.length + previewCarGap) * previewLayout.scale;
+                return (
+                  <g key={car.id}>
+                    <rect
+                      x={x}
+                      y={previewBaseY - car.height * previewLayout.scale}
+                      width={car.length * previewLayout.scale}
+                      height={car.height * previewLayout.scale}
+                      fill={car.color}
+                    />
+                    <rect
+                      x={x + 8 * previewLayout.scale}
+                      y={previewBaseY - (car.height - 10) * previewLayout.scale}
+                      width={(car.length - 16) * previewLayout.scale}
+                      height={Math.min(16, car.height * 0.4) * previewLayout.scale}
+                      fill={getCarWindowColor(previewTrain.id)}
+                    />
+                  </g>
+                );
+              })}
               <text x="12" y="22" fontSize="15" fill="#0f172a" fontWeight="700">
                 {previewTrain.displayName}
               </text>
@@ -152,8 +291,15 @@ export function TrainBuilder({
           ) : (
             <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
               {savedTrains.map((train) => (
-                <Button key={train.id} type="button" className="h-14 justify-start px-4 text-left text-base" variant="secondary" onClick={() => onLoadSaved(train.id)}>
-                  {train.displayName}
+                <Button
+                  key={train.id}
+                  type="button"
+                  className="h-auto min-h-14 justify-start px-3 py-2 text-left text-base"
+                  variant="secondary"
+                  onClick={() => onLoadSaved(train.id)}
+                >
+                  <span className="mr-2 inline-block h-3 w-8 rounded-full" style={{ backgroundColor: train.locomotive.trimColor }} />
+                  <span className="truncate">{train.displayName}</span>
                 </Button>
               ))}
             </div>

--- a/ui/partner-hub/components/steam-trains/train-selector.tsx
+++ b/ui/partner-hub/components/steam-trains/train-selector.tsx
@@ -1,4 +1,4 @@
-import { getLocomotiveSilhouette, getTrainLayout } from "@/lib/steam-trains/visuals";
+import { getCarWindowColor, getLocomotiveSilhouette, getPreviewPalette, getTrainLayout } from "@/lib/steam-trains/visuals";
 import type { TrainDefinition } from "@/lib/steam-trains/types";
 
 type TrainSelectorProps = {
@@ -11,6 +11,7 @@ const previewWidth = 220;
 const baseY = 98;
 const previewPadding = 8;
 const carGap = 10;
+const previewPalette = getPreviewPalette();
 
 const getTrainRole = (trainId: string): string => {
   if (trainId.includes("switcher")) return "Switcher";
@@ -27,9 +28,9 @@ const renderLocoPreview = (train: TrainDefinition, locomotiveStart: number, scal
 
   return (
     <g>
-      <rect x="0" y="95" width={previewWidth} height="15" fill="#7c6450" />
-      <rect x="0" y="93" width={previewWidth} height="3" fill="#d1d5db" />
-      <rect x="0" y="101" width={previewWidth} height="3" fill="#9ca3af" />
+      <rect x="0" y="95" width={previewWidth} height="15" fill={previewPalette.railBed} />
+      <rect x="0" y="93" width={previewWidth} height="3" fill={previewPalette.railTop} />
+      <rect x="0" y="101" width={previewWidth} height="3" fill={previewPalette.railBottom} />
 
       <polygon
         points={`${locomotiveStart - pilot.length * scale},${baseY} ${locomotiveStart + 4},${baseY} ${locomotiveStart + 4},${baseY - pilot.height * scale}`}
@@ -41,7 +42,7 @@ const renderLocoPreview = (train: TrainDefinition, locomotiveStart: number, scal
         y={baseY + silhouette.runningBoardY * scale}
         width={(silhouette.boilerLength + 50) * scale}
         height={loco.bodyHeight * 0.34 * scale}
-        fill="#0f172a"
+        fill={previewPalette.runningBoard}
       />
 
       <rect
@@ -57,7 +58,7 @@ const renderLocoPreview = (train: TrainDefinition, locomotiveStart: number, scal
         cx={locomotiveStart + silhouette.smokeboxCenterX * scale}
         cy={baseY + (silhouette.boilerTop + silhouette.boilerHeight / 2) * scale}
         r={silhouette.smokeboxRadius * scale}
-        fill="#111827"
+        fill={previewPalette.smokebox}
       />
 
       <rect
@@ -76,7 +77,7 @@ const renderLocoPreview = (train: TrainDefinition, locomotiveStart: number, scal
             width={loco.stack.width * scale}
             height={loco.stack.height * scale}
             rx={2 * scale}
-            fill="#0f172a"
+            fill={previewPalette.stack}
           />
           <rect
             x={locomotiveStart + (loco.stack.offsetX - (loco.stack.flareWidth - loco.stack.width) / 2) * scale}
@@ -84,7 +85,7 @@ const renderLocoPreview = (train: TrainDefinition, locomotiveStart: number, scal
             width={loco.stack.flareWidth * scale}
             height={loco.stack.flareHeight * scale}
             rx={2 * scale}
-            fill="#0f172a"
+            fill={previewPalette.stack}
           />
         </>
       )}
@@ -102,15 +103,23 @@ const renderLocoPreview = (train: TrainDefinition, locomotiveStart: number, scal
             cx={locomotiveStart + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing) * scale}
             cy={baseY}
             r={loco.wheelSet.radius * scale}
-            fill="#0f172a"
+            fill={previewPalette.wheelFill}
           />
           <circle
             cx={locomotiveStart + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing) * scale}
             cy={baseY}
             r={(loco.wheelSet.radius - 4) * scale}
             fill="none"
-            stroke="#cbd5e1"
+            stroke={previewPalette.wheelRim}
             strokeWidth={1.6 * scale}
+          />
+          <line
+            x1={locomotiveStart + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing - loco.wheelSet.radius + 4) * scale}
+            y1={baseY}
+            x2={locomotiveStart + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing + loco.wheelSet.radius - 4) * scale}
+            y2={baseY}
+            stroke={previewPalette.wheelSpoke}
+            strokeWidth={1.2 * scale}
           />
         </g>
       ))}
@@ -168,7 +177,7 @@ export function TrainSelector({ selectedTrainId, trains, onSelectTrain }: TrainS
                           y={baseY - (car.height - 10) * layout.scale}
                           width={(car.length - 16) * layout.scale}
                           height={Math.min(16, car.height * 0.4) * layout.scale}
-                          fill={train.id.includes("passenger") ? "#fef3c7" : "#334155"}
+                          fill={getCarWindowColor(train.id)}
                         />
                       </g>
                     );

--- a/ui/partner-hub/lib/steam-trains/visuals.test.ts
+++ b/ui/partner-hub/lib/steam-trains/visuals.test.ts
@@ -2,7 +2,7 @@ import * as assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { STEAM_TRAIN_CATALOG } from "./trainCatalog";
-import { countChuffPulses, getLocomotiveSilhouette, getTrainLayout } from "./visuals";
+import { countChuffPulses, getCarWindowColor, getLocomotiveSilhouette, getPreviewPalette, getTrainLayout } from "./visuals";
 
 describe("steam train visual helpers", () => {
   it("builds positive layouts for every stock train", () => {
@@ -28,5 +28,17 @@ describe("steam train visual helpers", () => {
     assert.equal(countChuffPulses(0, Math.PI / 4), 0);
     assert.equal(countChuffPulses(0, Math.PI / 2 + 0.01), 1);
     assert.equal(countChuffPulses(0, Math.PI * 2 + 0.01), 4);
+  });
+
+  it("provides stable preview palette colors", () => {
+    const palette = getPreviewPalette();
+    assert.equal(typeof palette.railBed, "string");
+    assert.equal(typeof palette.wheelFill, "string");
+    assert.equal(typeof palette.runningBoard, "string");
+  });
+
+  it("maps window color by train role", () => {
+    assert.equal(getCarWindowColor("starter-passenger"), "#fef3c7");
+    assert.equal(getCarWindowColor("starter-freight"), "#334155");
   });
 });

--- a/ui/partner-hub/lib/steam-trains/visuals.ts
+++ b/ui/partner-hub/lib/steam-trains/visuals.ts
@@ -21,6 +21,30 @@ export type LocomotiveSilhouette = {
   smokeboxCenterX: number;
 };
 
+export type TrainPreviewPalette = {
+  railBed: string;
+  railTop: string;
+  railBottom: string;
+  wheelFill: string;
+  wheelRim: string;
+  wheelSpoke: string;
+  runningBoard: string;
+  stack: string;
+  smokebox: string;
+};
+
+const DEFAULT_PREVIEW_PALETTE: TrainPreviewPalette = {
+  railBed: "#7c6450",
+  railTop: "#d1d5db",
+  railBottom: "#9ca3af",
+  wheelFill: "#0f172a",
+  wheelRim: "#cbd5e1",
+  wheelSpoke: "#94a3b8",
+  runningBoard: "#0f172a",
+  stack: "#0f172a",
+  smokebox: "#111827",
+};
+
 export const getTrainConsistLength = (train: TrainDefinition, gaps = { locomotiveToTender: LOCOMOTIVE_TO_TENDER_GAP, carGap: CAR_GAP }) => {
   const tenderLength = train.tender?.length ?? 0;
   const rollingStockLength = train.rollingStock.reduce((total, car) => total + car.length, 0);
@@ -34,6 +58,10 @@ export const getTrainConsistLength = (train: TrainDefinition, gaps = { locomotiv
     rollingStockSpacing
   );
 };
+
+export const getPreviewPalette = (): TrainPreviewPalette => DEFAULT_PREVIEW_PALETTE;
+
+export const getCarWindowColor = (trainId: string): string => (trainId.includes("passenger") ? "#fef3c7" : "#334155");
 
 export const getTrainLayout = (
   train: TrainDefinition,


### PR DESCRIPTION
### Motivation
- The Workshop custom-train preview used an older, overly-simple prototype look that no longer matches the runtime renderer and train selector visuals. 
- The preview should render a complete consist (locomotive, tender when present, and rolling stock when present) and scale/read well in the Workshop without touching gameplay or adding builder features. 
- Improve visual quality (boiler/cab/stack/headlamp/pilot, wheels, color/contrast) while keeping the Workshop UI simple and child-friendly.

### Description
- Reused and extended shared visual helpers by adding a small preview palette and window-color helper in `lib/steam-trains/visuals.ts` (`TrainPreviewPalette`, `getPreviewPalette`, `getCarWindowColor`) so previews share the runtime/selector visual language. 
- Rebuilt the Workshop preview in `components/steam-trains/train-builder.tsx` to use `getLocomotiveSilhouette`, `getTrainLayout`, and `getPreviewPalette`, and added a focused `renderPreviewLocomotive` to produce a fuller, better-scaled consist including tender and rolling stock when present. 
- Brought `components/steam-trains/train-selector.tsx` into parity by consuming `getPreviewPalette` and `getCarWindowColor` and improving wheel rim/spoke and rail rendering for consistent visuals. 
- Lightly improved Saved Custom Trains presentation by adding a small trim-color swatch in the saved list for readability without changing UX. 
- Added focused unit tests in `lib/steam-trains/visuals.test.ts` to assert preview palette stability and window-color mapping alongside existing visual helper tests.

### Testing
- Ran `npm test` from `ui/partner-hub` and the full test run passed with `# pass 180` and `# fail 0` and overall `# duration_ms 4973.462951`. 
- Ran `npm run typecheck` which executed `tsc --noEmit` and completed without errors. 
- Ran `npm run build` which produced a successful Next build with `✓ Compiled successfully in 19.2s` and `✓ Generating static pages (22/22)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c70dcf7b908330b5ad0633ab4dfd8a)