### PR TITLE
Isolate Steam Trains 3D cab from prerender

### DIFF
--- a/ui/partner-hub/components/steam-trains/steam-trains-tool.tsx
+++ b/ui/partner-hub/components/steam-trains/steam-trains-tool.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import dynamic from "next/dynamic";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -49,12 +50,40 @@ import {
 import type { GameMode, SteamTrainsSimulationState, TrackSwitchState } from "@/lib/steam-trains/types";
 
 import { TrainBuilder } from "./train-builder";
-import { TrainCab3D } from "./train-cab-3d";
 import { TrainShowroom } from "./train-showroom";
 
 const INACTIVITY_HELPER_MS = 2600;
 
 type ToolView = "play" | "workshop";
+
+function TrainCabLoadingShell() {
+  return (
+    <div
+      className="overflow-hidden rounded-2xl border bg-gradient-to-b from-slate-900 via-slate-800 to-slate-900 p-5 text-slate-100 shadow-inner"
+      role="status"
+      aria-live="polite"
+      aria-label="Loading train cab"
+    >
+      <div className="space-y-3">
+        <p className="text-lg font-bold">Loading cab controls…</p>
+        <div className="h-3 w-2/3 animate-pulse rounded-full bg-slate-600/70" />
+        <div className="h-40 animate-pulse rounded-xl border border-slate-700/80 bg-slate-800/60" />
+        <p className="text-sm font-semibold text-slate-300">Preparing the 3D driving view.</p>
+      </div>
+    </div>
+  );
+}
+
+const TrainCab3D = dynamic<{
+  state: SteamTrainsSimulationState;
+  helperMode: boolean;
+}>(
+  () => import("./train-cab-3d").then((mod) => mod.TrainCab3D),
+  {
+    ssr: false,
+    loading: () => <TrainCabLoadingShell />,
+  },
+);
 
 const createState = (mode: GameMode, levelOrder: number, trainId: string) => {
   const fallback = STEAM_TRAINS_LEVELS[0];


### PR DESCRIPTION
### Motivation
- The Steam Trains Play view statically imported `train-cab-3d` which pulls in `@react-three/*` and made the 3D cab module server-reachable during Next.js prerender, causing the build-time `ReactCurrentBatchConfig` crash.
- The goal is to keep the 3D cab behaviour identical while preventing browser-only 3D rendering code from entering SSR/prerender paths.

### Description
- Replaced the static `import { TrainCab3D } from "./train-cab-3d"` with a `next/dynamic` client-only import (`ssr: false`) in `ui/partner-hub/components/steam-trains/steam-trains-tool.tsx` so the module is only loaded in the browser. 
- Added a small polished `TrainCabLoadingShell` component used as the `loading` fallback for the dynamic import so the Play area presents an intentional UI while the 3D cab hydrates. 
- Preserved the existing `TrainCab3D` prop contract (`state: SteamTrainsSimulationState`, `helperMode: boolean`) and left the Play/Workshop split intact so no runtime behavior or saved-train data is changed. 
- Searched the Steam Trains area for other direct server-reachable 3D imports and confirmed the only server-reachable import that needed isolation was the cab import path which is now isolated.

### Testing
- Ran `npm install` in `ui/partner-hub`; install failed in this environment with a filesystem/rename/registry error as captured below:
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
npm error code ENOTEMPTY
npm error syscall rename
npm error path /workspace/accountlist/ui/partner-hub/node_modules/eslint-import-resolver-node
npm error dest /workspace/accountlist/ui/partner-hub/node_modules/.eslint-import-resolver-node-GvgPQ2ez
npm error errno -39
npm error ENOTEMPTY: directory not empty, rename '/workspace/accountlist/ui/partner-hub/node_modules/eslint-import-resolver-node' -> '/workspace/accountlist/ui/partner-hub/node_modules/.eslint-import-resolver-node-GvgPQ2ez'
npm error A complete log of this run can be found in: /root/.npm/_logs/2026-03-28T16_13_24_432Z-debug-0.log
``` 
- Ran `npm run typecheck` in `ui/partner-hub`; typecheck failed because dependencies (type packages) were not present in the environment, producing repeated `TS2688: Cannot find type definition file` errors (excerpt):
```
> partner-hub@0.0.1 typecheck
> tsc --noEmit

error TS2688: Cannot find type definition file for 'd3'.
error TS2688: Cannot find type definition file for 'd3-array'.
...
error TS2688: Cannot find type definition file for 'react'.
error TS2688: Cannot find type definition file for 'three'.
error TS2688: Cannot find type definition file for 'webxr'.
``` 
- Ran `npm test` in `ui/partner-hub`; the test run failed for the same missing type-definition reasons (excerpt):
```
> partner-hub@0.0.1 test
> tsc --noEmit false ... && node --test ...

error TS2688: Cannot find type definition file for 'd3'.
error TS2688: Cannot find type definition file for 'd3-array'.
...
error TS2688: Cannot find type definition file for 'webxr'.
``` 
- Ran `npm run build` in `ui/partner-hub`; build could not complete in this environment because `prisma` was not available (excerpt):
```
> partner-hub@0.0.1 prebuild
> npm run prisma:generate

> partner-hub@0.0.1 prisma:generate
> prisma generate --schema=./prisma/schema.prisma

sh: 1: prisma: not found
``` 
- Confirmation status: the code change to isolate the 3D cab from prerender has been committed to branch `codex/fix-steam-trains-prerender-cab`, but full local verification of `npm install`, `npm run typecheck`, `npm test` and `npm run build` could not be completed in this execution environment due to dependency installation and environment restrictions shown above.

Files changed:
- ui/partner-hub/components/steam-trains/steam-trains-tool.tsx

This patch follows the requested implementation (dynamic client-only import with `ssr: false` and a polished loading shell) and is production-safe because it uses the recommended Next.js client boundary to keep browser-only 3D rendering out of prerender paths while keeping runtime behavior and prop contracts unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7fcd44c808330bb725697dad7d73e)