### PR TITLE
Finish Steam Trains with real 3D cab gameplay view

### DIFF
--- a/ui/partner-hub/components/steam-trains/train-cab-3d.tsx
+++ b/ui/partner-hub/components/steam-trains/train-cab-3d.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
+
+import { PerspectiveCamera } from "@react-three/drei";
+import { Canvas, useFrame } from "@react-three/fiber";
+import type { GroupProps } from "@react-three/fiber";
+import type { Group } from "three";
 
 import { buildCabTheme, buildScene3dModel } from "@/lib/steam-trains/scene3d";
-import type { Scene3dLandmarkCue, Scene3dRepeater, Scene3dTrackPreview } from "@/lib/steam-trains/scene3d";
+import type { Scene3dLandmarkCue, Scene3dModel, Scene3dTrackPreview } from "@/lib/steam-trains/scene3d";
 import type { SteamTrainsSimulationState } from "@/lib/steam-trains/types";
 
 type TrainCab3DProps = {
@@ -11,152 +16,309 @@ type TrainCab3DProps = {
   helperMode: boolean;
 };
 
-const TRACK_WIDTH = 170;
-const ROADBED_WIDTH = 300;
+const toWorldZ = (forwardZ: number) => -forwardZ;
 
-const clamp01 = (value: number) => Math.max(0, Math.min(1, value));
-
-const perspectiveY = (z: number, horizon: number) => {
-  const ratio = 1 - clamp01(z / horizon);
-  return Math.round(460 - ratio * 430);
+const branchXAt = (route: Scene3dTrackPreview, z: number) => {
+  const span = Math.max(1, route.endZ - route.splitZ);
+  const ratio = Math.max(0, Math.min(1, (z - route.splitZ) / span));
+  return route.branchOffset * ratio;
 };
 
-const perspectiveScale = (z: number, horizon: number) => 0.35 + (1 - clamp01(z / horizon)) * 1.55;
-
-const perspectiveX = (x: number, z: number, horizon: number) => {
-  const spread = 0.35 + (1 - clamp01(z / horizon)) * 0.9;
-  return 400 + x * 9 * spread;
-};
-
-function RepeaterSprite({ item, horizon }: { item: Scene3dRepeater; horizon: number }) {
-  const y = perspectiveY(item.z, horizon);
-  const scale = perspectiveScale(item.z, horizon) * item.scale;
-  const x = perspectiveX(item.x, item.z, horizon);
-
-  if (item.kind === "sleeper") {
-    return (
-      <div
-        className="absolute rounded-sm bg-amber-950/95"
-        style={{ left: x - 20 * scale, top: y, width: 40 * scale, height: Math.max(2, 6 * scale) }}
-      />
-    );
-  }
-
-  if (item.kind === "pole") {
-    return (
-      <div className="absolute" style={{ left: x, top: y - 46 * scale, width: 4 * scale, height: 46 * scale }}>
-        <div className="h-full w-full rounded bg-stone-600" />
-        <div className="absolute left-0 top-1 h-[3px] w-[20px] rounded bg-stone-500" style={{ width: 20 * scale }} />
-      </div>
-    );
-  }
+function RepeaterField({ model }: { model: Scene3dModel }) {
+  const sleepers = model.repeaters.filter((item) => item.kind === "sleeper");
+  const poles = model.repeaters.filter((item) => item.kind === "pole");
+  const trees = model.repeaters.filter((item) => item.kind === "tree");
 
   return (
-    <div className="absolute" style={{ left: x - 11 * scale, top: y - 40 * scale, width: 22 * scale, height: 40 * scale }}>
-      <div className="absolute bottom-0 left-1/2 h-[35%] w-[12%] -translate-x-1/2 rounded bg-amber-900" />
-      <div className="absolute bottom-[26%] left-1/2 h-[74%] w-full -translate-x-1/2 rounded-[50%] bg-green-700" />
-    </div>
+    <>
+      {sleepers.map((item) => (
+        <mesh key={item.id} position={[0, 0.04, toWorldZ(item.z)]}>
+          <boxGeometry args={[1.95, 0.06, 0.26]} />
+          <meshStandardMaterial color="#6e4f2f" />
+        </mesh>
+      ))}
+
+      {poles.map((item) => (
+        <group key={item.id} position={[item.x, 0, toWorldZ(item.z)]}>
+          <mesh position={[0, 1.8, 0]}>
+            <cylinderGeometry args={[0.09, 0.11, 3.6, 8]} />
+            <meshStandardMaterial color="#7b7065" />
+          </mesh>
+          <mesh position={[0.45, 2.9, 0]}>
+            <boxGeometry args={[0.95, 0.08, 0.08]} />
+            <meshStandardMaterial color="#8e8176" />
+          </mesh>
+        </group>
+      ))}
+
+      {trees.map((item) => (
+        <group key={item.id} position={[item.x, 0, toWorldZ(item.z)]} scale={item.scale}>
+          <mesh position={[0, 1.15, 0]}>
+            <cylinderGeometry args={[0.16, 0.2, 2.3, 10]} />
+            <meshStandardMaterial color="#5a3f2a" />
+          </mesh>
+          <mesh position={[0, 2.85, 0]}>
+            <coneGeometry args={[0.95, 2.2, 10]} />
+            <meshStandardMaterial color="#2f7d3e" />
+          </mesh>
+        </group>
+      ))}
+    </>
   );
 }
 
-function RoutePreview({ route, horizon }: { route: Scene3dTrackPreview; horizon: number }) {
-  const yStart = perspectiveY(route.splitZ, horizon);
-  const yEnd = perspectiveY(route.endZ, horizon);
-  const startX = perspectiveX(0, route.splitZ, horizon);
-  const endX = perspectiveX(route.branchOffset, route.endZ, horizon);
-  const color = route.safeBranch === "main" ? "#93c5fd" : "#fcd34d";
-  const width = Math.hypot(endX - startX, yEnd - yStart);
-  const angle = Math.atan2(yEnd - yStart, endX - startX);
+function TrackGeometry({ model }: { model: Scene3dModel }) {
+  const farZ = -model.horizonDistance;
+  const nearZ = 56;
+  const centerZ = (farZ + nearZ) / 2;
+  const length = nearZ - farZ;
+
+  const railSegments = useMemo(
+    () =>
+      model.routePreviews.flatMap((route) => {
+        const pieces = 9;
+        const segLength = (route.endZ - route.splitZ) / pieces;
+        return Array.from({ length: pieces }, (_, index) => {
+          const segStart = route.splitZ + segLength * index;
+          const segEnd = segStart + segLength;
+          const midZ = (segStart + segEnd) / 2;
+          return {
+            id: `${route.id}-${index}`,
+            x: branchXAt(route, midZ),
+            z: toWorldZ(midZ),
+            len: Math.max(1, segLength),
+            safeBranch: route.safeBranch,
+          };
+        });
+      }),
+    [model.routePreviews],
+  );
 
   return (
-    <div
-      className="absolute origin-left rounded"
-      style={{ left: startX, top: yStart, width, height: 3, transform: `rotate(${angle}rad)`, backgroundColor: color, opacity: 0.92 }}
-    />
+    <>
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.04, centerZ]}>
+        <planeGeometry args={[48, length]} />
+        <meshStandardMaterial color="#76a95f" />
+      </mesh>
+
+      <mesh position={[0, 0, centerZ]}>
+        <boxGeometry args={[5.6, 0.18, length]} />
+        <meshStandardMaterial color="#6d5a45" />
+      </mesh>
+
+      <mesh position={[-0.72, 0.19, centerZ]}>
+        <boxGeometry args={[0.16, 0.16, length]} />
+        <meshStandardMaterial color="#b0b7c3" metalness={0.3} roughness={0.4} />
+      </mesh>
+      <mesh position={[0.72, 0.19, centerZ]}>
+        <boxGeometry args={[0.16, 0.16, length]} />
+        <meshStandardMaterial color="#b0b7c3" metalness={0.3} roughness={0.4} />
+      </mesh>
+
+      {railSegments.map((segment) => (
+        <group key={segment.id} position={[segment.x, 0, segment.z]}>
+          <mesh position={[-0.72, 0.2, 0]}>
+            <boxGeometry args={[0.12, 0.12, segment.len]} />
+            <meshStandardMaterial color={segment.safeBranch === "main" ? "#8fbef0" : "#f7cb73"} metalness={0.2} roughness={0.45} />
+          </mesh>
+          <mesh position={[0.72, 0.2, 0]}>
+            <boxGeometry args={[0.12, 0.12, segment.len]} />
+            <meshStandardMaterial color={segment.safeBranch === "main" ? "#8fbef0" : "#f7cb73"} metalness={0.2} roughness={0.45} />
+          </mesh>
+        </group>
+      ))}
+    </>
   );
 }
 
-function Landmark({ landmark, horizon }: { landmark: Scene3dLandmarkCue; horizon: number }) {
-  const y = perspectiveY(landmark.z, horizon);
-  const scale = perspectiveScale(landmark.z, horizon);
-  const x = perspectiveX(landmark.side === "left" ? -7 : 7, landmark.z, horizon);
+function LandmarkMesh({ landmark }: { landmark: Scene3dLandmarkCue }) {
+  const x = landmark.side === "left" ? -8.8 : 8.8;
+  const zCenter = toWorldZ(landmark.z + landmark.length / 2);
 
   if (landmark.type === "bridge") {
-    return <div className="absolute rounded-md bg-slate-500/90" style={{ left: 290, top: y - 30 * scale, width: 220, height: 16 * scale }} />;
+    return (
+      <group position={[0, 0, zCenter]}>
+        <mesh position={[0, 1.9, 0]}>
+          <boxGeometry args={[13, 0.45, landmark.length]} />
+          <meshStandardMaterial color="#6b7280" />
+        </mesh>
+        <mesh position={[-6.1, 1, 0]}>
+          <boxGeometry args={[0.4, 2, landmark.length]} />
+          <meshStandardMaterial color="#4b5563" />
+        </mesh>
+        <mesh position={[6.1, 1, 0]}>
+          <boxGeometry args={[0.4, 2, landmark.length]} />
+          <meshStandardMaterial color="#4b5563" />
+        </mesh>
+      </group>
+    );
   }
 
   if (landmark.type === "tunnel") {
     return (
-      <div className="absolute rounded-t-[35px] border-8 border-slate-700 bg-slate-900/80" style={{ left: 270, top: y - 70 * scale, width: 260, height: 88 * scale }} />
+      <group position={[0, 0, zCenter]}>
+        <mesh position={[0, 2.2, 0]}>
+          <boxGeometry args={[8.5, 4.4, landmark.length]} />
+          <meshStandardMaterial color="#374151" />
+        </mesh>
+        <mesh position={[0, 1.6, landmark.length / 2 - 0.45]}>
+          <boxGeometry args={[4.8, 2.8, 0.5]} />
+          <meshStandardMaterial color="#111827" />
+        </mesh>
+      </group>
     );
   }
 
-  return <div className="absolute rounded bg-stone-300" style={{ left: x - 28 * scale, top: y - 20 * scale, width: 56 * scale, height: 20 * scale }} />;
+  return (
+    <group position={[x, 0, zCenter]}>
+      <mesh position={[0, 0.45, 0]}>
+        <boxGeometry args={[4.8, 0.9, landmark.length]} />
+        <meshStandardMaterial color="#d6d3d1" />
+      </mesh>
+      <mesh position={[0, 1.75, 0]}>
+        <boxGeometry args={[2.8, 1.2, 5.8]} />
+        <meshStandardMaterial color="#a8a29e" />
+      </mesh>
+      <mesh position={[0, 2.45, 0]}>
+        <boxGeometry args={[3.4, 0.2, 6.2]} />
+        <meshStandardMaterial color="#57534e" />
+      </mesh>
+    </group>
+  );
+}
+
+function CheckpointSignals({ model }: { model: Scene3dModel }) {
+  return (
+    <>
+      {model.checkpointCues.map((cue) => {
+        const branchX = cue.safeBranch === "main" ? -3.2 : 3.2;
+        return (
+          <group key={cue.id} position={[branchX, 0, toWorldZ(cue.z)]}>
+            <mesh position={[0, 1.3, 0]}>
+              <cylinderGeometry args={[0.08, 0.08, 2.6, 12]} />
+              <meshStandardMaterial color="#52525b" />
+            </mesh>
+            <mesh position={[0, 2.2, 0]}>
+              <boxGeometry args={[0.75, 0.35, 0.2]} />
+              <meshStandardMaterial color={cue.safeBranch === "main" ? "#34d399" : "#f59e0b"} emissive={cue.safeBranch === "main" ? "#14532d" : "#7c2d12"} />
+            </mesh>
+          </group>
+        );
+      })}
+
+      {model.stationCue && model.stationCue.endZ > -45 && model.stationCue.startZ < model.horizonDistance && (
+        <group position={[-4.2, 0, toWorldZ((model.stationCue.startZ + model.stationCue.endZ) / 2)]}>
+          <mesh position={[0, 0.85, 0]}>
+            <boxGeometry args={[0.14, 1.7, Math.max(5, model.stationCue.endZ - model.stationCue.startZ)]} />
+            <meshStandardMaterial color={model.stationCue.completed ? "#10b981" : "#fb923c"} emissive={model.stationCue.completed ? "#064e3b" : "#7c2d12"} />
+          </mesh>
+        </group>
+      )}
+    </>
+  );
+}
+
+function HelperGuide({ model, enabled }: { model: Scene3dModel; enabled: boolean }) {
+  const target = enabled ? model.checkpointCues[0] : undefined;
+  const ringRef = useRef<Group | null>(null);
+
+  useFrame(({ clock }, delta) => {
+    if (!ringRef.current) {
+      return;
+    }
+
+    if (!target) {
+      ringRef.current.visible = false;
+      return;
+    }
+
+    ringRef.current.visible = true;
+    ringRef.current.position.set(0, 1.1 + Math.sin(clock.getElapsedTime() * 1.6) * 0.15, toWorldZ(target.z));
+    ringRef.current.rotation.y += delta * 0.85;
+  });
+
+  return (
+    <group ref={ringRef} visible={Boolean(target)}>
+      <mesh>
+        <torusGeometry args={[1.2, 0.06, 16, 64]} />
+        <meshStandardMaterial color="#facc15" emissive="#713f12" />
+      </mesh>
+    </group>
+  );
+}
+
+function MovingCabRig({ children, speedFactor = 1 }: GroupProps & { speedFactor?: number }) {
+  const rigRef = useRef<Group | null>(null);
+
+  useFrame(({ clock }) => {
+    if (!rigRef.current) {
+      return;
+    }
+
+    rigRef.current.position.y = Math.sin(clock.getElapsedTime() * 4.2) * 0.015 * speedFactor;
+  });
+
+  return <group ref={rigRef}>{children}</group>;
+}
+
+function CabShell({ model, helperMode, state }: { model: Scene3dModel; helperMode: boolean; state: SteamTrainsSimulationState }) {
+  const theme = useMemo(() => buildCabTheme(state.train.definition), [state.train.definition]);
+
+  return (
+    <>
+      <PerspectiveCamera makeDefault fov={56} position={[0, 2.45, 10.6]} rotation={[-0.05, 0, 0]} />
+      <color attach="background" args={["#87ceeb"]} />
+      <fog attach="fog" args={["#a9cfe8", 38, 220]} />
+      <ambientLight intensity={0.8} />
+      <directionalLight intensity={0.9} position={[8, 14, 14]} castShadow={false} />
+      <hemisphereLight args={["#e0f2fe", "#5b7b42", 0.7]} />
+
+      <TrackGeometry model={model} />
+      <RepeaterField model={model} />
+      <CheckpointSignals model={model} />
+      {model.landmarks.map((landmark) => (
+        <LandmarkMesh key={landmark.id} landmark={landmark} />
+      ))}
+      <HelperGuide model={model} enabled={helperMode} />
+
+      <MovingCabRig speedFactor={Math.max(0.45, state.train.speed * 0.03)}>
+        <mesh position={[0, -0.62, 13.2]}>
+          <boxGeometry args={[18, 1.15, 9]} />
+          <meshStandardMaterial color={theme.bodyColor} />
+        </mesh>
+        <mesh position={[0, -0.1, 8.9]}>
+          <boxGeometry args={[6.4, 0.8, 1.6]} />
+          <meshStandardMaterial color={theme.sillColor} />
+        </mesh>
+        <mesh position={[0, 0.45, 8.35]}>
+          <boxGeometry args={[3.9, 0.9, 0.6]} />
+          <meshStandardMaterial color={theme.dashColor} />
+        </mesh>
+        <mesh position={[0, 0.75, 7.85]}>
+          <boxGeometry args={[1.8, 0.3, 0.3]} />
+          <meshStandardMaterial color={theme.noseColor} />
+        </mesh>
+        <mesh position={[-2.95, 0.2, 8.95]}>
+          <boxGeometry args={[0.35, 1.2, 1.2]} />
+          <meshStandardMaterial color={theme.trimColor} />
+        </mesh>
+        <mesh position={[2.95, 0.2, 8.95]}>
+          <boxGeometry args={[0.35, 1.2, 1.2]} />
+          <meshStandardMaterial color={theme.trimColor} />
+        </mesh>
+      </MovingCabRig>
+    </>
+  );
 }
 
 export function TrainCab3D({ state, helperMode }: TrainCab3DProps) {
   const model = useMemo(() => buildScene3dModel(state), [state]);
-  const theme = useMemo(() => buildCabTheme(state.train.definition), [state.train.definition]);
 
   return (
     <div className="relative h-[500px] overflow-hidden rounded-2xl border border-border bg-sky-200">
-      <div className="absolute inset-x-0 top-0 h-52 bg-gradient-to-b from-sky-300 to-sky-100" />
-      <div className="absolute inset-x-0 bottom-0 h-80 bg-gradient-to-t from-green-900 via-green-700 to-green-600" />
-
-      <div className="absolute left-1/2 top-16 h-[410px] -translate-x-1/2" style={{ width: ROADBED_WIDTH, background: "linear-gradient(to top, #5b4637, #6b5a45 45%, #806c52 100%)", clipPath: "polygon(0 100%, 100% 100%, 58% 0, 42% 0)" }} />
-      <div className="absolute left-1/2 top-16 h-[410px] -translate-x-1/2" style={{ width: TRACK_WIDTH, background: "linear-gradient(to top, #4b5563, #9ca3af 60%, #d1d5db)", clipPath: "polygon(0 100%, 100% 100%, 58% 0, 42% 0)" }} />
-
-      {model.repeaters.map((item) => (
-        <RepeaterSprite key={item.id} item={item} horizon={model.horizonDistance} />
-      ))}
-
-      {model.routePreviews.map((route) => (
-        <RoutePreview key={route.id} route={route} horizon={model.horizonDistance} />
-      ))}
-
-      {model.landmarks.map((landmark) => (
-        <Landmark key={landmark.id} landmark={landmark} horizon={model.horizonDistance} />
-      ))}
-
-      {model.checkpointCues.map((cue) => {
-        const y = perspectiveY(cue.z, model.horizonDistance);
-        const x = perspectiveX(cue.safeBranch === "main" ? -4.5 : 4.5, cue.z, model.horizonDistance);
-        return (
-          <div key={cue.id} className="absolute" style={{ left: x - 6, top: y - 48 }}>
-            <div className="h-11 w-1 rounded bg-zinc-700" />
-            <div className="mt-1 h-4 w-12 -translate-x-6 rounded border border-zinc-900" style={{ backgroundColor: cue.safeBranch === "main" ? "#34d399" : "#f59e0b" }} />
-          </div>
-        );
-      })}
-
-      {model.stationCue && model.stationCue.endZ > -40 && model.stationCue.startZ < 360 && (
-        <div
-          className="absolute rounded-full"
-          style={{
-            left: perspectiveX(-3.8, model.stationCue.startZ, model.horizonDistance),
-            top: perspectiveY((model.stationCue.startZ + model.stationCue.endZ) / 2, model.horizonDistance),
-            width: 12,
-            height: 12,
-            backgroundColor: model.stationCue.completed ? "#34d399" : "#f97316",
-          }}
-        />
-      )}
-
-      {helperMode && model.checkpointCues[0] && (
-        <div
-          className="absolute h-10 w-10 rounded-full border-4 border-amber-300"
-          style={{ left: perspectiveX(0, model.checkpointCues[0].z, model.horizonDistance) - 20, top: perspectiveY(model.checkpointCues[0].z, model.horizonDistance) - 30 }}
-        />
-      )}
-
-      <div className="absolute inset-x-0 bottom-0 h-44 border-t-4" style={{ backgroundColor: theme.bodyColor, borderColor: theme.trimColor }}>
-        <div className="mx-auto mt-6 flex w-[74%] items-end justify-between rounded-t-xl border-t-4 px-8 pb-6 pt-5" style={{ backgroundColor: theme.sillColor, borderColor: theme.trimColor }}>
-          <div className="h-16 w-12 rounded bg-zinc-900/90" />
-          <div className="h-20 w-[44%] rounded-t-lg border-t-4" style={{ backgroundColor: theme.dashColor, borderColor: theme.trimColor }} />
-          <div className="h-16 w-12 rounded bg-zinc-900/90" />
-        </div>
-        <div className="absolute left-1/2 top-6 h-8 w-24 -translate-x-1/2 rounded-md border" style={{ backgroundColor: theme.noseColor, borderColor: theme.trimColor }} />
-      </div>
+      <Canvas dpr={[1, 1.5]}>
+        <CabShell model={model} helperMode={helperMode} state={state} />
+      </Canvas>
     </div>
   );
 }

--- a/ui/partner-hub/lib/steam-trains/scene3d.test.ts
+++ b/ui/partner-hub/lib/steam-trains/scene3d.test.ts
@@ -34,6 +34,35 @@ describe("steam trains scene3d model", () => {
     assert.equal(model.landmarks.some((landmark) => landmark.type === "station"), true);
   });
 
+
+  it("models route branches and landmark cue geometry for real 3d placement", () => {
+    const train = getTrainDefinition("copper-creek-switcher");
+    const level = getLevelDefinition("level-4-bridge-tunnel");
+    const initial = createSimulation(train, level, "levels");
+    const state = {
+      ...initial,
+      train: {
+        ...initial.train,
+        x: level.startX + 180,
+      },
+    };
+
+    const model = buildScene3dModel(state);
+    assert.equal(model.routePreviews.length > 0, true);
+
+    const firstRoute = model.routePreviews[0];
+    assert.equal(Boolean(firstRoute), true);
+    if (!firstRoute) {
+      return;
+    }
+
+    assert.equal(firstRoute.endZ > firstRoute.splitZ, true);
+    assert.equal(Math.abs(firstRoute.branchOffset) > 0, true);
+
+    const hasBridgeOrTunnel = model.landmarks.some((landmark) => landmark.type === "bridge" || landmark.type === "tunnel");
+    assert.equal(hasBridgeOrTunnel, true);
+  });
+
   it("moves repeaters toward and past the camera as train progresses", () => {
     const train = getTrainDefinition("copper-creek-switcher");
     const level = getLevelDefinition("level-2-two-routes");


### PR DESCRIPTION
### Motivation
- Convert the existing faux-perspective DOM-based cab view into an actual 3D cab experience so Play feels like an immersive forward-facing locomotive cab rather than layered absolute-positioned divs. 
- Reuse the existing data-driven scene model (`scene3d.ts`) so the same cues (repeaters, route previews, checkpoint/station cues, landmarks, and cab theme) power a true 3D scene.

### Description
- Replaced the faux DOM renderer by rebuilding `TrainCab3D` as a real @react-three/fiber scene that uses `Canvas` and a `PerspectiveCamera`, real meshes, lights, and fog so the view is a true perspective camera rather than layered CSS positioning (`ui/partner-hub/components/steam-trains/train-cab-3d.tsx`).
- Mapped `scene3d.ts` model data to 3D primitives: repeaters rendered as sleepers/poles/trees, route previews rendered as segmented branch rails, checkpoint signals and station cues rendered as in-world signal geometry, and landmarks (station/bridge/tunnel) rendered as simple 3D volumes; cab theme now skins the front cab/dash/sill meshes so selected train identity persists in Play. 
- Preserved helper mode by adding an animated in-scene guide ring at the next checkpoint, and preserved the Workshop / Showroom / builder split and builder code paths (no builder or showroom removal). 
- Added a focused unit test to validate route branch geometry and landmark cue modeling to support 3D placement expectations (`ui/partner-hub/lib/steam-trains/scene3d.test.ts`).

### Testing
- Ran `npm test` in `ui/partner-hub` and the full test suite passed (`# pass 194`, `# fail 0`), including the new `scene3d` test that validates route branch and bridge/tunnel landmark cues. 
- Ran `npm run typecheck` which failed with module-resolution TypeScript errors because the environment does not have `three`, `@react-three/fiber`, and `@react-three/drei` installed. 
- Ran `npm run build` which failed during webpack/Next build for the same missing modules. 
- Attempted `npm install` but package fetch failed with a `403 Forbidden` for `@react-three/drei` in this environment, so full typecheck/build validation is blocked until those packages are installable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7e69a0cb88330807cbb441523fd4f)