### PR TITLE
Rebuild Steam Trains visuals across runtime selector and Workshop

### DIFF
--- a/ui/partner-hub/components/steam-trains/train-builder.tsx
+++ b/ui/partner-hub/components/steam-trains/train-builder.tsx
@@ -8,8 +8,9 @@ import {
   type TrainBuilderSelection,
   validateTrainBuilderSelection,
 } from "@/lib/steam-trains/builder";
-import { getCarWindowColor, getLocomotiveSilhouette, getPreviewPalette, getTrainLayout } from "@/lib/steam-trains/visuals";
 import type { TrainDefinition } from "@/lib/steam-trains/types";
+
+import { TrainPreviewCanvas } from "./train-preview-canvas";
 
 type TrainBuilderProps = {
   selection: TrainBuilderSelection;
@@ -40,107 +41,6 @@ const cycleOption = (options: BuilderSlotOption[], currentId: string, direction:
   return options[nextIndex]?.id ?? options[0]?.id ?? currentId;
 };
 
-const previewWidth = 320;
-const previewBaseY = 96;
-const previewPadding = 10;
-const previewCarGap = 10;
-const previewPalette = getPreviewPalette();
-
-const renderPreviewLocomotive = (train: TrainDefinition, locomotiveStart: number, scale: number) => {
-  const loco = train.locomotive;
-  const silhouette = getLocomotiveSilhouette(loco);
-  const pilot = loco.pilot ?? { length: 40, height: 24, color: "#374151", ribCount: 5 };
-
-  return (
-    <g>
-      <polygon
-        points={`${locomotiveStart - pilot.length * scale},${previewBaseY} ${locomotiveStart + 4},${previewBaseY} ${locomotiveStart + 4},${previewBaseY - pilot.height * scale}`}
-        fill={pilot.color}
-      />
-      <rect
-        x={locomotiveStart + 10 * scale}
-        y={previewBaseY + silhouette.runningBoardY * scale}
-        width={(silhouette.boilerLength + 50) * scale}
-        height={train.locomotive.bodyHeight * 0.34 * scale}
-        fill={previewPalette.runningBoard}
-      />
-      <rect
-        x={locomotiveStart + 18 * scale}
-        y={previewBaseY + silhouette.boilerTop * scale}
-        width={silhouette.boilerLength * scale}
-        height={silhouette.boilerHeight * scale}
-        rx={10 * scale}
-        fill={loco.color}
-      />
-      <circle
-        cx={locomotiveStart + silhouette.smokeboxCenterX * scale}
-        cy={previewBaseY + (silhouette.boilerTop + silhouette.boilerHeight / 2) * scale}
-        r={silhouette.smokeboxRadius * scale}
-        fill={previewPalette.smokebox}
-      />
-      <rect
-        x={locomotiveStart + 22 * scale}
-        y={previewBaseY + (silhouette.boilerTop - 9) * scale}
-        width={silhouette.boilerLength * 0.58 * scale}
-        height={6 * scale}
-        fill={loco.trimColor}
-      />
-      {loco.stack && (
-        <>
-          <rect
-            x={locomotiveStart + loco.stack.offsetX * scale}
-            y={previewBaseY + loco.stack.offsetY * scale}
-            width={loco.stack.width * scale}
-            height={loco.stack.height * scale}
-            rx={2 * scale}
-            fill={previewPalette.stack}
-          />
-          <rect
-            x={locomotiveStart + (loco.stack.offsetX - (loco.stack.flareWidth - loco.stack.width) / 2) * scale}
-            y={previewBaseY + (loco.stack.offsetY - loco.stack.flareHeight) * scale}
-            width={loco.stack.flareWidth * scale}
-            height={loco.stack.flareHeight * scale}
-            rx={2 * scale}
-            fill={previewPalette.stack}
-          />
-        </>
-      )}
-      {loco.cab && (
-        <polygon
-          points={`${locomotiveStart + loco.cab.offsetX * scale},${previewBaseY - (loco.cab.height - 2) * scale} ${locomotiveStart + (loco.cab.offsetX + loco.cab.width) * scale},${previewBaseY - (loco.cab.height - 2) * scale} ${locomotiveStart + (loco.cab.offsetX + loco.cab.width) * scale},${previewBaseY - 8 * scale} ${locomotiveStart + (loco.cab.offsetX + 10) * scale},${previewBaseY - 8 * scale}`}
-          fill={loco.color}
-        />
-      )}
-      {Array.from({ length: loco.wheelSet.count }).map((_, wheelIndex) => (
-        <g key={`${train.id}-wheel-${wheelIndex}`}>
-          <circle
-            cx={locomotiveStart + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing) * scale}
-            cy={previewBaseY}
-            r={loco.wheelSet.radius * scale}
-            fill={previewPalette.wheelFill}
-          />
-          <circle
-            cx={locomotiveStart + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing) * scale}
-            cy={previewBaseY}
-            r={(loco.wheelSet.radius - 4) * scale}
-            fill="none"
-            stroke={previewPalette.wheelRim}
-            strokeWidth={1.6 * scale}
-          />
-          <line
-            x1={locomotiveStart + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing - loco.wheelSet.radius + 4) * scale}
-            y1={previewBaseY}
-            x2={locomotiveStart + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing + loco.wheelSet.radius - 4) * scale}
-            y2={previewBaseY}
-            stroke={previewPalette.wheelSpoke}
-            strokeWidth={1.2 * scale}
-          />
-        </g>
-      ))}
-    </g>
-  );
-};
-
 export function TrainBuilder({
   selection,
   onChange,
@@ -153,10 +53,6 @@ export function TrainBuilder({
 }: TrainBuilderProps) {
   const issues = validateTrainBuilderSelection(selection);
   const previewTrain = buildTrainDefinitionFromSelection(selection, "preview-custom");
-  const previewLayout = getTrainLayout(previewTrain, previewWidth, previewPadding, 0.62, {
-    locomotiveToTender: 18,
-    carGap: previewCarGap,
-  });
 
   return (
     <section className="space-y-4" aria-label="Train workshop">
@@ -187,54 +83,8 @@ export function TrainBuilder({
           </div>
 
           <div className="rounded-2xl border bg-gradient-to-b from-sky-100 via-sky-50 to-green-100 p-3">
-            <svg viewBox="0 0 320 128" className="h-36 w-full" role="img" aria-label="Custom train preview">
-              <rect x="0" y="95" width={previewWidth} height="15" fill={previewPalette.railBed} />
-              <rect x="0" y="93" width={previewWidth} height="3" fill={previewPalette.railTop} />
-              <rect x="0" y="101" width={previewWidth} height="3" fill={previewPalette.railBottom} />
-              {renderPreviewLocomotive(previewTrain, previewLayout.locomotiveStart, previewLayout.scale)}
-              {previewTrain.tender && (
-                <g>
-                  <rect
-                    x={previewLayout.tenderStart}
-                    y={previewBaseY - previewTrain.tender.height * previewLayout.scale}
-                    width={previewTrain.tender.length * previewLayout.scale}
-                    height={previewTrain.tender.height * previewLayout.scale}
-                    fill={previewTrain.tender.color}
-                  />
-                  <rect
-                    x={previewLayout.tenderStart + 8 * previewLayout.scale}
-                    y={previewBaseY - (previewTrain.tender.height + 12) * previewLayout.scale}
-                    width={(previewTrain.tender.length - 16) * previewLayout.scale}
-                    height={12 * previewLayout.scale}
-                    fill={previewPalette.runningBoard}
-                  />
-                </g>
-              )}
-              {previewTrain.rollingStock.map((car, carIndex) => {
-                const x = previewLayout.rollingStockStart + carIndex * (car.length + previewCarGap) * previewLayout.scale;
-                return (
-                  <g key={car.id}>
-                    <rect
-                      x={x}
-                      y={previewBaseY - car.height * previewLayout.scale}
-                      width={car.length * previewLayout.scale}
-                      height={car.height * previewLayout.scale}
-                      fill={car.color}
-                    />
-                    <rect
-                      x={x + 8 * previewLayout.scale}
-                      y={previewBaseY - (car.height - 10) * previewLayout.scale}
-                      width={(car.length - 16) * previewLayout.scale}
-                      height={Math.min(16, car.height * 0.4) * previewLayout.scale}
-                      fill={getCarWindowColor(previewTrain.id)}
-                    />
-                  </g>
-                );
-              })}
-              <text x="12" y="22" fontSize="15" fill="#0f172a" fontWeight="700">
-                {previewTrain.displayName}
-              </text>
-            </svg>
+            <TrainPreviewCanvas train={previewTrain} width={320} height={128} className="h-36 w-full" />
+            <p className="mt-2 text-sm font-bold text-slate-800">{previewTrain.displayName}</p>
           </div>
 
           <div className="grid gap-2 lg:grid-cols-2">

--- a/ui/partner-hub/components/steam-trains/train-preview-canvas.tsx
+++ b/ui/partner-hub/components/steam-trains/train-preview-canvas.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { renderTrainPreviewCard } from "@/lib/steam-trains/visuals";
+import type { TrainDefinition } from "@/lib/steam-trains/types";
+
+type TrainPreviewCanvasProps = {
+  train: TrainDefinition;
+  width: number;
+  height: number;
+  className?: string;
+  animated?: boolean;
+};
+
+export function TrainPreviewCanvas({ train, width, height, className, animated = true }: TrainPreviewCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+    const context = canvas.getContext("2d");
+    if (!context) {
+      return;
+    }
+
+    let frame: number | null = null;
+    let start = performance.now();
+
+    const draw = (timestamp: number) => {
+      const elapsed = (timestamp - start) / 1000;
+      const wheelRotation = elapsed * 1.6;
+      renderTrainPreviewCard(context, train, width, height, wheelRotation);
+      if (animated) {
+        frame = window.requestAnimationFrame(draw);
+      }
+    };
+
+    draw(start);
+    if (animated) {
+      frame = window.requestAnimationFrame(draw);
+    }
+
+    return () => {
+      if (frame !== null) {
+        window.cancelAnimationFrame(frame);
+      }
+    };
+  }, [animated, height, train, width]);
+
+  return <canvas ref={canvasRef} width={width} height={height} className={className} aria-label={train.displayName} role="img" />;
+}

--- a/ui/partner-hub/components/steam-trains/train-selector.tsx
+++ b/ui/partner-hub/components/steam-trains/train-selector.tsx
@@ -1,5 +1,6 @@
-import { getCarWindowColor, getLocomotiveSilhouette, getPreviewPalette, getTrainLayout } from "@/lib/steam-trains/visuals";
 import type { TrainDefinition } from "@/lib/steam-trains/types";
+
+import { TrainPreviewCanvas } from "./train-preview-canvas";
 
 type TrainSelectorProps = {
   selectedTrainId: string;
@@ -8,10 +9,7 @@ type TrainSelectorProps = {
 };
 
 const previewWidth = 220;
-const baseY = 98;
-const previewPadding = 8;
-const carGap = 10;
-const previewPalette = getPreviewPalette();
+const previewHeight = 110;
 
 const getTrainRole = (trainId: string): string => {
   if (trainId.includes("switcher")) return "Switcher";
@@ -21,112 +19,6 @@ const getTrainRole = (trainId: string): string => {
   return "Steam";
 };
 
-const renderLocoPreview = (train: TrainDefinition, locomotiveStart: number, scale: number) => {
-  const loco = train.locomotive;
-  const silhouette = getLocomotiveSilhouette(loco);
-  const pilot = loco.pilot ?? { length: 40, height: 24, color: "#374151", ribCount: 5 };
-
-  return (
-    <g>
-      <rect x="0" y="95" width={previewWidth} height="15" fill={previewPalette.railBed} />
-      <rect x="0" y="93" width={previewWidth} height="3" fill={previewPalette.railTop} />
-      <rect x="0" y="101" width={previewWidth} height="3" fill={previewPalette.railBottom} />
-
-      <polygon
-        points={`${locomotiveStart - pilot.length * scale},${baseY} ${locomotiveStart + 4},${baseY} ${locomotiveStart + 4},${baseY - pilot.height * scale}`}
-        fill={pilot.color}
-      />
-
-      <rect
-        x={locomotiveStart + 10 * scale}
-        y={baseY + silhouette.runningBoardY * scale}
-        width={(silhouette.boilerLength + 50) * scale}
-        height={loco.bodyHeight * 0.34 * scale}
-        fill={previewPalette.runningBoard}
-      />
-
-      <rect
-        x={locomotiveStart + 18 * scale}
-        y={baseY + silhouette.boilerTop * scale}
-        width={silhouette.boilerLength * scale}
-        height={silhouette.boilerHeight * scale}
-        rx={10 * scale}
-        fill={loco.color}
-      />
-
-      <circle
-        cx={locomotiveStart + silhouette.smokeboxCenterX * scale}
-        cy={baseY + (silhouette.boilerTop + silhouette.boilerHeight / 2) * scale}
-        r={silhouette.smokeboxRadius * scale}
-        fill={previewPalette.smokebox}
-      />
-
-      <rect
-        x={locomotiveStart + 22 * scale}
-        y={baseY + (silhouette.boilerTop - 9) * scale}
-        width={silhouette.boilerLength * 0.58 * scale}
-        height={6 * scale}
-        fill={loco.trimColor}
-      />
-
-      {loco.stack && (
-        <>
-          <rect
-            x={locomotiveStart + loco.stack.offsetX * scale}
-            y={baseY + loco.stack.offsetY * scale}
-            width={loco.stack.width * scale}
-            height={loco.stack.height * scale}
-            rx={2 * scale}
-            fill={previewPalette.stack}
-          />
-          <rect
-            x={locomotiveStart + (loco.stack.offsetX - (loco.stack.flareWidth - loco.stack.width) / 2) * scale}
-            y={baseY + (loco.stack.offsetY - loco.stack.flareHeight) * scale}
-            width={loco.stack.flareWidth * scale}
-            height={loco.stack.flareHeight * scale}
-            rx={2 * scale}
-            fill={previewPalette.stack}
-          />
-        </>
-      )}
-
-      {loco.cab && (
-        <polygon
-          points={`${locomotiveStart + loco.cab.offsetX * scale},${baseY - (loco.cab.height - 2) * scale} ${locomotiveStart + (loco.cab.offsetX + loco.cab.width) * scale},${baseY - (loco.cab.height - 2) * scale} ${locomotiveStart + (loco.cab.offsetX + loco.cab.width) * scale},${baseY - 8 * scale} ${locomotiveStart + (loco.cab.offsetX + 10) * scale},${baseY - 8 * scale}`}
-          fill={loco.color}
-        />
-      )}
-
-      {Array.from({ length: loco.wheelSet.count }).map((_, wheelIndex) => (
-        <g key={`${train.id}-wheel-${wheelIndex}`}>
-          <circle
-            cx={locomotiveStart + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing) * scale}
-            cy={baseY}
-            r={loco.wheelSet.radius * scale}
-            fill={previewPalette.wheelFill}
-          />
-          <circle
-            cx={locomotiveStart + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing) * scale}
-            cy={baseY}
-            r={(loco.wheelSet.radius - 4) * scale}
-            fill="none"
-            stroke={previewPalette.wheelRim}
-            strokeWidth={1.6 * scale}
-          />
-          <line
-            x1={locomotiveStart + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing - loco.wheelSet.radius + 4) * scale}
-            y1={baseY}
-            x2={locomotiveStart + (loco.wheelSet.offsetX + wheelIndex * loco.wheelSet.spacing + loco.wheelSet.radius - 4) * scale}
-            y2={baseY}
-            stroke={previewPalette.wheelSpoke}
-            strokeWidth={1.2 * scale}
-          />
-        </g>
-      ))}
-    </g>
-  );
-};
-
 export function TrainSelector({ selectedTrainId, trains, onSelectTrain }: TrainSelectorProps) {
   return (
     <section className="space-y-2" aria-label="Train selection">
@@ -134,7 +26,6 @@ export function TrainSelector({ selectedTrainId, trains, onSelectTrain }: TrainS
       <div className="grid gap-3 md:grid-cols-3">
         {trains.map((train) => {
           const selected = train.id === selectedTrainId;
-          const layout = getTrainLayout(train, previewWidth, previewPadding, 0.65, { locomotiveToTender: 20, carGap });
 
           return (
             <button
@@ -147,42 +38,7 @@ export function TrainSelector({ selectedTrainId, trains, onSelectTrain }: TrainS
               aria-pressed={selected}
             >
               <div className="rounded-xl bg-gradient-to-b from-sky-100 via-sky-50 to-green-100 p-2">
-                <svg viewBox={`0 0 ${previewWidth} 110`} role="img" aria-label={train.displayName} className="h-28 w-full">
-                  {renderLocoPreview(train, layout.locomotiveStart, layout.scale)}
-                  {train.tender && (
-                    <g>
-                      <rect
-                        x={layout.tenderStart}
-                        y={baseY - train.tender.height * layout.scale}
-                        width={train.tender.length * layout.scale}
-                        height={train.tender.height * layout.scale}
-                        fill={train.tender.color}
-                      />
-                      <rect
-                        x={layout.tenderStart + 8 * layout.scale}
-                        y={baseY - (train.tender.height + 12) * layout.scale}
-                        width={(train.tender.length - 16) * layout.scale}
-                        height={12 * layout.scale}
-                        fill="#0f172a"
-                      />
-                    </g>
-                  )}
-                  {train.rollingStock.map((car, carIndex) => {
-                    const x = layout.rollingStockStart + carIndex * (car.length + carGap) * layout.scale;
-                    return (
-                      <g key={car.id}>
-                        <rect x={x} y={baseY - car.height * layout.scale} width={car.length * layout.scale} height={car.height * layout.scale} fill={car.color} />
-                        <rect
-                          x={x + 8 * layout.scale}
-                          y={baseY - (car.height - 10) * layout.scale}
-                          width={(car.length - 16) * layout.scale}
-                          height={Math.min(16, car.height * 0.4) * layout.scale}
-                          fill={getCarWindowColor(train.id)}
-                        />
-                      </g>
-                    );
-                  })}
-                </svg>
+                <TrainPreviewCanvas train={train} width={previewWidth} height={previewHeight} className="h-28 w-full" />
               </div>
               <p className="mt-2 text-lg font-semibold">{train.displayName}</p>
               <p className="text-sm text-muted-foreground">

--- a/ui/partner-hub/lib/steam-trains/renderer.ts
+++ b/ui/partner-hub/lib/steam-trains/renderer.ts
@@ -1,174 +1,120 @@
-import type { AxleWheelDefinition, LevelCheckpoint, SteamParticle, SteamTrainsSimulationState } from "./types";
-import { getLocomotiveSilhouette, getRodCyclePhase } from "./visuals";
-
-const SKY_TOP = "#9fd5ff";
-const SKY_HORIZON = "#dff3ff";
-const GROUND_TOP = "#8fb74d";
-const GROUND_BASE = "#5f7f2d";
+import type { LevelCheckpoint, SteamParticle, SteamTrainsSimulationState } from "./types";
+import { drawPreviewBackdrop, drawSteamParticleRich, drawTrackAndBallast, drawTrainConsist, getPreviewPalette } from "./visuals";
 
 const checkpointToScreenX = (checkpoint: LevelCheckpoint, state: SteamTrainsSimulationState, width: number) =>
-  checkpoint.x - state.train.x + width * 0.4;
-
-const drawBackground = (ctx: CanvasRenderingContext2D, width: number, height: number) => {
-  const skyGradient = ctx.createLinearGradient(0, 0, 0, height * 0.76);
-  skyGradient.addColorStop(0, SKY_TOP);
-  skyGradient.addColorStop(0.7, SKY_HORIZON);
-  skyGradient.addColorStop(1, "#e9f7ff");
-  ctx.fillStyle = skyGradient;
-  ctx.fillRect(0, 0, width, height * 0.76);
-
-  const groundGradient = ctx.createLinearGradient(0, height * 0.68, 0, height);
-  groundGradient.addColorStop(0, GROUND_TOP);
-  groundGradient.addColorStop(1, GROUND_BASE);
-  ctx.fillStyle = groundGradient;
-  ctx.fillRect(0, height * 0.68, width, height * 0.32);
-};
+  checkpoint.x - state.train.x + width * 0.35;
 
 const drawCloudBands = (ctx: CanvasRenderingContext2D, width: number, elapsedMs: number) => {
   const scrollA = (elapsedMs * 0.01) % (width + 340);
   const scrollB = (elapsedMs * 0.018) % (width + 380);
-  ctx.fillStyle = "rgba(255,255,255,0.5)";
+  ctx.fillStyle = "rgba(255,255,255,0.52)";
   for (let i = 0; i < 4; i += 1) {
     const x = width - scrollA + i * 280;
     ctx.beginPath();
-    ctx.ellipse(x, 92 + (i % 2) * 14, 120, 30, 0, 0, Math.PI * 2);
+    ctx.ellipse(x, 86 + (i % 2) * 14, 130, 32, 0, 0, Math.PI * 2);
     ctx.fill();
   }
-  ctx.fillStyle = "rgba(255,255,255,0.33)";
+  ctx.fillStyle = "rgba(255,255,255,0.34)";
   for (let i = 0; i < 3; i += 1) {
     const x = width - scrollB + i * 340;
     ctx.beginPath();
-    ctx.ellipse(x, 132 + (i % 2) * 12, 140, 34, 0, 0, Math.PI * 2);
+    ctx.ellipse(x, 128 + (i % 2) * 12, 146, 36, 0, 0, Math.PI * 2);
     ctx.fill();
   }
 };
 
 const drawSceneDecor = (ctx: CanvasRenderingContext2D, state: SteamTrainsSimulationState, width: number) => {
-  const railY = state.train.y + 52;
-  const horizonY = state.train.y - 128;
+  const railY = state.train.y + 56;
+  const horizonY = state.train.y - 136;
 
-  ctx.fillStyle = "rgba(51, 85, 36, 0.48)";
+  ctx.fillStyle = "rgba(57, 92, 40, 0.44)";
   for (let i = 0; i < 7; i += 1) {
     ctx.beginPath();
     ctx.moveTo(i * 170, horizonY + 70);
-    ctx.quadraticCurveTo(i * 170 + 80, horizonY + 20, i * 170 + 160, horizonY + 70);
-    ctx.lineTo(i * 170 + 160, railY + 140);
-    ctx.lineTo(i * 170, railY + 140);
+    ctx.quadraticCurveTo(i * 170 + 80, horizonY + 16, i * 170 + 160, horizonY + 70);
+    ctx.lineTo(i * 170 + 160, railY + 144);
+    ctx.lineTo(i * 170, railY + 144);
     ctx.closePath();
     ctx.fill();
   }
 
   if (state.level.scene === "yard") {
     ctx.fillStyle = "#7f8b98";
-    ctx.fillRect(width * 0.06, railY - 130, 190, 86);
+    ctx.fillRect(width * 0.05, railY - 140, 220, 94);
     ctx.fillStyle = "#5f6d7d";
-    ctx.fillRect(width * 0.05, railY - 140, 208, 14);
+    ctx.fillRect(width * 0.04, railY - 154, 238, 16);
     ctx.fillStyle = "#475569";
-    for (let i = 0; i < 4; i += 1) {
-      ctx.fillRect(width * 0.08 + i * 40, railY - 112, 24, 34);
+    for (let i = 0; i < 5; i += 1) {
+      ctx.fillRect(width * 0.07 + i * 42, railY - 120, 25, 38);
+    }
+    ctx.fillStyle = "#374151";
+    ctx.fillRect(width * 0.36, railY - 44, 180, 8);
+    for (let i = 0; i < 3; i += 1) {
+      ctx.fillRect(width * 0.37 + i * 56, railY - 72, 8, 28);
     }
   }
 
   if (state.level.scene === "station") {
-    ctx.fillStyle = "#f1f5f9";
-    ctx.fillRect(width * 0.52, railY - 150, 300, 100);
+    ctx.fillStyle = "#f2f6fc";
+    ctx.fillRect(width * 0.5, railY - 164, 330, 112);
     ctx.fillStyle = "#64748b";
-    ctx.fillRect(width * 0.5, railY - 165, 340, 18);
+    ctx.fillRect(width * 0.47, railY - 180, 380, 20);
     ctx.fillStyle = "#334155";
-    for (let i = 0; i < 5; i += 1) {
-      ctx.fillRect(width * 0.54 + i * 52, railY - 130, 24, 34);
+    for (let i = 0; i < 6; i += 1) {
+      ctx.fillRect(width * 0.52 + i * 52, railY - 142, 24, 40);
     }
-    ctx.fillStyle = "#dbeafe";
-    ctx.fillRect(width * 0.54, railY - 86, 286, 18);
+    ctx.fillStyle = "#d8e8ff";
+    ctx.fillRect(width * 0.52, railY - 96, 310, 22);
+    ctx.fillStyle = "#a7b4c5";
+    ctx.fillRect(width * 0.44, railY - 6, 420, 10);
   }
 
   if (state.level.scene === "bridge") {
     ctx.fillStyle = "#334155";
-    ctx.fillRect(width * 0.08, railY + 8, width * 0.84, 24);
+    ctx.fillRect(width * 0.06, railY + 8, width * 0.88, 26);
     ctx.fillStyle = "#475569";
-    for (let i = 0; i < 9; i += 1) {
-      const x = width * 0.11 + i * (width * 0.08);
-      ctx.fillRect(x, railY + 32, 12, 62);
+    for (let i = 0; i < 10; i += 1) {
+      const x = width * 0.1 + i * (width * 0.078);
+      ctx.fillRect(x, railY + 34, 12, 72);
       ctx.beginPath();
-      ctx.moveTo(x + 6, railY + 32);
-      ctx.lineTo(x + 48, railY + 96);
-      ctx.lineTo(x + 40, railY + 96);
-      ctx.lineTo(x, railY + 38);
+      ctx.moveTo(x + 6, railY + 34);
+      ctx.lineTo(x + 52, railY + 106);
+      ctx.lineTo(x + 44, railY + 106);
+      ctx.lineTo(x, railY + 40);
       ctx.closePath();
       ctx.fill();
     }
     ctx.fillStyle = "#3b82f6";
-    ctx.fillRect(0, railY + 102, width, 130);
+    ctx.fillRect(0, railY + 112, width, 130);
   }
 
   if (state.level.scene === "tunnel") {
     ctx.fillStyle = "#4b5563";
     ctx.beginPath();
-    ctx.arc(width * 0.72, railY - 24, 136, Math.PI, Math.PI * 2);
+    ctx.arc(width * 0.73, railY - 22, 144, Math.PI, Math.PI * 2);
     ctx.fill();
-    ctx.fillRect(width * 0.72 - 136, railY - 24, 272, 120);
+    ctx.fillRect(width * 0.73 - 144, railY - 22, 288, 126);
     ctx.fillStyle = "#111827";
     ctx.beginPath();
-    ctx.arc(width * 0.72, railY - 24, 102, Math.PI, Math.PI * 2);
+    ctx.arc(width * 0.73, railY - 22, 110, Math.PI, Math.PI * 2);
     ctx.fill();
-    ctx.fillRect(width * 0.72 - 102, railY - 24, 204, 102);
+    ctx.fillRect(width * 0.73 - 110, railY - 22, 220, 106);
   }
 };
 
 const drawTrack = (ctx: CanvasRenderingContext2D, state: SteamTrainsSimulationState, width: number) => {
-  const railY = state.train.y + 52;
-
-  ctx.fillStyle = "#7c6450";
-  ctx.fillRect(0, railY - 2, width, 38);
-  ctx.fillStyle = "#8e7961";
-  for (let x = -40; x < width + 50; x += 14) {
-    ctx.fillRect(x, railY + 22, 8, 4);
-  }
-
-  const tieSpacing = 28;
-  for (let x = -20; x < width + 34; x += tieSpacing) {
-    ctx.fillStyle = "#5b3f2a";
-    ctx.fillRect(x, railY + 1, 22, 18);
-    ctx.fillStyle = "#3f2d1e";
-    ctx.fillRect(x + 1, railY + 13, 20, 3);
-  }
-
-  const railGradient = ctx.createLinearGradient(0, railY - 4, 0, railY + 18);
-  railGradient.addColorStop(0, "#eef2f7");
-  railGradient.addColorStop(0.6, "#9ca3af");
-  railGradient.addColorStop(1, "#4b5563");
-  ctx.fillStyle = railGradient;
-  ctx.fillRect(0, railY - 4, width, 7);
-  ctx.fillRect(0, railY + 13, width, 7);
+  const palette = getPreviewPalette();
+  const railY = state.train.y + 56;
+  drawTrackAndBallast(ctx, width, railY, palette);
 
   state.level.checkpoints.forEach((checkpoint, index) => {
     const switchX = checkpointToScreenX(checkpoint, state, width);
     const chosen = state.checkpointDecisions[index] ?? state.switchState;
-    const targetY = chosen === "main" ? railY + 2 : railY + 56;
-
-    ctx.strokeStyle = "#6b7280";
-    ctx.lineWidth = 8;
-    ctx.beginPath();
-    ctx.moveTo(switchX - 8, railY + 2);
-    ctx.lineTo(switchX + state.level.forkLength, targetY);
-    ctx.stroke();
-
-    ctx.strokeStyle = "#d1d5db";
-    ctx.lineWidth = 3;
-    ctx.beginPath();
-    ctx.moveTo(switchX - 8, railY + 2);
-    ctx.lineTo(switchX + state.level.forkLength, targetY - 2);
-    ctx.stroke();
-
-    ctx.fillStyle = "#374151";
-    ctx.fillRect(switchX - 6, railY - 26, 6, 22);
-    ctx.fillStyle = chosen === checkpoint.safeBranch ? "#22c55e" : "#f97316";
-    ctx.beginPath();
-    ctx.moveTo(switchX, railY - 24);
-    ctx.lineTo(switchX + 18, railY - 18);
-    ctx.lineTo(switchX, railY - 12);
-    ctx.closePath();
-    ctx.fill();
+    drawTrackAndBallast(ctx, 0, railY, palette, {
+      includeSwitchStand: true,
+      switchX,
+      switchToSiding: chosen !== "main",
+    });
   });
 };
 
@@ -178,7 +124,7 @@ const drawHelperGlow = (ctx: CanvasRenderingContext2D, state: SteamTrainsSimulat
     return;
   }
 
-  const railY = state.train.y + 52;
+  const railY = state.train.y + 56;
   const x = checkpointToScreenX(checkpoint, state, width);
   const y = checkpoint.safeBranch === "main" ? railY - 26 : railY + 36;
 
@@ -190,357 +136,22 @@ const drawHelperGlow = (ctx: CanvasRenderingContext2D, state: SteamTrainsSimulat
 
 const drawSteam = (ctx: CanvasRenderingContext2D, state: SteamTrainsSimulationState, cameraX: number) => {
   const sorted = [...state.particles].sort((a, b) => a.radius - b.radius);
-  sorted.forEach((particle) => {
-    drawSteamParticle(ctx, particle, cameraX);
-  });
+  sorted.forEach((particle) => drawSteamParticle(ctx, particle, cameraX));
 };
 
 const drawSteamParticle = (ctx: CanvasRenderingContext2D, particle: SteamParticle, cameraX: number) => {
-  const px = particle.x - cameraX;
-  const baseAlpha = Math.max(0.05, particle.alpha);
-
-  const body = ctx.createRadialGradient(px - particle.radius * 0.2, particle.y - particle.radius * 0.2, 1, px, particle.y, particle.radius * 1.2);
-  body.addColorStop(0, `rgba(255,255,255,${baseAlpha})`);
-  body.addColorStop(0.65, `rgba(226,232,240,${baseAlpha * 0.74})`);
-  body.addColorStop(1, `rgba(203,213,225,${baseAlpha * 0.12})`);
-  ctx.fillStyle = body;
-  ctx.beginPath();
-  ctx.arc(px, particle.y, particle.radius * 1.15, 0, Math.PI * 2);
-  ctx.fill();
-};
-
-const drawAuxWheelSet = (
-  ctx: CanvasRenderingContext2D,
-  originX: number,
-  originY: number,
-  wheelDef: AxleWheelDefinition,
-  rotation: number,
-) => {
-  for (let index = 0; index < wheelDef.count; index += 1) {
-    const x = originX + wheelDef.offsetX + index * wheelDef.spacing;
-    const y = originY - 1 + (wheelDef.yOffset ?? 0);
-
-    ctx.fillStyle = "#0f172a";
-    ctx.beginPath();
-    ctx.arc(x, y, wheelDef.radius, 0, Math.PI * 2);
-    ctx.fill();
-
-    ctx.strokeStyle = "#e2e8f0";
-    ctx.lineWidth = 2;
-    ctx.beginPath();
-    ctx.arc(x, y, wheelDef.radius - 2, 0, Math.PI * 2);
-    ctx.stroke();
-
-    const angle = rotation + index * (Math.PI / 2);
-    ctx.strokeStyle = "#a8b0bf";
-    ctx.lineWidth = 2;
-    ctx.beginPath();
-    ctx.moveTo(x - Math.cos(angle) * (wheelDef.radius - 4), y - Math.sin(angle) * (wheelDef.radius - 4));
-    ctx.lineTo(x + Math.cos(angle) * (wheelDef.radius - 4), y + Math.sin(angle) * (wheelDef.radius - 4));
-    ctx.stroke();
-  }
-};
-
-const drawCarCoupler = (ctx: CanvasRenderingContext2D, leftX: number, rightX: number, baseY: number) => {
-  ctx.strokeStyle = "#1f2937";
-  ctx.lineWidth = 4;
-  ctx.lineCap = "round";
-  ctx.beginPath();
-  ctx.moveTo(leftX, baseY - 8);
-  ctx.lineTo((leftX + rightX) / 2, baseY - 5);
-  ctx.lineTo(rightX, baseY - 8);
-  ctx.stroke();
-  ctx.lineCap = "butt";
+  drawSteamParticleRich(ctx, particle, cameraX);
 };
 
 const drawLocomotive = (ctx: CanvasRenderingContext2D, state: SteamTrainsSimulationState, cameraX: number) => {
-  const loco = state.train.definition.locomotive;
+  const palette = getPreviewPalette();
   const originX = state.train.x - cameraX;
-  const originY = state.train.y;
-  const silhouette = getLocomotiveSilhouette(loco);
-
-  const pilot = loco.pilot ?? { length: 44, height: 28, color: "#374151", ribCount: 5 };
-  ctx.fillStyle = pilot.color;
-  ctx.beginPath();
-  ctx.moveTo(originX - pilot.length, originY - 1);
-  ctx.lineTo(originX + 6, originY + 2);
-  ctx.lineTo(originX + 6, originY - pilot.height);
-  ctx.closePath();
-  ctx.fill();
-
-  ctx.strokeStyle = "#111827";
-  ctx.lineWidth = 2;
-  for (let rib = 0; rib < pilot.ribCount; rib += 1) {
-    const progress = rib / Math.max(1, pilot.ribCount - 1);
-    const ribX = originX - pilot.length + progress * pilot.length;
-    ctx.beginPath();
-    ctx.moveTo(ribX, originY - 1);
-    ctx.lineTo(ribX + 10, originY - pilot.height + 4);
-    ctx.stroke();
-  }
-
-  const chassisGradient = ctx.createLinearGradient(originX, originY + 2, originX, originY - loco.bodyHeight);
-  chassisGradient.addColorStop(0, "#0f172a");
-  chassisGradient.addColorStop(0.45, loco.color);
-  chassisGradient.addColorStop(1, "#374151");
-
-  ctx.fillStyle = chassisGradient;
-  ctx.fillRect(originX + 10, originY + 1 + silhouette.runningBoardY, silhouette.boilerLength + 58, loco.bodyHeight * 0.36);
-
-  ctx.fillStyle = loco.color;
-  ctx.beginPath();
-  ctx.roundRect(originX + 18, originY + silhouette.boilerTop, silhouette.boilerLength, silhouette.boilerHeight, 18);
-  ctx.fill();
-
-  const smokeboxX = originX + silhouette.smokeboxCenterX;
-  const smokeboxY = originY + silhouette.boilerTop + silhouette.boilerHeight / 2;
-  const smokeboxFace = ctx.createRadialGradient(smokeboxX - 4, smokeboxY - 2, 2, smokeboxX, smokeboxY, silhouette.smokeboxRadius);
-  smokeboxFace.addColorStop(0, "#4b5563");
-  smokeboxFace.addColorStop(1, "#111827");
-  ctx.fillStyle = smokeboxFace;
-  ctx.beginPath();
-  ctx.arc(smokeboxX, smokeboxY, silhouette.smokeboxRadius, 0, Math.PI * 2);
-  ctx.fill();
-
-  ctx.strokeStyle = "#94a3b8";
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  ctx.arc(smokeboxX, smokeboxY, silhouette.smokeboxRadius - 3, 0, Math.PI * 2);
-  ctx.stroke();
-
-  ctx.fillStyle = loco.trimColor;
-  ctx.fillRect(originX + 24, originY + silhouette.boilerTop - 10, silhouette.boilerLength * 0.62, 7);
-
-  const stack = loco.stack ?? { width: 20, height: 36, flareWidth: 32, flareHeight: 10, offsetX: 68, offsetY: -102 };
-  const stackX = originX + stack.offsetX;
-  const stackY = originY + stack.offsetY;
-  const stackGradient = ctx.createLinearGradient(stackX, stackY, stackX, stackY + stack.height + stack.flareHeight);
-  stackGradient.addColorStop(0, "#0b1222");
-  stackGradient.addColorStop(1, "#475569");
-  ctx.fillStyle = stackGradient;
-  ctx.beginPath();
-  ctx.roundRect(stackX, stackY, stack.width, stack.height, 4);
-  ctx.fill();
-  ctx.beginPath();
-  ctx.roundRect(stackX - (stack.flareWidth - stack.width) / 2, stackY - stack.flareHeight, stack.flareWidth, stack.flareHeight + 2, 5);
-  ctx.fill();
-
-  const cab = loco.cab ?? {
-    width: 82,
-    height: 62,
-    roofOverhang: 12,
-    roofHeight: 12,
-    offsetX: loco.bodyLength - 94,
-    windowWidth: 18,
-    windowHeight: 16,
-  };
-
-  const cabX = originX + cab.offsetX;
-  const cabY = originY - cab.height - 10;
-  ctx.fillStyle = loco.color;
-  ctx.beginPath();
-  ctx.moveTo(cabX, cabY + cab.height);
-  ctx.lineTo(cabX + cab.width, cabY + cab.height);
-  ctx.lineTo(cabX + cab.width, cabY + 10);
-  ctx.lineTo(cabX + cab.width - 18, cabY);
-  ctx.lineTo(cabX + 16, cabY);
-  ctx.lineTo(cabX, cabY + 10);
-  ctx.closePath();
-  ctx.fill();
-
-  ctx.fillStyle = "#0f172a";
-  ctx.fillRect(cabX - cab.roofOverhang, cabY - cab.roofHeight, cab.width + cab.roofOverhang * 2, cab.roofHeight);
-  ctx.fillStyle = "#cfe9ff";
-  ctx.fillRect(cabX + 12, cabY + 14, cab.windowWidth, cab.windowHeight);
-  ctx.fillRect(cabX + 40, cabY + 14, cab.windowWidth, cab.windowHeight);
-
-  const lamp = loco.headlamp ?? {
-    radius: 10,
-    offsetX: 6,
-    offsetY: -58,
-    rimColor: "#f59e0b",
-    glowColor: "rgba(255, 244, 180, 0.6)",
-  };
-
-  const lampX = originX + lamp.offsetX;
-  const lampY = originY + lamp.offsetY;
-  ctx.fillStyle = lamp.glowColor;
-  ctx.beginPath();
-  ctx.ellipse(lampX - 22, lampY, lamp.radius * 2.6, lamp.radius * 1.6, 0, 0, Math.PI * 2);
-  ctx.fill();
-  ctx.fillStyle = lamp.rimColor;
-  ctx.beginPath();
-  ctx.arc(lampX, lampY, lamp.radius + 1, 0, Math.PI * 2);
-  ctx.fill();
-  ctx.fillStyle = "#fef3c7";
-  ctx.beginPath();
-  ctx.arc(lampX, lampY, lamp.radius * 0.55, 0, Math.PI * 2);
-  ctx.fill();
-
-  if (loco.pilotWheels) {
-    drawAuxWheelSet(ctx, originX, originY, loco.pilotWheels, state.train.wheelRotationRad * 0.82);
-  }
-
-  const wheelSet = loco.wheelSet;
-  const wheelCenters = Array.from({ length: wheelSet.count }).map((_, index) => {
-    const x = originX + wheelSet.offsetX + index * wheelSet.spacing;
-    const y = originY - 1;
-
-    const wheelGradient = ctx.createRadialGradient(x - 5, y - 5, 2, x, y, wheelSet.radius);
-    wheelGradient.addColorStop(0, "#d7dde6");
-    wheelGradient.addColorStop(0.22, "#a9b3c3");
-    wheelGradient.addColorStop(1, "#111827");
-    ctx.fillStyle = wheelGradient;
-    ctx.beginPath();
-    ctx.arc(x, y, wheelSet.radius, 0, Math.PI * 2);
-    ctx.fill();
-
-    ctx.strokeStyle = "#f8fafc";
-    ctx.lineWidth = 2;
-    ctx.beginPath();
-    ctx.arc(x, y, wheelSet.radius - 3, 0, Math.PI * 2);
-    ctx.stroke();
-
-    const spokeCount = 9;
-    ctx.strokeStyle = "#c7d2e0";
-    ctx.lineWidth = 2;
-    for (let spoke = 0; spoke < spokeCount; spoke += 1) {
-      const angle = state.train.wheelRotationRad + (Math.PI * 2 * spoke) / spokeCount;
-      ctx.beginPath();
-      ctx.moveTo(x, y);
-      ctx.lineTo(x + Math.cos(angle) * (wheelSet.radius - 4), y + Math.sin(angle) * (wheelSet.radius - 4));
-      ctx.stroke();
-    }
-
-    return { x, y };
-  });
-
-  if (loco.trailingWheels) {
-    drawAuxWheelSet(ctx, originX, originY, loco.trailingWheels, state.train.wheelRotationRad * 0.74);
-  }
-
-  const rod = loco.drivingRod;
-  const phase = getRodCyclePhase(state.train.wheelRotationRad);
-  const crankWheel = wheelCenters[Math.min(wheelCenters.length - 1, Math.max(0, rod.wheelIndex))];
-  const leadWheel = wheelCenters[0];
-  const trailingWheel = wheelCenters[wheelCenters.length - 1];
-
-  const leftCrankX = crankWheel.x + Math.cos(phase) * rod.crankRadius;
-  const leftCrankY = crankWheel.y + Math.sin(phase) * rod.crankRadius;
-  const rightCrankX = leadWheel.x + Math.cos(phase + 0.18) * (rod.crankRadius * 0.92);
-  const rightCrankY = leadWheel.y + Math.sin(phase + 0.18) * (rod.crankRadius * 0.92);
-
-  const pistonX = leadWheel.x - rod.rodLength * 0.45;
-  const pistonY = crankWheel.y + rod.anchorOffsetY;
-  ctx.fillStyle = "#475569";
-  ctx.fillRect(pistonX - 24, pistonY - 8, 24, 16);
-
-  ctx.strokeStyle = "#facc15";
-  ctx.lineWidth = rod.thickness;
-  ctx.lineCap = "round";
-  ctx.beginPath();
-  ctx.moveTo(pistonX, pistonY);
-  ctx.lineTo(leftCrankX, leftCrankY);
-  ctx.lineTo(trailingWheel.x + 10, trailingWheel.y - 2);
-  ctx.stroke();
-
-  ctx.strokeStyle = "#d4af37";
-  ctx.lineWidth = Math.max(3, rod.thickness - 2);
-  ctx.beginPath();
-  ctx.moveTo(rightCrankX, rightCrankY);
-  ctx.lineTo(leftCrankX, leftCrankY);
-  ctx.lineTo(leadWheel.x + 10, leadWheel.y - 2);
-  ctx.stroke();
-
-  ctx.fillStyle = "#f8d14b";
-  [
-    [leftCrankX, leftCrankY],
-    [rightCrankX, rightCrankY],
-    [pistonX, pistonY],
-  ].forEach(([x, y]) => {
-    ctx.beginPath();
-    ctx.arc(x, y, 5, 0, Math.PI * 2);
-    ctx.fill();
-  });
-
-  let rollingX = originX + loco.bodyLength + 20;
-  let previousCouplerX = originX + loco.bodyLength + 5;
-
-  if (state.train.definition.tender) {
-    const tender = state.train.definition.tender;
-    const tenderX = rollingX;
-    const tenderY = originY - tender.height;
-
-    const tenderGradient = ctx.createLinearGradient(tenderX, tenderY, tenderX, originY);
-    tenderGradient.addColorStop(0, tender.color);
-    tenderGradient.addColorStop(1, "#0f172a");
-    ctx.fillStyle = tenderGradient;
-    ctx.fillRect(tenderX, tenderY, tender.length, tender.height);
-    ctx.fillStyle = "#111827";
-    ctx.fillRect(tenderX + 8, tenderY - 14, tender.length - 16, 14);
-    ctx.fillStyle = "#64748b";
-    ctx.fillRect(tenderX + 16, tenderY + 10, tender.length - 32, 8);
-
-    [36, tender.length - 44].forEach((offset) => {
-      const x = tenderX + offset;
-      const y = originY - 2;
-      ctx.fillStyle = "#111827";
-      ctx.beginPath();
-      ctx.arc(x, y, 18, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.strokeStyle = "#d1d5db";
-      ctx.lineWidth = 2;
-      ctx.beginPath();
-      ctx.arc(x, y, 14, 0, Math.PI * 2);
-      ctx.stroke();
-    });
-
-    drawCarCoupler(ctx, previousCouplerX, tenderX + 2, originY);
-    previousCouplerX = tenderX + tender.length - 2;
-    rollingX += tender.length + 18;
-  }
-
-  state.train.definition.rollingStock.forEach((car, carIndex) => {
-    const carX = rollingX;
-    const carY = originY - car.height;
-
-    const carGradient = ctx.createLinearGradient(carX, carY, carX, originY);
-    carGradient.addColorStop(0, car.color);
-    carGradient.addColorStop(1, "#1f2937");
-    ctx.fillStyle = carGradient;
-    ctx.fillRect(carX, carY, car.length, car.height);
-
-    if (state.train.definition.id.includes("passenger")) {
-      ctx.fillStyle = "#fef3c7";
-      const windowCount = Math.max(4, Math.floor(car.length / 28));
-      for (let windowIndex = 0; windowIndex < windowCount; windowIndex += 1) {
-        const wx = carX + 10 + windowIndex * ((car.length - 20) / windowCount);
-        ctx.fillRect(wx, carY + 10, 11, 11);
-      }
-    } else {
-      ctx.fillStyle = "#334155";
-      ctx.fillRect(carX + 10, carY + 10, car.length - 20, Math.min(20, car.height * 0.46));
-      for (let rib = 0; rib < 4; rib += 1) {
-        ctx.fillStyle = "rgba(226,232,240,0.22)";
-        ctx.fillRect(carX + 14 + rib * ((car.length - 36) / 4), carY + 10, 4, car.height - 18);
-      }
-    }
-
-    [24, car.length - 26].forEach((offset) => {
-      ctx.fillStyle = "#111827";
-      ctx.beginPath();
-      ctx.arc(carX + offset, originY - 2, 14, 0, Math.PI * 2);
-      ctx.fill();
-    });
-
-    drawCarCoupler(ctx, previousCouplerX, carX + 2, originY);
-    previousCouplerX = carX + car.length - 2;
-    rollingX += car.length + 16;
-
-    if (carIndex === state.train.definition.rollingStock.length - 1) {
-      ctx.fillStyle = "#7f1d1d";
-      ctx.fillRect(previousCouplerX + 4, originY - 18, 5, 10);
-    }
+  const originY = state.train.y + 4;
+  drawTrainConsist(ctx, state.train.definition, {
+    baseX: originX,
+    baseY: originY,
+    wheelRotationRad: state.train.wheelRotationRad,
+    palette,
   });
 };
 
@@ -563,11 +174,11 @@ type RenderOptions = {
 export const renderScene = (ctx: CanvasRenderingContext2D, state: SteamTrainsSimulationState, options: RenderOptions = {}) => {
   const width = ctx.canvas.width;
   const height = ctx.canvas.height;
-  const cameraX = state.train.x - width * 0.4;
+  const cameraX = state.train.x - width * 0.35;
 
   ctx.clearRect(0, 0, width, height);
 
-  drawBackground(ctx, width, height);
+  drawPreviewBackdrop(ctx, width, height, getPreviewPalette());
   drawCloudBands(ctx, width, state.elapsedMs);
   drawSceneDecor(ctx, state, width);
   drawTrack(ctx, state, width);

--- a/ui/partner-hub/lib/steam-trains/visuals.test.ts
+++ b/ui/partner-hub/lib/steam-trains/visuals.test.ts
@@ -2,7 +2,14 @@ import * as assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { STEAM_TRAIN_CATALOG } from "./trainCatalog";
-import { countChuffPulses, getCarWindowColor, getLocomotiveSilhouette, getPreviewPalette, getTrainLayout } from "./visuals";
+import {
+  countChuffPulses,
+  getCarWindowColor,
+  getLocomotiveSilhouette,
+  getPreviewPalette,
+  getTrainConsistLength,
+  getTrainLayout,
+} from "./visuals";
 
 describe("steam train visual helpers", () => {
   it("builds positive layouts for every stock train", () => {
@@ -12,6 +19,14 @@ describe("steam train visual helpers", () => {
       assert.equal(layout.scale > 0, true, `${train.id}: scale`);
       assert.equal(layout.tenderStart > layout.locomotiveStart, true, `${train.id}: tender start`);
       assert.equal(layout.rollingStockStart >= layout.tenderStart, true, `${train.id}: rolling stock start`);
+    });
+  });
+
+  it("keeps consist lengths stable and positive", () => {
+    STEAM_TRAIN_CATALOG.forEach((train) => {
+      const length = getTrainConsistLength(train);
+      assert.equal(length > 100, true, `${train.id}: minimum length`);
+      assert.equal(length >= train.locomotive.bodyLength, true, `${train.id}: locomotive not clipped`);
     });
   });
 
@@ -35,6 +50,8 @@ describe("steam train visual helpers", () => {
     assert.equal(typeof palette.railBed, "string");
     assert.equal(typeof palette.wheelFill, "string");
     assert.equal(typeof palette.runningBoard, "string");
+    assert.equal(typeof palette.skyTop, "string");
+    assert.equal(typeof palette.brass, "string");
   });
 
   it("maps window color by train role", () => {

--- a/ui/partner-hub/lib/steam-trains/visuals.ts
+++ b/ui/partner-hub/lib/steam-trains/visuals.ts
@@ -1,4 +1,4 @@
-import type { LocomotiveDefinition, TrainDefinition } from "./types";
+import type { AxleWheelDefinition, LocomotiveDefinition, SteamParticle, TrainDefinition } from "./types";
 
 export const LOCOMOTIVE_TO_TENDER_GAP = 20;
 export const CAR_GAP = 10;
@@ -22,27 +22,63 @@ export type LocomotiveSilhouette = {
 };
 
 export type TrainPreviewPalette = {
+  skyTop: string;
+  skyHorizon: string;
+  groundTop: string;
+  groundBottom: string;
   railBed: string;
+  ballastLight: string;
+  ballastDark: string;
   railTop: string;
   railBottom: string;
+  tieTop: string;
+  tieShadow: string;
   wheelFill: string;
   wheelRim: string;
   wheelSpoke: string;
   runningBoard: string;
   stack: string;
   smokebox: string;
+  brass: string;
+  metalDark: string;
 };
 
 const DEFAULT_PREVIEW_PALETTE: TrainPreviewPalette = {
-  railBed: "#7c6450",
-  railTop: "#d1d5db",
-  railBottom: "#9ca3af",
+  skyTop: "#9ed3fa",
+  skyHorizon: "#edf7ff",
+  groundTop: "#8fae57",
+  groundBottom: "#5f7431",
+  railBed: "#7f6449",
+  ballastLight: "#a98a6c",
+  ballastDark: "#6e533b",
+  railTop: "#f1f5f9",
+  railBottom: "#7f8b97",
+  tieTop: "#5d4029",
+  tieShadow: "#3c2a1b",
   wheelFill: "#0f172a",
-  wheelRim: "#cbd5e1",
-  wheelSpoke: "#94a3b8",
+  wheelRim: "#d0d8e4",
+  wheelSpoke: "#a1aebe",
   runningBoard: "#0f172a",
-  stack: "#0f172a",
-  smokebox: "#111827",
+  stack: "#172033",
+  smokebox: "#1a212d",
+  brass: "#d8ad3f",
+  metalDark: "#273241",
+};
+
+export type TrackRenderOptions = {
+  includeSwitchStand?: boolean;
+  switchX?: number;
+  switchToSiding?: boolean;
+};
+
+export type TrainArtRenderOptions = {
+  baseX: number;
+  baseY: number;
+  scale?: number;
+  wheelRotationRad?: number;
+  palette?: TrainPreviewPalette;
+  railTopY?: number;
+  smokeIntensity?: number;
 };
 
 export const getTrainConsistLength = (train: TrainDefinition, gaps = { locomotiveToTender: LOCOMOTIVE_TO_TENDER_GAP, carGap: CAR_GAP }) => {
@@ -88,11 +124,11 @@ export const getTrainLayout = (
 };
 
 export const getLocomotiveSilhouette = (locomotive: LocomotiveDefinition): LocomotiveSilhouette => {
-  const boilerHeight = locomotive.bodyHeight * 0.58;
-  const boilerTop = -locomotive.bodyHeight + 14;
-  const boilerLength = locomotive.bodyLength * 0.74;
+  const boilerHeight = locomotive.bodyHeight * 0.62;
+  const boilerTop = -locomotive.bodyHeight + 10;
+  const boilerLength = locomotive.bodyLength * 0.76;
   const runningBoardY = -locomotive.bodyHeight * 0.34;
-  const cabRoofY = -(locomotive.cab?.height ?? locomotive.bodyHeight * 0.75) - 16;
+  const cabRoofY = -(locomotive.cab?.height ?? locomotive.bodyHeight * 0.78) - 18;
 
   return {
     boilerTop,
@@ -100,8 +136,8 @@ export const getLocomotiveSilhouette = (locomotive: LocomotiveDefinition): Locom
     boilerLength,
     runningBoardY,
     cabRoofY,
-    smokeboxRadius: boilerHeight * 0.48,
-    smokeboxCenterX: boilerLength - boilerHeight * 0.18,
+    smokeboxRadius: boilerHeight * 0.49,
+    smokeboxCenterX: boilerLength - boilerHeight * 0.12,
   };
 };
 
@@ -112,4 +148,493 @@ export const countChuffPulses = (previousWheelRotation: number, nextWheelRotatio
   const previousIndex = Math.floor(previousWheelRotation / segment);
   const nextIndex = Math.floor(nextWheelRotation / segment);
   return Math.max(0, nextIndex - previousIndex);
+};
+
+const drawWheel = (
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radius: number,
+  rotation: number,
+  palette: TrainPreviewPalette,
+  spokeCount = 8,
+) => {
+  const wheelGradient = ctx.createRadialGradient(x - radius * 0.28, y - radius * 0.28, 1, x, y, radius);
+  wheelGradient.addColorStop(0, "#dce3ee");
+  wheelGradient.addColorStop(0.3, "#a4afc0");
+  wheelGradient.addColorStop(1, palette.wheelFill);
+  ctx.fillStyle = wheelGradient;
+  ctx.beginPath();
+  ctx.arc(x, y, radius, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.strokeStyle = palette.wheelRim;
+  ctx.lineWidth = Math.max(1.2, radius * 0.11);
+  ctx.beginPath();
+  ctx.arc(x, y, radius - 2, 0, Math.PI * 2);
+  ctx.stroke();
+
+  ctx.strokeStyle = palette.wheelSpoke;
+  ctx.lineWidth = Math.max(1, radius * 0.09);
+  for (let spoke = 0; spoke < spokeCount; spoke += 1) {
+    const angle = rotation + (Math.PI * 2 * spoke) / spokeCount;
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+    ctx.lineTo(x + Math.cos(angle) * (radius - 4), y + Math.sin(angle) * (radius - 4));
+    ctx.stroke();
+  }
+};
+
+const drawAuxWheelSet = (
+  ctx: CanvasRenderingContext2D,
+  originX: number,
+  originY: number,
+  wheelDef: AxleWheelDefinition,
+  rotation: number,
+  palette: TrainPreviewPalette,
+) => {
+  for (let index = 0; index < wheelDef.count; index += 1) {
+    const x = originX + wheelDef.offsetX + index * wheelDef.spacing;
+    const y = originY - 1 + (wheelDef.yOffset ?? 0);
+    drawWheel(ctx, x, y, wheelDef.radius, rotation + index * 0.3, palette, 6);
+  }
+};
+
+const drawCoupler = (ctx: CanvasRenderingContext2D, leftX: number, rightX: number, baseY: number) => {
+  ctx.strokeStyle = "#212937";
+  ctx.lineWidth = 4;
+  ctx.lineCap = "round";
+  ctx.beginPath();
+  ctx.moveTo(leftX, baseY - 8);
+  ctx.lineTo((leftX + rightX) / 2, baseY - 4);
+  ctx.lineTo(rightX, baseY - 8);
+  ctx.stroke();
+  ctx.lineCap = "butt";
+};
+
+export const drawTrackAndBallast = (
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  railY: number,
+  palette: TrainPreviewPalette = DEFAULT_PREVIEW_PALETTE,
+  options: TrackRenderOptions = {},
+) => {
+  ctx.fillStyle = palette.railBed;
+  ctx.fillRect(0, railY - 4, width, 42);
+  ctx.fillStyle = palette.ballastLight;
+  for (let x = -18; x < width + 30; x += 12) {
+    ctx.fillRect(x, railY + 18 + (x % 3), 7, 4);
+  }
+
+  const tieSpacing = 26;
+  for (let x = -20; x < width + 36; x += tieSpacing) {
+    ctx.fillStyle = palette.tieTop;
+    ctx.fillRect(x, railY + 1, 20, 18);
+    ctx.fillStyle = palette.tieShadow;
+    ctx.fillRect(x + 1, railY + 13, 18, 4);
+  }
+
+  const railGradient = ctx.createLinearGradient(0, railY - 4, 0, railY + 18);
+  railGradient.addColorStop(0, palette.railTop);
+  railGradient.addColorStop(0.58, "#9aa6b4");
+  railGradient.addColorStop(1, palette.railBottom);
+  ctx.fillStyle = railGradient;
+  ctx.fillRect(0, railY - 4, width, 7);
+  ctx.fillRect(0, railY + 13, width, 7);
+
+  if (options.includeSwitchStand && options.switchX !== undefined) {
+    const switchX = options.switchX;
+    const branchY = options.switchToSiding ? railY + 58 : railY + 2;
+    ctx.strokeStyle = "#67717f";
+    ctx.lineWidth = 8;
+    ctx.beginPath();
+    ctx.moveTo(switchX - 6, railY + 2);
+    ctx.lineTo(switchX + 90, branchY);
+    ctx.stroke();
+
+    ctx.strokeStyle = "#d0d7e2";
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    ctx.moveTo(switchX - 6, railY + 2);
+    ctx.lineTo(switchX + 90, branchY - 2);
+    ctx.stroke();
+
+    ctx.fillStyle = "#364152";
+    ctx.fillRect(switchX - 8, railY - 26, 8, 22);
+    ctx.fillStyle = options.switchToSiding ? "#f97316" : "#22c55e";
+    ctx.beginPath();
+    ctx.moveTo(switchX, railY - 23);
+    ctx.lineTo(switchX + 20, railY - 18);
+    ctx.lineTo(switchX, railY - 13);
+    ctx.closePath();
+    ctx.fill();
+  }
+};
+
+const drawLocomotiveBody = (
+  ctx: CanvasRenderingContext2D,
+  loco: LocomotiveDefinition,
+  originX: number,
+  originY: number,
+  wheelRotation: number,
+  palette: TrainPreviewPalette,
+) => {
+  const silhouette = getLocomotiveSilhouette(loco);
+  const pilot = loco.pilot ?? { length: 46, height: 28, color: "#38465a", ribCount: 6 };
+
+  ctx.fillStyle = pilot.color;
+  ctx.beginPath();
+  ctx.moveTo(originX - pilot.length, originY);
+  ctx.lineTo(originX + 8, originY + 2);
+  ctx.lineTo(originX + 8, originY - pilot.height);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.strokeStyle = "#111827";
+  ctx.lineWidth = 1.8;
+  for (let rib = 0; rib < pilot.ribCount; rib += 1) {
+    const p = rib / Math.max(1, pilot.ribCount - 1);
+    const ribX = originX - pilot.length + p * pilot.length;
+    ctx.beginPath();
+    ctx.moveTo(ribX, originY);
+    ctx.lineTo(ribX + 10, originY - pilot.height + 4);
+    ctx.stroke();
+  }
+
+  const boardGradient = ctx.createLinearGradient(originX, originY + 1, originX, originY - loco.bodyHeight);
+  boardGradient.addColorStop(0, "#0f172a");
+  boardGradient.addColorStop(0.42, palette.runningBoard);
+  boardGradient.addColorStop(1, "#344255");
+  ctx.fillStyle = boardGradient;
+  ctx.fillRect(originX + 8, originY + silhouette.runningBoardY, silhouette.boilerLength + 62, loco.bodyHeight * 0.38);
+
+  const boilerGradient = ctx.createLinearGradient(originX, originY + silhouette.boilerTop, originX, originY + silhouette.boilerTop + silhouette.boilerHeight);
+  boilerGradient.addColorStop(0, "#e4ebf4");
+  boilerGradient.addColorStop(0.16, loco.color);
+  boilerGradient.addColorStop(0.55, loco.color);
+  boilerGradient.addColorStop(1, "#1f2a38");
+  ctx.fillStyle = boilerGradient;
+  ctx.beginPath();
+  ctx.roundRect(originX + 18, originY + silhouette.boilerTop, silhouette.boilerLength, silhouette.boilerHeight, 18);
+  ctx.fill();
+
+  const smokeX = originX + silhouette.smokeboxCenterX;
+  const smokeY = originY + silhouette.boilerTop + silhouette.boilerHeight / 2;
+  const smokeGradient = ctx.createRadialGradient(smokeX - 3, smokeY - 3, 2, smokeX, smokeY, silhouette.smokeboxRadius);
+  smokeGradient.addColorStop(0, "#5f6977");
+  smokeGradient.addColorStop(1, palette.smokebox);
+  ctx.fillStyle = smokeGradient;
+  ctx.beginPath();
+  ctx.arc(smokeX, smokeY, silhouette.smokeboxRadius, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.strokeStyle = "#bcc9d8";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.arc(smokeX, smokeY, silhouette.smokeboxRadius - 3, 0, Math.PI * 2);
+  ctx.stroke();
+
+  ctx.fillStyle = loco.trimColor;
+  ctx.fillRect(originX + 24, originY + silhouette.boilerTop - 10, silhouette.boilerLength * 0.62, 6);
+
+  const stack = loco.stack ?? { width: 20, height: 36, flareWidth: 32, flareHeight: 10, offsetX: 68, offsetY: -102 };
+  const stackX = originX + stack.offsetX;
+  const stackY = originY + stack.offsetY;
+  const stackGradient = ctx.createLinearGradient(stackX, stackY, stackX, stackY + stack.height + stack.flareHeight);
+  stackGradient.addColorStop(0, "#0a0f1b");
+  stackGradient.addColorStop(1, "#485566");
+  ctx.fillStyle = stackGradient;
+  ctx.beginPath();
+  ctx.roundRect(stackX, stackY, stack.width, stack.height, 4);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.roundRect(stackX - (stack.flareWidth - stack.width) / 2, stackY - stack.flareHeight, stack.flareWidth, stack.flareHeight + 2, 5);
+  ctx.fill();
+
+  const cab = loco.cab ?? {
+    width: 82,
+    height: 62,
+    roofOverhang: 12,
+    roofHeight: 12,
+    offsetX: loco.bodyLength - 94,
+    windowWidth: 18,
+    windowHeight: 16,
+  };
+
+  const cabX = originX + cab.offsetX;
+  const cabY = originY - cab.height - 10;
+  ctx.fillStyle = loco.color;
+  ctx.beginPath();
+  ctx.moveTo(cabX, cabY + cab.height);
+  ctx.lineTo(cabX + cab.width, cabY + cab.height);
+  ctx.lineTo(cabX + cab.width, cabY + 10);
+  ctx.lineTo(cabX + cab.width - 18, cabY);
+  ctx.lineTo(cabX + 16, cabY);
+  ctx.lineTo(cabX, cabY + 10);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = "#0f172a";
+  ctx.fillRect(cabX - cab.roofOverhang, cabY - cab.roofHeight, cab.width + cab.roofOverhang * 2, cab.roofHeight);
+  ctx.fillStyle = "#d7edff";
+  ctx.fillRect(cabX + 12, cabY + 14, cab.windowWidth, cab.windowHeight);
+  ctx.fillRect(cabX + 40, cabY + 14, cab.windowWidth, cab.windowHeight);
+
+  const lamp = loco.headlamp ?? {
+    radius: 10,
+    offsetX: 6,
+    offsetY: -58,
+    rimColor: "#f59e0b",
+    glowColor: "rgba(255, 244, 180, 0.6)",
+  };
+  const lampX = originX + lamp.offsetX;
+  const lampY = originY + lamp.offsetY;
+  ctx.fillStyle = lamp.glowColor;
+  ctx.beginPath();
+  ctx.ellipse(lampX - 22, lampY, lamp.radius * 2.8, lamp.radius * 1.7, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillStyle = lamp.rimColor;
+  ctx.beginPath();
+  ctx.arc(lampX, lampY, lamp.radius + 1.4, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillStyle = "#fff3b0";
+  ctx.beginPath();
+  ctx.arc(lampX, lampY, lamp.radius * 0.56, 0, Math.PI * 2);
+  ctx.fill();
+
+  if (loco.pilotWheels) {
+    drawAuxWheelSet(ctx, originX, originY, loco.pilotWheels, wheelRotation * 0.82, palette);
+  }
+
+  const wheelSet = loco.wheelSet;
+  const wheelCenters = Array.from({ length: wheelSet.count }).map((_, index) => {
+    const x = originX + wheelSet.offsetX + index * wheelSet.spacing;
+    const y = originY - 1;
+    drawWheel(ctx, x, y, wheelSet.radius, wheelRotation + index * 0.18, palette, 9);
+    return { x, y };
+  });
+
+  if (loco.trailingWheels) {
+    drawAuxWheelSet(ctx, originX, originY, loco.trailingWheels, wheelRotation * 0.74, palette);
+  }
+
+  const rod = loco.drivingRod;
+  const phase = getRodCyclePhase(wheelRotation);
+  const crankWheel = wheelCenters[Math.min(wheelCenters.length - 1, Math.max(0, rod.wheelIndex))];
+  const leadWheel = wheelCenters[0];
+  const trailingWheel = wheelCenters[wheelCenters.length - 1];
+
+  const leftCrankX = crankWheel.x + Math.cos(phase) * rod.crankRadius;
+  const leftCrankY = crankWheel.y + Math.sin(phase) * rod.crankRadius;
+  const rightCrankX = leadWheel.x + Math.cos(phase + 0.18) * (rod.crankRadius * 0.92);
+  const rightCrankY = leadWheel.y + Math.sin(phase + 0.18) * (rod.crankRadius * 0.92);
+
+  const pistonX = leadWheel.x - rod.rodLength * 0.45;
+  const pistonY = crankWheel.y + rod.anchorOffsetY;
+  ctx.fillStyle = "#46576d";
+  ctx.fillRect(pistonX - 24, pistonY - 8, 24, 16);
+
+  ctx.strokeStyle = palette.brass;
+  ctx.lineWidth = rod.thickness;
+  ctx.lineCap = "round";
+  ctx.beginPath();
+  ctx.moveTo(pistonX, pistonY);
+  ctx.lineTo(leftCrankX, leftCrankY);
+  ctx.lineTo(trailingWheel.x + 10, trailingWheel.y - 2);
+  ctx.stroke();
+
+  ctx.strokeStyle = "#c68e2e";
+  ctx.lineWidth = Math.max(3, rod.thickness - 2);
+  ctx.beginPath();
+  ctx.moveTo(rightCrankX, rightCrankY);
+  ctx.lineTo(leftCrankX, leftCrankY);
+  ctx.lineTo(leadWheel.x + 10, leadWheel.y - 2);
+  ctx.stroke();
+
+  ctx.fillStyle = "#ffd26a";
+  [
+    [leftCrankX, leftCrankY],
+    [rightCrankX, rightCrankY],
+    [pistonX, pistonY],
+  ].forEach(([x, y]) => {
+    ctx.beginPath();
+    ctx.arc(x, y, 5, 0, Math.PI * 2);
+    ctx.fill();
+  });
+
+  return originX + loco.bodyLength + 6;
+};
+
+const drawTender = (
+  ctx: CanvasRenderingContext2D,
+  train: TrainDefinition,
+  x: number,
+  baseY: number,
+  palette: TrainPreviewPalette,
+) => {
+  const tender = train.tender;
+  if (!tender) {
+    return x;
+  }
+
+  const y = baseY - tender.height;
+  const tenderGradient = ctx.createLinearGradient(x, y, x, baseY);
+  tenderGradient.addColorStop(0, tender.color);
+  tenderGradient.addColorStop(1, "#111827");
+  ctx.fillStyle = tenderGradient;
+  ctx.fillRect(x, y, tender.length, tender.height);
+
+  ctx.fillStyle = "#111827";
+  ctx.fillRect(x + 8, y - 14, tender.length - 16, 14);
+  ctx.fillStyle = "#64748b";
+  ctx.fillRect(x + 16, y + 10, tender.length - 32, 8);
+
+  [36, tender.length - 44].forEach((offset) => {
+    drawWheel(ctx, x + offset, baseY - 2, 18, 0, palette, 8);
+  });
+
+  return x + tender.length;
+};
+
+const drawCar = (
+  ctx: CanvasRenderingContext2D,
+  train: TrainDefinition,
+  carIndex: number,
+  x: number,
+  baseY: number,
+  palette: TrainPreviewPalette,
+) => {
+  const car = train.rollingStock[carIndex];
+  if (!car) {
+    return x;
+  }
+  const y = baseY - car.height;
+  const carGradient = ctx.createLinearGradient(x, y, x, baseY);
+  carGradient.addColorStop(0, car.color);
+  carGradient.addColorStop(1, "#1f2937");
+  ctx.fillStyle = carGradient;
+  ctx.fillRect(x, y, car.length, car.height);
+
+  if (train.id.includes("passenger")) {
+    ctx.fillStyle = "#ffefb1";
+    const windowCount = Math.max(4, Math.floor(car.length / 28));
+    for (let windowIndex = 0; windowIndex < windowCount; windowIndex += 1) {
+      const wx = x + 10 + windowIndex * ((car.length - 20) / windowCount);
+      ctx.fillRect(wx, y + 10, 11, 11);
+    }
+  } else {
+    ctx.fillStyle = "#334155";
+    ctx.fillRect(x + 10, y + 10, car.length - 20, Math.min(20, car.height * 0.46));
+    for (let rib = 0; rib < 4; rib += 1) {
+      ctx.fillStyle = "rgba(226,232,240,0.22)";
+      ctx.fillRect(x + 14 + rib * ((car.length - 36) / 4), y + 10, 4, car.height - 18);
+    }
+  }
+
+  drawWheel(ctx, x + 24, baseY - 2, 14, 0, palette, 6);
+  drawWheel(ctx, x + car.length - 26, baseY - 2, 14, 0, palette, 6);
+
+  return x + car.length;
+};
+
+export const drawTrainConsist = (ctx: CanvasRenderingContext2D, train: TrainDefinition, options: TrainArtRenderOptions) => {
+  const scale = options.scale ?? 1;
+  const palette = options.palette ?? DEFAULT_PREVIEW_PALETTE;
+  const wheelRotation = options.wheelRotationRad ?? 0;
+  const railTopY = options.railTopY ?? options.baseY;
+
+  ctx.save();
+  ctx.translate(options.baseX, options.baseY);
+  ctx.scale(scale, scale);
+
+  const locoCouplerX = drawLocomotiveBody(ctx, train.locomotive, 0, 0, wheelRotation, palette);
+  let rollingX = train.locomotive.bodyLength + LOCOMOTIVE_TO_TENDER_GAP;
+  let previousCouplerX = locoCouplerX;
+
+  if (train.tender) {
+    drawCoupler(ctx, previousCouplerX, rollingX + 2, railTopY - options.baseY);
+    const tenderEndX = drawTender(ctx, train, rollingX, 0, palette);
+    previousCouplerX = tenderEndX - 2;
+    rollingX = tenderEndX + LOCOMOTIVE_TO_TENDER_GAP;
+  }
+
+  train.rollingStock.forEach((_, index) => {
+    drawCoupler(ctx, previousCouplerX, rollingX + 2, railTopY - options.baseY);
+    const carEnd = drawCar(ctx, train, index, rollingX, 0, palette);
+    previousCouplerX = carEnd - 2;
+    rollingX = carEnd + CAR_GAP + 6;
+  });
+
+  if (train.rollingStock.length > 0) {
+    ctx.fillStyle = "#7f1d1d";
+    ctx.fillRect(previousCouplerX + 4, -18, 5, 10);
+  }
+
+  ctx.restore();
+};
+
+export const drawSteamParticleRich = (ctx: CanvasRenderingContext2D, particle: SteamParticle, cameraX: number) => {
+  const px = particle.x - cameraX;
+  const baseAlpha = Math.max(0.04, particle.alpha);
+
+  const body = ctx.createRadialGradient(px - particle.radius * 0.3, particle.y - particle.radius * 0.3, 1, px, particle.y, particle.radius * 1.4);
+  body.addColorStop(0, `rgba(255,255,255,${baseAlpha})`);
+  body.addColorStop(0.35, `rgba(240,246,255,${baseAlpha * 0.82})`);
+  body.addColorStop(0.75, `rgba(190,198,210,${baseAlpha * 0.35})`);
+  body.addColorStop(1, `rgba(105,113,126,${baseAlpha * 0.05})`);
+  ctx.fillStyle = body;
+  ctx.beginPath();
+  ctx.arc(px, particle.y, particle.radius * 1.16, 0, Math.PI * 2);
+  ctx.fill();
+};
+
+export const drawPreviewBackdrop = (ctx: CanvasRenderingContext2D, width: number, height: number, palette: TrainPreviewPalette = DEFAULT_PREVIEW_PALETTE) => {
+  const skyGradient = ctx.createLinearGradient(0, 0, 0, height * 0.76);
+  skyGradient.addColorStop(0, palette.skyTop);
+  skyGradient.addColorStop(0.68, palette.skyHorizon);
+  skyGradient.addColorStop(1, "#f7fbff");
+  ctx.fillStyle = skyGradient;
+  ctx.fillRect(0, 0, width, height * 0.76);
+
+  const groundGradient = ctx.createLinearGradient(0, height * 0.72, 0, height);
+  groundGradient.addColorStop(0, palette.groundTop);
+  groundGradient.addColorStop(1, palette.groundBottom);
+  ctx.fillStyle = groundGradient;
+  ctx.fillRect(0, height * 0.72, width, height * 0.28);
+};
+
+export const renderTrainPreviewCard = (
+  ctx: CanvasRenderingContext2D,
+  train: TrainDefinition,
+  width: number,
+  height: number,
+  wheelRotationRad = 0,
+) => {
+  const palette = getPreviewPalette();
+  const previewPadding = 8;
+  const layout = getTrainLayout(train, width, previewPadding, 0.64);
+  const baseY = Math.round(height * 0.82);
+
+  ctx.clearRect(0, 0, width, height);
+  drawPreviewBackdrop(ctx, width, height, palette);
+  drawTrackAndBallast(ctx, width, baseY - 2, palette);
+
+  drawTrainConsist(ctx, train, {
+    baseX: layout.locomotiveStart,
+    baseY,
+    scale: layout.scale,
+    wheelRotationRad,
+    palette,
+  });
+
+  const smokeX = layout.locomotiveStart + (train.locomotive.stack?.offsetX ?? 68) * layout.scale;
+  const smokeY = baseY + ((train.locomotive.stack?.offsetY ?? -102) - 8) * layout.scale;
+  for (let i = 0; i < 5; i += 1) {
+    const r = 12 * layout.scale + i * 7 * layout.scale;
+    const drift = i * 18 * layout.scale;
+    ctx.fillStyle = `rgba(234,240,248,${0.28 - i * 0.04})`;
+    ctx.beginPath();
+    ctx.ellipse(smokeX + drift, smokeY - i * 12 * layout.scale, r * 1.14, r, 0, 0, Math.PI * 2);
+    ctx.fill();
+  }
 };


### PR DESCRIPTION
### Motivation
- The Steam Trains UI relied on three separate, prototype-style art paths (runtime Canvas, SVG selector, and simple Workshop preview) and needed a single, production-ready shared visual foundation to make runtime, selector, and Workshop feel like the same richer steam-locomotive experience.
- The goal was a visual-only patch that preserves the data-driven train/catalog/builder architecture and gameplay/progression while dramatically improving art fidelity (metal, brass, soot), wheel/rod realism, steam/smoke, and world presentation.

### Description
- Introduced a shared Canvas-based train art/rendering foundation in `ui/partner-hub/lib/steam-trains/visuals.ts` that implements reusable helpers for boiler/smokebox, stack, cab, headlamp, pilot/cowcatcher, wheels/rods, tender, rolling stock, couplers, steam particles, and track/ballast composition; this centralizes proportions and rendering language for all surfaces.
- Updated the runtime renderer to consume the shared helpers (`drawTrainConsist`, `drawTrackAndBallast`, `drawSteamParticleRich`, `drawPreviewBackdrop`) and adjusted scene framing and camera offsets so the in-game locomotive reads heavier and matches previews (`ui/partner-hub/lib/steam-trains/renderer.ts`).
- Replaced the old SVG previews with a shared animated `TrainPreviewCanvas` React component and switched both the Train Selector and Workshop preview to use it so selector/workshop/runtime share identical visuals and proportions (`ui/partner-hub/components/steam-trains/train-preview-canvas.tsx`, `train-selector.tsx`, `train-builder.tsx`).
- Kept all builder/runtime/progression logic intact and preserved stock trains and custom-train compatibility by reusing existing train definitions and builder outputs; only visual drawing surfaces were refactored.
- Tests and small helpers expanded to cover the new shared visual assumptions and consist-length safety: `ui/partner-hub/lib/steam-trains/visuals.test.ts` was updated to assert consist lengths and palette properties.
- Summary of changed files: `ui/partner-hub/lib/steam-trains/visuals.ts`, `ui/partner-hub/lib/steam-trains/renderer.ts`, `ui/partner-hub/components/steam-trains/train-preview-canvas.tsx` (new), `ui/partner-hub/components/steam-trains/train-selector.tsx`, `ui/partner-hub/components/steam-trains/train-builder.tsx`, and `ui/partner-hub/lib/steam-trains/visuals.test.ts`.

### Testing
- Ran unit/test suite from `ui/partner-hub` with `npm test`; all tests passed: final summary reported `# tests 181` and `# pass 181` with `# fail 0`.
- Ran type checking with `npm run typecheck`; `tsc --noEmit` completed successfully with no errors.
- Built the Next app with `npm run build`; the build completed successfully and reported successful compilation and static page generation (Next reported `✓ Compiled successfully` and `✓ Generating static pages (22/22)`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c710555ae8833092116f1bff39338b)