### PR TITLE
Polish Steam Trains 3D world and cab driving feel

### DIFF
--- a/ui/partner-hub/components/steam-trains/steam-trains-tool.tsx
+++ b/ui/partner-hub/components/steam-trains/steam-trains-tool.tsx
@@ -297,6 +297,9 @@ export function SteamTrainsTool() {
 
   const cabModel = buildScene3dModel(state);
   const cabTheme = buildCabTheme(state.train.definition);
+  const routeHint = cabModel.routeCues[0]?.hintText ?? "Keep straight and enjoy the ride";
+  const stationDistance =
+    cabModel.stationCue && cabModel.stationCue.startZ > 0 ? `${Math.round(cabModel.stationCue.startZ)}m` : cabModel.stationCue ? "At station" : null;
 
   return (
     <Card className="mx-auto w-full max-w-6xl">
@@ -378,10 +381,12 @@ export function SteamTrainsTool() {
 
             <TrainCab3D state={state} helperMode={shouldShowHelper} />
 
-            <div className="grid gap-3 rounded-xl bg-muted/50 p-4 sm:grid-cols-4">
+            <div className="grid gap-3 rounded-xl bg-muted/50 p-4 sm:grid-cols-2 lg:grid-cols-6">
               <p className="text-center text-base font-semibold">Goal: {state.statusText}</p>
               <p className="text-center text-base font-semibold">Next route: {nextRouteLabel}</p>
               <p className="text-center text-base font-semibold">Speed: {cabModel.speedMph} mph</p>
+              <p className="text-center text-base font-semibold">Route hint: {routeHint}</p>
+              <p className="text-center text-base font-semibold">{stationDistance ? `Station: ${stationDistance}` : "Station: none"}</p>
               <p className="text-center text-base font-semibold" style={{ color: cabTheme.trimColor }}>
                 Cab Trim: {cabTheme.handlingLabel}
               </p>

--- a/ui/partner-hub/components/steam-trains/train-cab-3d.tsx
+++ b/ui/partner-hub/components/steam-trains/train-cab-3d.tsx
@@ -8,7 +8,15 @@ import type { GroupProps } from "@react-three/fiber";
 import type { Group } from "three";
 
 import { buildCabTheme, buildScene3dModel } from "@/lib/steam-trains/scene3d";
-import type { Scene3dLandmarkCue, Scene3dModel, Scene3dTrackPreview } from "@/lib/steam-trains/scene3d";
+import type {
+  Scene3dBuilding,
+  Scene3dCloud,
+  Scene3dLandmarkCue,
+  Scene3dModel,
+  Scene3dRidge,
+  Scene3dRouteCue,
+  Scene3dTrackPreview,
+} from "@/lib/steam-trains/scene3d";
 import type { SteamTrainsSimulationState } from "@/lib/steam-trains/types";
 
 type TrainCab3DProps = {
@@ -61,6 +69,59 @@ function RepeaterField({ model }: { model: Scene3dModel }) {
             <coneGeometry args={[0.95, 2.2, 10]} />
             <meshStandardMaterial color="#2f7d3e" />
           </mesh>
+          <mesh position={[0.2, 3.5, 0]}>
+            <sphereGeometry args={[0.44, 8, 8]} />
+            <meshStandardMaterial color="#3f9a4c" />
+          </mesh>
+        </group>
+      ))}
+    </>
+  );
+}
+
+function SkyLayers({ clouds, ridges }: { clouds: Scene3dCloud[]; ridges: Scene3dRidge[] }) {
+  return (
+    <>
+      {clouds.map((cloud) => (
+        <group key={cloud.id} position={[cloud.x, cloud.y, toWorldZ(cloud.z)]} scale={cloud.scale}>
+          <mesh>
+            <sphereGeometry args={[cloud.depth === "near" ? 1.25 : 1.55, 14, 14]} />
+            <meshStandardMaterial color={cloud.depth === "near" ? "#f8fdff" : "#dbeafe"} transparent opacity={cloud.depth === "near" ? 0.88 : 0.64} />
+          </mesh>
+          <mesh position={[0.9, -0.15, 0.12]}>
+            <sphereGeometry args={[0.9, 12, 12]} />
+            <meshStandardMaterial color="#f1f5f9" transparent opacity={0.8} />
+          </mesh>
+          <mesh position={[-0.75, -0.2, -0.12]}>
+            <sphereGeometry args={[0.82, 12, 12]} />
+            <meshStandardMaterial color="#eff6ff" transparent opacity={0.75} />
+          </mesh>
+        </group>
+      ))}
+
+      {ridges.map((ridge) => (
+        <mesh key={ridge.id} position={[ridge.x, ridge.y, toWorldZ(ridge.z)]}>
+          <coneGeometry args={[ridge.width * 0.5, ridge.height, 9]} />
+          <meshStandardMaterial color={ridge.depth === "near" ? "#4d7c0f" : "#64748b"} transparent opacity={ridge.depth === "near" ? 0.86 : 0.6} />
+        </mesh>
+      ))}
+    </>
+  );
+}
+
+function BuildingField({ buildings }: { buildings: Scene3dBuilding[] }) {
+  return (
+    <>
+      {buildings.map((building) => (
+        <group key={building.id} position={[building.x, 0, toWorldZ(building.z)]}>
+          <mesh position={[0, building.height / 2, 0]}>
+            <boxGeometry args={[building.width, building.height, building.depth]} />
+            <meshStandardMaterial color={building.color} />
+          </mesh>
+          <mesh position={[0, building.height + 0.28, 0]}>
+            <boxGeometry args={[building.width + 0.2, 0.34, building.depth + 0.2]} />
+            <meshStandardMaterial color={building.roofColor} />
+          </mesh>
         </group>
       ))}
     </>
@@ -98,12 +159,20 @@ function TrackGeometry({ model }: { model: Scene3dModel }) {
     <>
       <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.04, centerZ]}>
         <planeGeometry args={[48, length]} />
-        <meshStandardMaterial color="#76a95f" />
+        <meshStandardMaterial color="#6fa857" />
       </mesh>
 
       <mesh position={[0, 0, centerZ]}>
         <boxGeometry args={[5.6, 0.18, length]} />
         <meshStandardMaterial color="#6d5a45" />
+      </mesh>
+      <mesh position={[-3.6, -0.01, centerZ]}>
+        <boxGeometry args={[1.5, 0.1, length]} />
+        <meshStandardMaterial color="#a3c973" />
+      </mesh>
+      <mesh position={[3.6, -0.01, centerZ]}>
+        <boxGeometry args={[1.5, 0.1, length]} />
+        <meshStandardMaterial color="#a3c973" />
       </mesh>
 
       <mesh position={[-0.72, 0.19, centerZ]}>
@@ -207,13 +276,49 @@ function CheckpointSignals({ model }: { model: Scene3dModel }) {
       })}
 
       {model.stationCue && model.stationCue.endZ > -45 && model.stationCue.startZ < model.horizonDistance && (
-        <group position={[-4.2, 0, toWorldZ((model.stationCue.startZ + model.stationCue.endZ) / 2)]}>
-          <mesh position={[0, 0.85, 0]}>
-            <boxGeometry args={[0.14, 1.7, Math.max(5, model.stationCue.endZ - model.stationCue.startZ)]} />
-            <meshStandardMaterial color={model.stationCue.completed ? "#10b981" : "#fb923c"} emissive={model.stationCue.completed ? "#064e3b" : "#7c2d12"} />
+        <>
+          <group position={[-4.2, 0, toWorldZ((model.stationCue.startZ + model.stationCue.endZ) / 2)]}>
+            <mesh position={[0, 0.85, 0]}>
+              <boxGeometry args={[0.14, 1.7, Math.max(5, model.stationCue.endZ - model.stationCue.startZ)]} />
+              <meshStandardMaterial color={model.stationCue.completed ? "#10b981" : "#fb923c"} emissive={model.stationCue.completed ? "#064e3b" : "#7c2d12"} />
+            </mesh>
+          </group>
+          <mesh
+            rotation={[-Math.PI / 2, 0, 0]}
+            position={[0, 0.02, toWorldZ((model.stationCue.startZ + model.stationCue.endZ) / 2)]}
+          >
+            <planeGeometry args={[6, Math.max(8, model.stationCue.endZ - model.stationCue.startZ)]} />
+            <meshStandardMaterial
+              color={model.stationCue.completed ? "#4ade80" : "#fdba74"}
+              transparent
+              opacity={model.stationCue.completed ? 0.28 : 0.42}
+              emissive={model.stationCue.completed ? "#14532d" : "#7c2d12"}
+            />
           </mesh>
-        </group>
+        </>
       )}
