### PR TITLE
Harden Steam Trains shared visuals after rebuild

### DIFF
--- a/ui/partner-hub/components/steam-trains/train-builder.tsx
+++ b/ui/partner-hub/components/steam-trains/train-builder.tsx
@@ -139,18 +139,23 @@ export function TrainBuilder({
           {savedTrains.length === 0 ? (
             <p className="text-sm text-muted-foreground">Save your first train to use it in Levels and Free Play.</p>
           ) : (
-            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
               {savedTrains.map((train) => (
-                <Button
+                <button
                   key={train.id}
                   type="button"
-                  className="h-auto min-h-14 justify-start px-3 py-2 text-left text-base"
-                  variant="secondary"
+                  className="rounded-2xl border bg-card p-2 text-left transition hover:border-primary/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
                   onClick={() => onLoadSaved(train.id)}
                 >
-                  <span className="mr-2 inline-block h-3 w-8 rounded-full" style={{ backgroundColor: train.locomotive.trimColor }} />
-                  <span className="truncate">{train.displayName}</span>
-                </Button>
+                  <div className="rounded-xl bg-gradient-to-b from-sky-100 via-sky-50 to-green-100 p-2">
+                    <TrainPreviewCanvas train={train} width={220} height={110} className="h-24 w-full" animated={false} />
+                  </div>
+                  <div className="mt-2 flex items-center gap-2">
+                    <span className="inline-block h-3 w-8 rounded-full" style={{ backgroundColor: train.locomotive.trimColor }} />
+                    <p className="truncate text-sm font-semibold">{train.displayName}</p>
+                  </div>
+                  <p className="text-xs text-muted-foreground">Load this train</p>
+                </button>
               ))}
             </div>
           )}

--- a/ui/partner-hub/components/steam-trains/train-preview-canvas.tsx
+++ b/ui/partner-hub/components/steam-trains/train-preview-canvas.tsx
@@ -27,20 +27,21 @@ export function TrainPreviewCanvas({ train, width, height, className, animated =
     }
 
     let frame: number | null = null;
-    let start = performance.now();
+    const start = performance.now();
 
-    const draw = (timestamp: number) => {
+    const drawFrame = (timestamp: number) => {
       const elapsed = (timestamp - start) / 1000;
       const wheelRotation = elapsed * 1.6;
       renderTrainPreviewCard(context, train, width, height, wheelRotation);
       if (animated) {
-        frame = window.requestAnimationFrame(draw);
+        frame = window.requestAnimationFrame(drawFrame);
       }
     };
 
-    draw(start);
     if (animated) {
-      frame = window.requestAnimationFrame(draw);
+      frame = window.requestAnimationFrame(drawFrame);
+    } else {
+      drawFrame(start);
     }
 
     return () => {

--- a/ui/partner-hub/components/steam-trains/train-selector.tsx
+++ b/ui/partner-hub/components/steam-trains/train-selector.tsx
@@ -38,7 +38,7 @@ export function TrainSelector({ selectedTrainId, trains, onSelectTrain }: TrainS
               aria-pressed={selected}
             >
               <div className="rounded-xl bg-gradient-to-b from-sky-100 via-sky-50 to-green-100 p-2">
-                <TrainPreviewCanvas train={train} width={previewWidth} height={previewHeight} className="h-28 w-full" />
+                <TrainPreviewCanvas train={train} width={previewWidth} height={previewHeight} className="h-28 w-full" animated={selected} />
               </div>
               <p className="mt-2 text-lg font-semibold">{train.displayName}</p>
               <p className="text-sm text-muted-foreground">

--- a/ui/partner-hub/lib/steam-trains/renderer.ts
+++ b/ui/partner-hub/lib/steam-trains/renderer.ts
@@ -1,5 +1,12 @@
 import type { LevelCheckpoint, SteamParticle, SteamTrainsSimulationState } from "./types";
-import { drawPreviewBackdrop, drawSteamParticleRich, drawTrackAndBallast, drawTrainConsist, getPreviewPalette } from "./visuals";
+import {
+  drawPreviewBackdrop,
+  drawSteamParticleRich,
+  drawTrackAndBallast,
+  drawTrackTurnout,
+  drawTrainConsist,
+  getPreviewPalette,
+} from "./visuals";
 
 const checkpointToScreenX = (checkpoint: LevelCheckpoint, state: SteamTrainsSimulationState, width: number) =>
   checkpoint.x - state.train.x + width * 0.35;
@@ -110,8 +117,7 @@ const drawTrack = (ctx: CanvasRenderingContext2D, state: SteamTrainsSimulationSt
   state.level.checkpoints.forEach((checkpoint, index) => {
     const switchX = checkpointToScreenX(checkpoint, state, width);
     const chosen = state.checkpointDecisions[index] ?? state.switchState;
-    drawTrackAndBallast(ctx, 0, railY, palette, {
-      includeSwitchStand: true,
+    drawTrackTurnout(ctx, railY, {
       switchX,
       switchToSiding: chosen !== "main",
     });

--- a/ui/partner-hub/lib/steam-trains/visuals.test.ts
+++ b/ui/partner-hub/lib/steam-trains/visuals.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 import { STEAM_TRAIN_CATALOG } from "./trainCatalog";
 import {
   countChuffPulses,
+  drawTrackTurnout,
   getCarWindowColor,
   getLocomotiveSilhouette,
   getPreviewPalette,
@@ -57,5 +58,29 @@ describe("steam train visual helpers", () => {
   it("maps window color by train role", () => {
     assert.equal(getCarWindowColor("starter-passenger"), "#fef3c7");
     assert.equal(getCarWindowColor("starter-freight"), "#334155");
+  });
+
+  it("draws turnout geometry only when switch position is provided", () => {
+    const calls: string[] = [];
+    const ctx = {
+      beginPath: () => calls.push("beginPath"),
+      moveTo: (_x: number, _y: number) => calls.push("moveTo"),
+      lineTo: (_x: number, _y: number) => calls.push("lineTo"),
+      stroke: () => calls.push("stroke"),
+      fillRect: (_x: number, _y: number, _w: number, _h: number) => calls.push("fillRect"),
+      closePath: () => calls.push("closePath"),
+      fill: () => calls.push("fill"),
+      set strokeStyle(_value: string) {},
+      set lineWidth(_value: number) {},
+      set fillStyle(_value: string) {},
+    } as unknown as CanvasRenderingContext2D;
+
+    drawTrackTurnout(ctx, 100, {});
+    assert.equal(calls.length, 0);
+
+    drawTrackTurnout(ctx, 100, { switchX: 120, switchToSiding: true });
+    assert.equal(calls.includes("fillRect"), true);
+    assert.equal(calls.filter((call) => call === "stroke").length, 2);
+    assert.equal(calls.filter((call) => call === "lineTo").length >= 3, true);
   });
 });

--- a/ui/partner-hub/lib/steam-trains/visuals.ts
+++ b/ui/partner-hub/lib/steam-trains/visuals.ts
@@ -71,6 +71,42 @@ export type TrackRenderOptions = {
   switchToSiding?: boolean;
 };
 
+export const drawTrackTurnout = (
+  ctx: CanvasRenderingContext2D,
+  railY: number,
+  options: Pick<TrackRenderOptions, "switchX" | "switchToSiding">,
+) => {
+  if (options.switchX === undefined) {
+    return;
+  }
+
+  const switchX = options.switchX;
+  const branchY = options.switchToSiding ? railY + 58 : railY + 2;
+  ctx.strokeStyle = "#67717f";
+  ctx.lineWidth = 8;
+  ctx.beginPath();
+  ctx.moveTo(switchX - 6, railY + 2);
+  ctx.lineTo(switchX + 90, branchY);
+  ctx.stroke();
+
+  ctx.strokeStyle = "#d0d7e2";
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.moveTo(switchX - 6, railY + 2);
+  ctx.lineTo(switchX + 90, branchY - 2);
+  ctx.stroke();
+
+  ctx.fillStyle = "#364152";
+  ctx.fillRect(switchX - 8, railY - 26, 8, 22);
+  ctx.fillStyle = options.switchToSiding ? "#f97316" : "#22c55e";
+  ctx.beginPath();
+  ctx.moveTo(switchX, railY - 23);
+  ctx.lineTo(switchX + 20, railY - 18);
+  ctx.lineTo(switchX, railY - 13);
+  ctx.closePath();
+  ctx.fill();
+};
+
 export type TrainArtRenderOptions = {
   baseX: number;
   baseY: number;
@@ -242,32 +278,11 @@ export const drawTrackAndBallast = (
   ctx.fillRect(0, railY - 4, width, 7);
   ctx.fillRect(0, railY + 13, width, 7);
 
-  if (options.includeSwitchStand && options.switchX !== undefined) {
-    const switchX = options.switchX;
-    const branchY = options.switchToSiding ? railY + 58 : railY + 2;
-    ctx.strokeStyle = "#67717f";
-    ctx.lineWidth = 8;
-    ctx.beginPath();
-    ctx.moveTo(switchX - 6, railY + 2);
-    ctx.lineTo(switchX + 90, branchY);
-    ctx.stroke();
-
-    ctx.strokeStyle = "#d0d7e2";
-    ctx.lineWidth = 3;
-    ctx.beginPath();
-    ctx.moveTo(switchX - 6, railY + 2);
-    ctx.lineTo(switchX + 90, branchY - 2);
-    ctx.stroke();
-
-    ctx.fillStyle = "#364152";
-    ctx.fillRect(switchX - 8, railY - 26, 8, 22);
-    ctx.fillStyle = options.switchToSiding ? "#f97316" : "#22c55e";
-    ctx.beginPath();
-    ctx.moveTo(switchX, railY - 23);
-    ctx.lineTo(switchX + 20, railY - 18);
-    ctx.lineTo(switchX, railY - 13);
-    ctx.closePath();
-    ctx.fill();
+  if (options.includeSwitchStand) {
+    drawTrackTurnout(ctx, railY, {
+      switchX: options.switchX,
+      switchToSiding: options.switchToSiding,
+    });
   }
 };
 


### PR DESCRIPTION
### Motivation
- Remove accidental ballast/tie artifacts caused by using `drawTrackAndBallast` with `width=0` for switch visuals and simplify the renderer architecture. 
- Reduce CPU/GPU load from many continuously animating preview canvases while preserving a high-quality animated Workshop preview. 
- Bring saved custom trains UI up to the rebuilt visual standard with lightweight, child-friendly preview cards and add focused tests to guard the refactor. 

### Description
- Extracted turnout drawing into a dedicated helper `drawTrackTurnout(ctx, railY, { switchX, switchToSiding })` and kept base track/ballast drawing separate in `ui/partner-hub/lib/steam-trains/visuals.ts`. 
- Updated the runtime renderer to call `drawTrackTurnout` for checkpoints instead of calling `drawTrackAndBallast` with `width=0` to avoid stray ballast/tie artifacts in `ui/partner-hub/lib/steam-trains/renderer.ts`. 
- Fixed preview canvas scheduling so static previews render once and animated previews use a single RAF loop by changing `TrainPreviewCanvas` (`ui/partner-hub/components/steam-trains/train-preview-canvas.tsx`). 
- Reduced selector cost by animating only the selected train card (`animated={selected}`) in `ui/partner-hub/components/steam-trains/train-selector.tsx`. 
- Upgraded Workshop "Saved Custom Trains" from text-heavy buttons to lightweight preview cards using `TrainPreviewCanvas` (static) and a simpler presentation in `ui/partner-hub/components/steam-trains/train-builder.tsx`. 
- Added a focused unit test for the turnout helper in `ui/partner-hub/lib/steam-trains/visuals.test.ts` to assert no-op when `switchX` is absent and expected drawing ops when provided. 
- Files changed: `visuals.ts`, `renderer.ts`, `visuals.test.ts`, `train-preview-canvas.tsx`, `train-selector.tsx`, `train-builder.tsx` (small, focused edits). 
- This follow-up completes the Prompt 1 hardening pass for the visual rebuild. 

### Testing
- Ran `npm test` from `ui/partner-hub`: all tests passed and the TAP summary reported `# tests 182` and `# pass 182` with `# fail 0`. 
- Ran `npm run typecheck` (which runs `tsc --noEmit`): type checking completed with no errors. 
- Ran `npm run build` (Next.js): the build compiled successfully (`✓ Compiled successfully in 14.2s`) and completed static page generation (`Generating static pages (22/22)`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c714158c9c8330986b4643f166d527)