### PR TITLE
Fix Steam Trains 3D world spacing and depth distribution

### DIFF
--- a/ui/partner-hub/lib/steam-trains/scene3d.test.ts
+++ b/ui/partner-hub/lib/steam-trains/scene3d.test.ts
@@ -6,6 +6,12 @@ import { getLevelDefinition } from "./levels";
 import { buildCabTheme, buildScene3dModel } from "./scene3d";
 import { getTrainDefinition } from "./trainCatalog";
 
+const getZSpread = (values: number[]) => {
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  return { min, max, span: max - min };
+};
+
 describe("steam trains scene3d model", () => {
   it("builds cab theme using selected train colors and consist weight", () => {
     const lightTheme = buildCabTheme(getTrainDefinition("copper-creek-switcher"));
@@ -63,7 +69,7 @@ describe("steam trains scene3d model", () => {
     assert.equal(hasBridgeOrTunnel, true);
   });
 
-  it("moves repeaters toward and past the camera as train progresses", () => {
+  it("distributes repeater families across depth and moves stable ids with progress", () => {
     const train = getTrainDefinition("copper-creek-switcher");
     const level = getLevelDefinition("level-2-two-routes");
     const stateA = createSimulation(train, level, "levels");
@@ -78,24 +84,31 @@ describe("steam trains scene3d model", () => {
     const modelA = buildScene3dModel(stateA);
     const modelB = buildScene3dModel(stateB);
 
-    const sleeperA = modelA.repeaters.find((item) => item.id === "sleeper-0");
-    const sleeperB = modelB.repeaters.find((item) => item.id === "sleeper-0");
+    const families = ["sleeper", "pole", "tree"] as const;
+    families.forEach((kind) => {
+      const zValues = modelA.repeaters.filter((item) => item.kind === kind).map((item) => item.z);
+      const distinct = new Set(zValues.map((value) => value.toFixed(2)));
+      const spread = getZSpread(zValues);
+      assert.equal(distinct.size > 4, true);
+      assert.equal(spread.min <= -80, true);
+      assert.equal(spread.max >= 260, true);
+    });
 
-    assert.equal(Boolean(sleeperA), true);
-    assert.equal(Boolean(sleeperB), true);
-    assert.notEqual(sleeperA?.z, sleeperB?.z);
+    const stableIds = ["sleeper-0", "pole-0", "tree-0"];
+    stableIds.forEach((id) => {
+      const repeaterA = modelA.repeaters.find((item) => item.id === id);
+      const repeaterB = modelB.repeaters.find((item) => item.id === id);
+      assert.equal(Boolean(repeaterA), true);
+      assert.equal(Boolean(repeaterB), true);
+      assert.notEqual(repeaterA?.z, repeaterB?.z);
+    });
   });
 
-  it("builds layered sky, terrain, and route hints for immersive driving", () => {
+  it("spreads clouds, ridges, and buildings across near/far forward depth", () => {
     const train = getTrainDefinition("sunset-passenger");
     const level = getLevelDefinition("level-5-fast-switches");
-    const state = {
-      ...createSimulation(train, level, "levels"),
-      train: {
-        ...createSimulation(train, level, "levels").train,
-        x: level.startX + 200,
-      },
-    };
+    const initial = createSimulation(train, level, "levels");
+    const state = { ...initial, train: { ...initial.train, x: level.startX + 200 } };
 
     const model = buildScene3dModel(state);
     assert.equal(model.clouds.length > 0, true);
@@ -103,5 +116,24 @@ describe("steam trains scene3d model", () => {
     assert.equal(model.buildings.length > 0, true);
     assert.equal(model.routeCues.length > 0, true);
     assert.equal(model.routeCues[0]?.hintText.includes("track"), true);
+
+    const cloudSpread = getZSpread(model.clouds.map((cloud) => cloud.z));
+    const ridgeSpread = getZSpread(model.ridges.map((ridge) => ridge.z));
+    const buildingSpread = getZSpread(model.buildings.map((building) => building.z));
+    assert.equal(cloudSpread.span >= 250, true);
+    assert.equal(ridgeSpread.span >= 250, true);
+    assert.equal(buildingSpread.span >= 250, true);
+
+    const cloudDepths = new Set(model.clouds.map((cloud) => cloud.depth));
+    const ridgeDepths = new Set(model.ridges.map((ridge) => ridge.depth));
+    assert.deepEqual(cloudDepths, new Set(["near", "far"]));
+    assert.deepEqual(ridgeDepths, new Set(["near", "far"]));
+
+    assert.equal(model.clouds.some((cloud) => cloud.z <= -50), true);
+    assert.equal(model.clouds.some((cloud) => cloud.z >= 220), true);
+    assert.equal(model.ridges.some((ridge) => ridge.z <= -50), true);
+    assert.equal(model.ridges.some((ridge) => ridge.z >= 220), true);
+    assert.equal(model.buildings.some((building) => building.z <= -50), true);
+    assert.equal(model.buildings.some((building) => building.z >= 220), true);
   });
 });

--- a/ui/partner-hub/lib/steam-trains/scene3d.ts
+++ b/ui/partner-hub/lib/steam-trains/scene3d.ts
@@ -114,8 +114,8 @@ const clamp01 = (value: number) => Math.max(0, Math.min(1, value));
 
 const toForwardZ = (trainX: number, worldX: number) => worldX - trainX;
 
-const repeatForwardZ = (offset: number, spacing: number) => {
-  const wrapped = ((offset % spacing) + spacing) % spacing;
+const repeatForwardZ = (offset: number, cycleLength: number) => {
+  const wrapped = ((offset % cycleLength) + cycleLength) % cycleLength;
   return WORLD_NEAR_Z + wrapped;
 };
 
@@ -150,28 +150,34 @@ export const buildCabTheme = (train: TrainDefinition): CabTheme => {
 
 const buildRepeaters = (state: SteamTrainsSimulationState): Scene3dRepeater[] => {
   const motion = state.train.x - state.level.startX;
+  const sleeperSpacing = 7.8;
+  const sleeperCycleLength = sleeperSpacing * 56;
 
   const sleepers = Array.from({ length: 56 }, (_, index) => ({
     id: `sleeper-${index}`,
     kind: "sleeper" as const,
     x: 0,
-    z: repeatForwardZ(motion + index * 7.8, 7.8),
+    z: repeatForwardZ(motion + index * sleeperSpacing, sleeperCycleLength),
     scale: 1,
     variant: index % 4,
   }));
 
+  const poleSpacing = 20;
+  const poleCycleLength = poleSpacing * 30;
   const poles = Array.from({ length: 30 }, (_, index) => {
     const side = index % 2 === 0 ? -1 : 1;
     return {
       id: `pole-${index}`,
       kind: "pole" as const,
       x: side * 10.8,
-      z: repeatForwardZ(motion * 0.96 + index * 20, 20),
+      z: repeatForwardZ(motion * 0.96 + index * poleSpacing, poleCycleLength),
       scale: side === -1 ? 1 : 0.94,
       variant: index % 3,
     };
   });
 
+  const treeSpacing = 9.5;
+  const treeCycleLength = treeSpacing * 84;
   const trees = Array.from({ length: 84 }, (_, index) => {
     const side = index % 2 === 0 ? -1 : 1;
     const laneOffset = 14 + (index % 9) * 1.9 + (index % 3) * 0.7;
@@ -179,7 +185,7 @@ const buildRepeaters = (state: SteamTrainsSimulationState): Scene3dRepeater[] =>
       id: `tree-${index}`,
       kind: "tree" as const,
       x: side * laneOffset,
-      z: repeatForwardZ(motion * 0.86 + index * 9.5, 9.5),
+      z: repeatForwardZ(motion * 0.86 + index * treeSpacing, treeCycleLength),
       scale: 0.72 + (index % 6) * 0.11,
       variant: index % 5,
     };
@@ -190,16 +196,19 @@ const buildRepeaters = (state: SteamTrainsSimulationState): Scene3dRepeater[] =>
 
 const buildClouds = (state: SteamTrainsSimulationState): Scene3dCloud[] => {
   const motion = state.train.x - state.level.startX;
+  const cloudsPerDepth = 8;
   return Array.from({ length: 16 }, (_, index) => {
     const near = index % 2 === 0;
     const spacing = near ? 96 : 128;
     const drift = near ? motion * 0.09 : motion * 0.05;
+    const layerIndex = Math.floor(index / 2);
+    const cycleLength = spacing * cloudsPerDepth;
     const side = index % 3 === 0 ? -1 : 1;
     return {
       id: `cloud-${index}`,
       x: side * (6 + (index % 5) * 4.2),
       y: near ? 11 + (index % 4) * 0.9 : 13 + (index % 3) * 1.2,
-      z: repeatForwardZ(drift + index * spacing, spacing),
+      z: repeatForwardZ(drift + layerIndex * spacing, cycleLength),
       scale: near ? 1 + (index % 3) * 0.26 : 1.4 + (index % 4) * 0.18,
       depth: near ? "near" : "far",
     };
@@ -208,15 +217,18 @@ const buildClouds = (state: SteamTrainsSimulationState): Scene3dCloud[] => {
 
 const buildRidges = (state: SteamTrainsSimulationState): Scene3dRidge[] => {
   const motion = state.train.x - state.level.startX;
+  const ridgesPerDepth = 7;
   return Array.from({ length: 14 }, (_, index) => {
     const near = index % 2 === 0;
     const spacing = near ? 72 : 110;
     const side = index % 3 === 0 ? -1 : 1;
+    const layerIndex = Math.floor(index / 2);
+    const cycleLength = spacing * ridgesPerDepth;
     return {
       id: `ridge-${index}`,
       x: side * (20 + (index % 4) * 7),
       y: near ? 4.8 : 5.8,
-      z: repeatForwardZ((near ? motion * 0.34 : motion * 0.2) + index * spacing, spacing),
+      z: repeatForwardZ((near ? motion * 0.34 : motion * 0.2) + layerIndex * spacing, cycleLength),
       width: near ? 30 + (index % 4) * 5 : 40 + (index % 3) * 6,
       height: near ? 9 + (index % 4) * 1.7 : 12 + (index % 4) * 2,
       depth: near ? "near" : "far",
@@ -229,6 +241,8 @@ const buildRidges = (state: SteamTrainsSimulationState): Scene3dRidge[] => {
 const buildBuildings = (state: SteamTrainsSimulationState): Scene3dBuilding[] => {
   const motion = state.train.x - state.level.startX;
   const density = state.level.scene === "station" || state.level.scene === "yard" ? 10 : 6;
+  const buildingSpacing = 62;
+  const buildingCycleLength = buildingSpacing * density;
   return Array.from({ length: density }, (_, index) => {
     const side = index % 2 === 0 ? -1 : 1;
     const palette =
@@ -241,7 +255,7 @@ const buildBuildings = (state: SteamTrainsSimulationState): Scene3dBuilding[] =>
     return {
       id: `building-${index}`,
       x: side * (14 + (index % 4) * 4),
-      z: repeatForwardZ(motion * 0.5 + index * 62, 62),
+      z: repeatForwardZ(motion * 0.5 + index * buildingSpacing, buildingCycleLength),
       width: 4 + (index % 3) * 1.3,
       height: 2.2 + (index % 4) * 0.6,
       depth: 3.6 + (index % 2) * 1.8,


### PR DESCRIPTION
### Motivation
- The scene generator was collapsing repeated families because `index * spacing` was being canceled by the modulo helper, producing many objects in the same Z band and destroying depth perception. 
- The intent is to preserve per-family index offsets while keeping motion/parallax tied to train progress and without touching the 3D cab view or HUD architecture. 
- This change focuses on correctness of world-layout math so scenic layers and repeaters span meaningful forward depth.

### Description
- Reworked the repeat helper to accept a family `cycleLength` and wrap across that cycle, changing `repeatForwardZ(offset, spacing)` to `repeatForwardZ(offset, cycleLength)` so item spacing is preserved instead of modulo-canceled. 
- Distributed repeater families (sleepers, poles, trees) by computing `spacing` and `cycleLength = spacing * familyCount`, and used `repeatForwardZ(motion [+ parallax] + index * spacing, cycleLength)` so families span a full depth cycle while keeping per-id motion tied to `state.train.x`. 
- Spread scenic layers (clouds, ridges, buildings) across per-layer cycles using a layer index (e.g., `Math.floor(index / 2)`) and `cycleLength = spacing * itemsPerLayer`, preserving near/far parallax multipliers to retain slower background motion. 
- Preserved stable ids for all repeaters and scenic items so the same id moves predictably with train progress. 
- Added/strengthened tests in `scene3d.test.ts` to assert multi-Z distribution, near/far coverage across visible range, and that stable ids change Z as train progress changes. 
- Files changed: `ui/partner-hub/lib/steam-trains/scene3d.ts` (math + distribution changes) and `ui/partner-hub/lib/steam-trains/scene3d.test.ts` (new assertions and helpers).

### Testing
- Ran `npm test` from `ui/partner-hub` and full suite passed (TAP summary line): `# pass 195`.
- Ran `git fetch origin main` which failed in this environment with: `fatal: 'origin' does not appear to be a git repository`.
- Created branch with `git checkout -b codex/steam-trains-3d-world-distribution-fix` which returned: `Switched to a new branch 'codex/steam-trains-3d-world-distribution-fix'`.
- Committed changes with `git commit -m "Fix Steam Trains 3D world spacing and depth distribution"` which returned: `[codex/steam-trains-3d-world-distribution-fix 81f8a6a] Fix Steam Trains 3D world spacing and depth distribution\n 2 files changed, 69 insertions(+), 23 deletions(-)`.
- `npm run typecheck` in this environment reported unresolved `@react-three/*` and `three` imports and JSX intrinsic typing errors in `components/steam-trains/train-cab-3d.tsx` so typecheck failed (environment dependency issue). 
- `npm run build` failed in this environment with webpack module resolution errors for `@react-three/drei`, `@react-three/fiber`, and `three` (missing modules in this runner). 

Explicit confirmation: the repeater and scenery distribution now wrap over full family/layer cycle lengths so `index * spacing` is preserved as a real forward offset and not canceled by modulo, resulting in world elements (sleepers, poles, trees, clouds, ridges, buildings) spanning meaningful forward depth instead of collapsing into the same Z band.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7edc26d308330b0af60eae55e4d38)