+    </>
+  );
+}
+
+function RouteCueBoards({ routeCues }: { routeCues: Scene3dRouteCue[] }) {
+  return (
+    <>
+      {routeCues.map((cue) => {
+        const x = cue.safeBranch === "main" ? -6.2 : 6.2;
+        return (
+          <group key={cue.id} position={[x, 0, toWorldZ(cue.z)]}>
+            <mesh position={[0, 2.1, 0]}>
+              <boxGeometry args={[1.9, 0.9, 0.15]} />
+              <meshStandardMaterial color={cue.urgency === "now" ? "#facc15" : "#93c5fd"} emissive={cue.urgency === "now" ? "#713f12" : "#1e3a8a"} />
+            </mesh>
+            <mesh position={[0, 1.2, 0]}>
+              <cylinderGeometry args={[0.08, 0.08, 2.3, 10]} />
+              <meshStandardMaterial color="#4b5563" />
+            </mesh>
+          </group>
+        );
+      })}
     </>
   );
 }
@@ -268,14 +373,17 @@ function CabShell({ model, helperMode, state }: { model: Scene3dModel; helperMod
     <>
       <PerspectiveCamera makeDefault fov={56} position={[0, 2.45, 10.6]} rotation={[-0.05, 0, 0]} />
       <color attach="background" args={["#87ceeb"]} />
-      <fog attach="fog" args={["#a9cfe8", 38, 220]} />
+      <fog attach="fog" args={["#9fc8e4", 36, 250]} />
       <ambientLight intensity={0.8} />
       <directionalLight intensity={0.9} position={[8, 14, 14]} castShadow={false} />
       <hemisphereLight args={["#e0f2fe", "#5b7b42", 0.7]} />
 
+      <SkyLayers clouds={model.clouds} ridges={model.ridges} />
       <TrackGeometry model={model} />
+      <BuildingField buildings={model.buildings} />
       <RepeaterField model={model} />
       <CheckpointSignals model={model} />
+      <RouteCueBoards routeCues={model.routeCues} />
       {model.landmarks.map((landmark) => (
         <LandmarkMesh key={landmark.id} landmark={landmark} />
       ))}
@@ -298,6 +406,14 @@ function CabShell({ model, helperMode, state }: { model: Scene3dModel; helperMod
           <boxGeometry args={[1.8, 0.3, 0.3]} />
           <meshStandardMaterial color={theme.noseColor} />
         </mesh>
+        <mesh position={[0, 2, 8.1]}>
+          <boxGeometry args={[7.4, 2.7, 0.4]} />
+          <meshStandardMaterial color={theme.trimColor} metalness={0.12} roughness={0.55} />
+        </mesh>
+        <mesh position={[0, 1.95, 7.92]}>
+          <boxGeometry args={[4.7, 1.8, 0.1]} />
+          <meshStandardMaterial color="#dbeafe" transparent opacity={0.24} />
+        </mesh>
         <mesh position={[-2.95, 0.2, 8.95]}>
           <boxGeometry args={[0.35, 1.2, 1.2]} />
           <meshStandardMaterial color={theme.trimColor} />
@@ -305,6 +421,14 @@ function CabShell({ model, helperMode, state }: { model: Scene3dModel; helperMod
         <mesh position={[2.95, 0.2, 8.95]}>
           <boxGeometry args={[0.35, 1.2, 1.2]} />
           <meshStandardMaterial color={theme.trimColor} />
+        </mesh>
+        <mesh position={[-1.1, 0.95, 8.15]}>
+          <cylinderGeometry args={[0.1, 0.1, 0.42, 12]} />
+          <meshStandardMaterial color="#334155" />
+        </mesh>
+        <mesh position={[1.1, 0.95, 8.15]}>
+          <cylinderGeometry args={[0.1, 0.1, 0.42, 12]} />
+          <meshStandardMaterial color="#334155" />
         </mesh>
       </MovingCabRig>
     </>

--- a/ui/partner-hub/lib/steam-trains/scene3d.test.ts
+++ b/ui/partner-hub/lib/steam-trains/scene3d.test.ts
@@ -85,4 +85,23 @@ describe("steam trains scene3d model", () => {
     assert.equal(Boolean(sleeperB), true);
     assert.notEqual(sleeperA?.z, sleeperB?.z);
   });
+
+  it("builds layered sky, terrain, and route hints for immersive driving", () => {
+    const train = getTrainDefinition("sunset-passenger");
+    const level = getLevelDefinition("level-5-fast-switches");
+    const state = {
+      ...createSimulation(train, level, "levels"),
+      train: {
+        ...createSimulation(train, level, "levels").train,
+        x: level.startX + 200,
+      },
+    };
+
+    const model = buildScene3dModel(state);
+    assert.equal(model.clouds.length > 0, true);
+    assert.equal(model.ridges.length > 0, true);
+    assert.equal(model.buildings.length > 0, true);
+    assert.equal(model.routeCues.length > 0, true);
+    assert.equal(model.routeCues[0]?.hintText.includes("track"), true);
+  });
 });

--- a/ui/partner-hub/lib/steam-trains/scene3d.ts
+++ b/ui/partner-hub/lib/steam-trains/scene3d.ts
@@ -48,6 +48,44 @@ export type Scene3dRepeater = {
   scale: number;
 };
 
+export type Scene3dCloud = {
+  id: string;
+  x: number;
+  y: number;
+  z: number;
+  scale: number;
+  depth: "near" | "far";
+};
+
+export type Scene3dRidge = {
+  id: string;
+  x: number;
+  y: number;
+  z: number;
+  width: number;
+  height: number;
+  depth: "near" | "far";
+};
+
+export type Scene3dBuilding = {
+  id: string;
+  x: number;
+  z: number;
+  width: number;
+  height: number;
+  depth: number;
+  color: string;
+  roofColor: string;
+};
+
+export type Scene3dRouteCue = {
+  id: string;
+  z: number;
+  safeBranch: TrackSwitchState;
+  hintText: string;
+  urgency: "upcoming" | "now";
+};
+
 export type Scene3dModel = {
   speedMph: number;
   nextRouteLabel: string;
@@ -58,6 +96,10 @@ export type Scene3dModel = {
   stationCue: Scene3dStationCue | null;
   landmarks: Scene3dLandmarkCue[];
   repeaters: Scene3dRepeater[];
+  clouds: Scene3dCloud[];
+  ridges: Scene3dRidge[];
+  buildings: Scene3dBuilding[];
+  routeCues: Scene3dRouteCue[];
 };
 
 const HUD_HORIZON_DISTANCE = 460;
@@ -112,28 +154,107 @@ const buildRepeaters = (state: SteamTrainsSimulationState): Scene3dRepeater[] =>
     scale: 1,
   }));
 
-  const poles = Array.from({ length: 22 }, (_, index) => ({
-    id: `pole-${index}`,
-    kind: "pole" as const,
-    x: -10.8,
-    z: repeatForwardZ(motion * 0.92 + index * 23, 23),
-    scale: 1,
-  }));
-
-  const trees = Array.from({ length: 30 }, (_, index) => {
+  const poles = Array.from({ length: 30 }, (_, index) => {
     const side = index % 2 === 0 ? -1 : 1;
-    const laneOffset = 16 + (index % 5) * 2.2;
+    return {
+      id: `pole-${index}`,
+      kind: "pole" as const,
+      x: side * 10.8,
+      z: repeatForwardZ(motion * 0.96 + index * 20, 20),
+      scale: side === -1 ? 1 : 0.94,
+    };
+  });
+
+  const trees = Array.from({ length: 42 }, (_, index) => {
+    const side = index % 2 === 0 ? -1 : 1;
+    const laneOffset = 15 + (index % 7) * 1.8 + (index % 3) * 0.7;
     return {
       id: `tree-${index}`,
       kind: "tree" as const,
       x: side * laneOffset,
-      z: repeatForwardZ(motion * 0.84 + index * 18, 18),
-      scale: 0.85 + (index % 4) * 0.14,
+      z: repeatForwardZ(motion * 0.86 + index * 14, 14),
+      scale: 0.78 + (index % 5) * 0.12,
     };
   });
 
   return [...sleepers, ...poles, ...trees];
 };
+
+const buildClouds = (state: SteamTrainsSimulationState): Scene3dCloud[] => {
+  const motion = state.train.x - state.level.startX;
+  return Array.from({ length: 16 }, (_, index) => {
+    const near = index % 2 === 0;
+    const spacing = near ? 96 : 128;
+    const drift = near ? motion * 0.09 : motion * 0.05;
+    const side = index % 3 === 0 ? -1 : 1;
+    return {
+      id: `cloud-${index}`,
+      x: side * (6 + (index % 5) * 4.2),
+      y: near ? 11 + (index % 4) * 0.9 : 13 + (index % 3) * 1.2,
+      z: repeatForwardZ(drift + index * spacing, spacing),
+      scale: near ? 1 + (index % 3) * 0.26 : 1.4 + (index % 4) * 0.18,
+      depth: near ? "near" : "far",
+    };
+  });
+};
+
+const buildRidges = (state: SteamTrainsSimulationState): Scene3dRidge[] => {
+  const motion = state.train.x - state.level.startX;
+  return Array.from({ length: 14 }, (_, index) => {
+    const near = index % 2 === 0;
+    const spacing = near ? 72 : 110;
+    const side = index % 3 === 0 ? -1 : 1;
+    return {
+      id: `ridge-${index}`,
+      x: side * (20 + (index % 4) * 7),
+      y: near ? 4.8 : 5.8,
+      z: repeatForwardZ((near ? motion * 0.34 : motion * 0.2) + index * spacing, spacing),
+      width: near ? 30 + (index % 4) * 5 : 40 + (index % 3) * 6,
+      height: near ? 9 + (index % 4) * 1.7 : 12 + (index % 4) * 2,
+      depth: near ? "near" : "far",
+    };
+  });
+};
+
+const buildBuildings = (state: SteamTrainsSimulationState): Scene3dBuilding[] => {
+  const motion = state.train.x - state.level.startX;
+  const density = state.level.scene === "station" || state.level.scene === "yard" ? 10 : 6;
+  return Array.from({ length: density }, (_, index) => {
+    const side = index % 2 === 0 ? -1 : 1;
+    const palette =
+      index % 3 === 0
+        ? { wall: "#cbd5e1", roof: "#64748b" }
+        : index % 3 === 1
+          ? { wall: "#d6d3d1", roof: "#57534e" }
+          : { wall: "#bfdbfe", roof: "#475569" };
+
+    return {
+      id: `building-${index}`,
+      x: side * (14 + (index % 4) * 4),
+      z: repeatForwardZ(motion * 0.5 + index * 62, 62),
+      width: 4 + (index % 3) * 1.3,
+      height: 2.2 + (index % 4) * 0.6,
+      depth: 3.6 + (index % 2) * 1.8,
+      color: palette.wall,
+      roofColor: palette.roof,
+    };
+  });
+};
+
+const buildRouteCues = (state: SteamTrainsSimulationState): Scene3dRouteCue[] =>
+  state.level.checkpoints
+    .slice(state.nextCheckpointIndex, state.nextCheckpointIndex + 2)
+    .map((checkpoint) => {
+      const z = toForwardZ(state.train.x, checkpoint.x);
+      return {
+        id: `route-cue-${checkpoint.id}`,
+        z,
+        safeBranch: checkpoint.safeBranch,
+        hintText: checkpoint.safeBranch === "main" ? "Top track is safe" : "Side track is safe",
+        urgency: z < 140 ? ("now" as const) : ("upcoming" as const),
+      };
+    })
+    .filter((cue) => cue.z >= WORLD_NEAR_Z && cue.z <= HUD_HORIZON_DISTANCE);
 
 const buildRoutePreviews = (state: SteamTrainsSimulationState): Scene3dTrackPreview[] =>
   state.level.checkpoints
@@ -229,5 +350,9 @@ export const buildScene3dModel = (state: SteamTrainsSimulationState): Scene3dMod
     stationCue,
     landmarks: buildLandmarks(state),
     repeaters: buildRepeaters(state),
+    clouds: buildClouds(state),
+    ridges: buildRidges(state),
+    buildings: buildBuildings(state),
+    routeCues: buildRouteCues(state),
   };
 };


### PR DESCRIPTION
### Motivation
- Make the 3D cab view feel modern, believable, and joyful for a child by adding layered depth, richer roadside scenery, clearer route and station cues, and subtle cab framing details while preserving the simple controls and builder/workshop flow.
- Improve forward motion and route readability so the child clearly feels like they are driving through a place and can understand upcoming choices and station stops.

### Description
- Extended the scene model with new types and data producers: `Scene3dCloud`, `Scene3dRidge`, `Scene3dBuilding`, and `Scene3dRouteCue`, and wired them into `buildScene3dModel` in `ui/partner-hub/lib/steam-trains/scene3d.ts` (new builders: `buildClouds`, `buildRidges`, `buildBuildings`, `buildRouteCues`) and increased repeater density/variation for poles and trees.
- Upgraded the cab renderer in `ui/partner-hub/components/steam-trains/train-cab-3d.tsx` with `SkyLayers`, `BuildingField`, `RouteCueBoards`, stronger station stop surface overlay, improved ground shoulders and track accents, and added simple interior/window framing and dashboard sill details to increase inside-the-train presence.
- Added small HUD hints in `ui/partner-hub/components/steam-trains/steam-trains-tool.tsx` showing a short route hint and station distance while keeping large GO/SLOW/STOP and Steam Puff/Whistle actions unchanged.
- Added a focused scene test in `ui/partner-hub/lib/steam-trains/scene3d.test.ts` that asserts layered sky/ridge/building/route cue generation so the polish pass has regression coverage.

### Testing
- Ran `npm test` from `ui/partner-hub` and all steam-trains-related tests passed (full test run: 195 tests, 53 suites, 195 passed, 0 failed).
- Ran `npm run typecheck` and `npm run build` but both failed to complete in this environment because `@react-three/drei` and `@react-three/fiber` could not be installed/resolved (attempted `npm install` returned `403 Forbidden` from the registry), so compile/typecheck of the 3D React components is blocked by the environment's package access policy.
- The patch was committed on branch `codex/steam-trains-3d-world-polish` with commit message "Polish Steam Trains 3D world and cab driving feel".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7e8ecfd348330a056dddb19f87a92)