### PR TITLE
Refine HPC Lab Phase 1 scaffold labels and documentation

### DIFF
--- a/ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx
+++ b/ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx
@@ -5,7 +5,14 @@ import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { HPC_LAB_PRESETS } from "@/lib/hpc-lab/presets";
-import { HPC_LAB_PANEL_KEYS, type HpcLabConfig, type HpcLabPanelKey, type HpcLabPresetId } from "@/lib/hpc-lab/types";
+import {
+  HPC_LAB_PANEL_KEYS,
+  type HpcLabConfig,
+  type HpcLabFileSizeDistribution,
+  type HpcLabPanelKey,
+  type HpcLabPresetId,
+  type HpcLabWorkloadType,
+} from "@/lib/hpc-lab/types";
 
 const panelTitles: Record<HpcLabPanelKey, string> = {
   "cluster-topology": "Cluster topology",
@@ -19,10 +26,24 @@ const panelTitles: Record<HpcLabPanelKey, string> = {
   "bottleneck-attribution": "Bottleneck attribution",
 };
 
+const workloadTypeLabels: Record<HpcLabWorkloadType, string> = {
+  "traditional-hpc": "Traditional HPC",
+  "distributed-ai-training": "Distributed AI Training",
+  "metadata-heavy": "Metadata Heavy",
+};
+
+const fileSizeDistributionLabels: Record<HpcLabFileSizeDistribution, string> = {
+  "large-sequential": "Large Sequential",
+  mixed: "Mixed",
+  "small-random": "Small Random",
+};
+
 const controlRows: Array<{ label: string; key: keyof HpcLabConfig }> = [
   { label: "Compute nodes", key: "computeNodes" },
   { label: "GPU nodes", key: "gpuNodes" },
-  { label: "OSS / OST", key: "ossCount" },
+  { label: "OSS count", key: "ossCount" },
+  { label: "OST per OSS", key: "ostPerOss" },
+  { label: "Total OSTs", key: "ostPerOss" },
   { label: "Stripe width", key: "stripeWidth" },
   { label: "Metadata latency", key: "metadataLatencyMs" },
   { label: "Network bandwidth", key: "networkBandwidthGbps" },
@@ -91,15 +112,19 @@ export function HpcLabTool() {
             {controlRows.map((row) => {
               const value = selectedPreset.initialConfig[row.key];
               const formatted =
-                row.key === "metadataLatencyMs"
-                  ? `${value} ms`
-                  : row.key === "networkBandwidthGbps"
-                    ? `${value} Gbps`
-                    : row.key === "checkpointFrequencyMinutes"
-                      ? `${value} minutes`
-                      : row.key === "ossCount"
-                        ? `${selectedPreset.initialConfig.ossCount} OSS / ${selectedPreset.initialConfig.ossCount * selectedPreset.initialConfig.ostPerOss} OST`
-                        : String(value);
+                row.label === "Total OSTs"
+                  ? selectedPreset.initialConfig.ossCount * selectedPreset.initialConfig.ostPerOss
+                  : row.key === "metadataLatencyMs"
+                    ? `${value} ms`
+                    : row.key === "networkBandwidthGbps"
+                      ? `${value} Gbps`
+                      : row.key === "checkpointFrequencyMinutes"
+                        ? `${value} minutes`
+                        : row.key === "workloadType"
+                          ? workloadTypeLabels[value]
+                          : row.key === "fileSizeDistribution"
+                            ? fileSizeDistributionLabels[value]
+                            : String(value);
 
               return (
                 <div key={row.label} className="flex items-start justify-between gap-4 rounded-md border border-border/60 bg-muted/20 px-3 py-2">

--- a/ui/partner-hub/docs/hpc-lab.md
+++ b/ui/partner-hub/docs/hpc-lab.md
@@ -40,6 +40,8 @@ When the flag is not set to `"true"`, `/hpc-lab` renders a disabled message card
 This separation keeps simulation concerns independent from UI presentation and is designed for a later engine module.
 
 ## Planned later phases
-- Phase 2: implement simulation engine and connect outputs to observability panels.
-- Phase 3: add richer interaction controls, parameter validation, and scenario comparison workflows.
-- Phase 4: introduce persisted scenarios and optional export/reporting capabilities.
+- Phase 2: simulation engine core + types.
+- Phase 3: controls panel + state wiring.
+- Phase 4: visualization layer + topology + charts.
+- Phase 5: workload presets + metrics + bottleneck attribution.
+- Phase 6: polish, validation, tests, docs updates.

--- a/ui/partner-hub/lib/hpc-lab/presets.ts
+++ b/ui/partner-hub/lib/hpc-lab/presets.ts
@@ -39,7 +39,7 @@ export const HPC_LAB_PRESETS: readonly HpcLabPreset[] = [
   },
   {
     id: "small-file",
-    name: "Small File Stress",
+    name: "Small File Workload",
     description: "Metadata-sensitive profile for many small random I/O operations and high job concurrency.",
     initialConfig: {
       computeNodes: 80,


### PR DESCRIPTION
### Motivation
- Align the Phase 1 HPC Lab scaffold with the agreed contract for preset naming, UI labels, storage clarity, and phased roadmap. 
- Show user-facing labels in the UI rather than raw internal enum strings to improve clarity while preserving internal types and IDs. 
- Make storage display explicit (OSS count, OST per OSS, total OSTs) in the scaffold without introducing editable controls or engine wiring. 

### Description
- Changed the `small-file` preset display name from `"Small File Stress"` to `"Small File Workload"` while preserving the `small-file` preset id and description in `ui/partner-hub/lib/hpc-lab/presets.ts`.
- Added display-label maps for workload and file-size enums and used them in the UI so internal values (e.g. `traditional-hpc`, `distributed-ai-training`, `metadata-heavy`, `large-sequential`, `mixed`, `small-random`) render as friendly labels (e.g. `Traditional HPC`, `Distributed AI Training`, `Metadata Heavy`, `Large Sequential`, `Mixed`, `Small Random`) in `ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx`.
- Replaced the single ambiguous `OSS / OST` control row with explicit read-only rows: `OSS count`, `OST per OSS`, and `Total OSTs` (computed display) in `ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx` without introducing editable controls.
- Updated the docs `ui/partner-hub/docs/hpc-lab.md` to replace the previous “Planned later phases” block with the agreed Phase 2–6 plan: `Phase 2: simulation engine core + types.`, `Phase 3: controls panel + state wiring.`, `Phase 4: visualization layer + topology + charts.`, `Phase 5: workload presets + metrics + bottleneck attribution.`, `Phase 6: polish, validation, tests, docs updates.`

### Testing
- Ran `cd ui/partner-hub && npm run lint` and it failed in this environment due to missing `next` binary; exact observed output:
  - `npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.`
  - `> partner-hub@0.0.1 lint`
  - `> next lint`
  - `sh: 1: next: not found`
- Ran `cd ui/partner-hub && npm run typecheck` and TypeScript type-checking failed in this environment due to unresolved dependencies and ambient types; initial observed output lines include:
  - `npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.`
  - `> partner-hub@0.0.1 typecheck`
  - `> tsc --noEmit`
  - `app/(routes)/about/page.tsx(1,18): error TS2307: Cannot find module 'next/link' or its corresponding type declarations.`
  - `app/(routes)/hpc-lab/page.tsx(3,23): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try \`npm i --save-dev @types/node\`.`
  - Additional TS diagnostics followed across project files (environment lacks node_modules/typed deps required to pass full typecheck).
- Ran `cd ui/partner-hub && npm test` and the test harness failed for the same environment reasons; initial observed output lines include:
  - `npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.`
  - `> partner-hub@0.0.1 test`
  - `> tsc --noEmit false --module commonjs --moduleResolution node --target ES2020 --outDir .tmp-tests --rootDir . ... && node --test ...`
  - `components/ui/comboboxUtils.test.ts(1,30): error TS2307: Cannot find module 'node:test' or its corresponding type declarations.`
  - `lib/hpc-lab/presets.test.ts(1,20): error TS2307: Cannot find module 'node:assert/strict' or its corresponding type declarations.`
  - Additional test compile/runtime errors followed due to missing environment deps and types.

Files changed
- `ui/partner-hub/lib/hpc-lab/presets.ts`
- `ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx`
- `ui/partner-hub/docs/hpc-lab.md`

Notes and confirmations
- Preset ids were not changed and remain exactly: `classic-hpc`, `ai-training`, `small-file`.
- No routing changes were made; `/hpc-lab` route, feature-flag gating, left-nav and home-page visibility behaviors are preserved.
- The updates are UI/documentation-only for Phase 1; the simulation engine is still not implemented and remains Phase 2 work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d684d08cf48330b60a9132df489cd3)