### PR TITLE
Refine HPC Lab simulation progress to use effective work accounting

### DIFF
--- a/ui/partner-hub/docs/hpc-lab.md
+++ b/ui/partner-hub/docs/hpc-lab.md
@@ -18,9 +18,17 @@ Included in Phase 2:
 - Network model core for throughput capping, utilization, and contention signals.
 - Top-level pure API: `simulateHpcLab(config, options?)`.
 
+- Engine now applies deterministic, per-job effective-work progress each tick (fractional progress is supported), rather than advancing jobs by a flat +1 runtime tick.
+- Effective progress now reflects modeled bottlenecks:
+  - `traditional-hpc`: strongly scaled by delivered data ratio.
+  - `distributed-ai-training`: scaled by delivered data ratio and reduced during checkpoint pause intervals.
+  - `metadata-heavy`: strongly scaled by metadata service ratio and wait-on-data conditions.
+- Checkpoint ticks now influence both write pressure metrics and useful progress, so checkpointing affects completion timing and queue dynamics.
+- Jobs admitted on a tick are eligible to accrue useful progress on that same tick.
+
 ## What remains out of scope after Phase 2
-- Interactive controls wiring and stateful simulation execution in the UI (Phase 3).
-- Visualization layer (charts/topology rendering) and panel population (Phase 4).
+- Interactive controls wiring and stateful simulation execution in the UI (Phase 3, still deferred).
+- Visualization layer (charts/topology rendering) and panel population (Phase 4, still deferred).
 - User-facing bottleneck attribution labels (planned later).
 
 ## Feature flag

--- a/ui/partner-hub/lib/hpc-lab/engine.test.ts
+++ b/ui/partner-hub/lib/hpc-lab/engine.test.ts
@@ -14,36 +14,55 @@ test("identical config and options produce identical simulation results", () => 
   assert.deepEqual(first, second);
 });
 
-test("lower network bandwidth lowers achieved throughput for the same workload", () => {
+test("lower network bandwidth lowers throughput and completed work over the same horizon", () => {
   const base = { ...HPC_LAB_PRESETS[0].initialConfig, concurrentJobs: 12 };
   const high = simulateHpcLab({ ...base, networkBandwidthGbps: 300 }, { totalTicks: 30 });
   const low = simulateHpcLab({ ...base, networkBandwidthGbps: 40 }, { totalTicks: 30 });
 
+  const highWork = high.jobs.reduce((sum, job) => sum + job.completedWorkTicks, 0);
+  const lowWork = low.jobs.reduce((sum, job) => sum + job.completedWorkTicks, 0);
+
   assert.equal(low.summary.avgDeliveredReadGbps + low.summary.avgDeliveredWriteGbps < high.summary.avgDeliveredReadGbps + high.summary.avgDeliveredWriteGbps, true);
+  assert.equal(lowWork < highWork || low.summary.totalCompletedJobs < high.summary.totalCompletedJobs, true);
 });
 
-test("higher metadata latency worsens metadata service for small-file behavior", () => {
+test("higher metadata latency worsens metadata-heavy completion behavior", () => {
   const base = { ...HPC_LAB_PRESETS[2].initialConfig, concurrentJobs: 16 };
   const fast = simulateHpcLab({ ...base, metadataLatencyMs: 1.2 }, { totalTicks: 30 });
   const slow = simulateHpcLab({ ...base, metadataLatencyMs: 4.2 }, { totalTicks: 30 });
 
-  assert.equal(slow.summary.avgMetadataUtilization >= fast.summary.avgMetadataUtilization, true);
+  const fastWork = fast.jobs.reduce((sum, job) => sum + job.completedWorkTicks, 0);
+  const slowWork = slow.jobs.reduce((sum, job) => sum + job.completedWorkTicks, 0);
+
   assert.equal(slow.summary.avgWaitOnDataRatio >= fast.summary.avgWaitOnDataRatio, true);
+  assert.equal(slowWork < fastWork || slow.summary.totalCompletedJobs < fast.summary.totalCompletedJobs, true);
 });
 
-test("AI training checkpoint intervals create visible write bursts and checkpoint pause impact", () => {
-  const result = simulateHpcLab({ ...HPC_LAB_PRESETS[1].initialConfig, checkpointFrequencyMinutes: 0.05, concurrentJobs: 4 }, { totalTicks: 20 });
+test("AI checkpoint intervals reduce useful progress while creating write bursts", () => {
+  const base = { ...HPC_LAB_PRESETS[1].initialConfig, concurrentJobs: 4 };
+  const frequent = simulateHpcLab({ ...base, checkpointFrequencyMinutes: 0.05 }, { totalTicks: 20 });
+  const rare = simulateHpcLab({ ...base, checkpointFrequencyMinutes: 100 }, { totalTicks: 20 });
 
-  const writes = result.timeline.map((tick) => tick.requestedWriteGbps);
+  const writes = frequent.timeline.map((tick) => tick.requestedWriteGbps);
   const maxWrite = Math.max(...writes);
   const minWrite = Math.min(...writes);
-  const maxPause = Math.max(...result.timeline.map((tick) => tick.checkpointPauseRatio));
+  const frequentWork = frequent.jobs.reduce((sum, job) => sum + job.completedWorkTicks, 0);
+  const rareWork = rare.jobs.reduce((sum, job) => sum + job.completedWorkTicks, 0);
 
   assert.equal(maxWrite > minWrite, true);
-  assert.equal(maxPause > 0, true);
+  assert.equal(frequent.timeline.some((tick) => tick.checkpointPauseRatio > 0), true);
+  assert.equal(frequentWork < rareWork || frequent.summary.totalCompletedJobs < rare.summary.totalCompletedJobs, true);
 });
 
 test("insufficient nodes create queued jobs", () => {
   const result = simulateHpcLab({ ...HPC_LAB_PRESETS[0].initialConfig, computeNodes: 2, concurrentJobs: 12 }, { totalTicks: 15 });
   assert.equal(result.summary.peakQueuedJobs > 0, true);
+});
+
+test("newly admitted jobs can make useful progress on their start tick", () => {
+  const result = simulateHpcLab({ ...HPC_LAB_PRESETS[0].initialConfig, concurrentJobs: 2 }, { totalTicks: 1 });
+  const started = result.jobs.filter((job) => job.startTick === 1);
+
+  assert.equal(started.length > 0, true);
+  assert.equal(started.every((job) => job.completedWorkTicks > 0), true);
 });

--- a/ui/partner-hub/lib/hpc-lab/engine.ts
+++ b/ui/partner-hub/lib/hpc-lab/engine.ts
@@ -1,13 +1,36 @@
 import { normalizeHpcLabConfig, normalizeSimulationOptions } from "./config";
 import { simulateNetworkTick } from "./network";
-import { advanceSchedulerTick, createSchedulerState } from "./scheduler";
-import { buildStorageRequest, simulateStorageTick } from "./storage";
-import type { HpcLabConfig, HpcLabSimulationOptions, HpcLabSimulationResult, HpcLabTickSnapshot } from "./types";
+import { admitQueuedJobs, applyRunningJobProgress, createSchedulerState } from "./scheduler";
+import { buildStorageRequest, isCheckpointActiveThisTick, simulateStorageTick } from "./storage";
+import type { HpcLabConfig, HpcLabJobInstance, HpcLabSimulationOptions, HpcLabSimulationResult, HpcLabTickSnapshot } from "./types";
 import { buildDeterministicJobPlan } from "./workloads";
 
 const clamp01 = (value: number) => Math.max(0, Math.min(1, value));
 
 const average = (values: number[]) => (values.length === 0 ? 0 : values.reduce((sum, value) => sum + value, 0) / values.length);
+
+const computeEffectiveProgressForJob = (
+  job: HpcLabJobInstance,
+  deliveredDataRatio: number,
+  metadataServiceRatio: number,
+  waitOnDataRatio: number,
+  checkpointActive: boolean,
+): number => {
+  const dataRatio = clamp01(deliveredDataRatio);
+  const metadataRatio = clamp01(metadataServiceRatio);
+  const waitFreeRatio = clamp01(1 - waitOnDataRatio);
+  const checkpointRatio = checkpointActive ? clamp01(1 - job.checkpointPauseRatio) : 1;
+
+  if (job.kind === "traditional-hpc") {
+    return dataRatio * dataRatio;
+  }
+
+  if (job.kind === "distributed-ai-training") {
+    return dataRatio * checkpointRatio;
+  }
+
+  return metadataRatio * metadataRatio * waitFreeRatio;
+};
 
 export const simulateHpcLab = (config: HpcLabConfig, options?: Partial<HpcLabSimulationOptions>): HpcLabSimulationResult => {
   const normalizedConfig = normalizeHpcLabConfig(config);
@@ -18,25 +41,32 @@ export const simulateHpcLab = (config: HpcLabConfig, options?: Partial<HpcLabSim
   const timeline: HpcLabTickSnapshot[] = [];
 
   for (let tick = 1; tick <= normalizedOptions.totalTicks; tick += 1) {
-    scheduler = advanceSchedulerTick(scheduler, normalizedConfig, tick);
+    scheduler = admitQueuedJobs(scheduler, normalizedConfig, tick);
 
     const request = buildStorageRequest(scheduler.runningJobs, tick);
     const storage = simulateStorageTick(normalizedConfig, request);
-
     const network = simulateNetworkTick(storage.deliveredReadGbps, storage.deliveredWriteGbps, normalizedConfig.networkBandwidthGbps);
 
-    const waitOnDataRatio =
-      request.requestedReadGbps + request.requestedWriteGbps > 0
-        ? clamp01(1 - (network.deliveredReadGbps + network.deliveredWriteGbps) / (request.requestedReadGbps + request.requestedWriteGbps))
-        : 0;
+    const requestedTotal = request.requestedReadGbps + request.requestedWriteGbps;
+    const deliveredTotal = network.deliveredReadGbps + network.deliveredWriteGbps;
+    const waitOnDataRatio = requestedTotal > 0 ? clamp01(1 - deliveredTotal / requestedTotal) : 0;
+    const deliveredDataRatio = requestedTotal > 0 ? clamp01(deliveredTotal / requestedTotal) : 1;
+    const metadataServiceRatio = request.metadataOpsRequested > 0 ? clamp01(storage.metadataOpsServed / request.metadataOpsRequested) : 1;
 
-    const checkpointActiveJobs = scheduler.runningJobs.filter(
-      (job) => job.checkpointIntervalTicks !== null && job.progressTicks > 0 && job.progressTicks % job.checkpointIntervalTicks === 0,
-    );
+    const checkpointActiveJobs = scheduler.runningJobs.filter((job) => isCheckpointActiveThisTick(job));
     const checkpointPauseRatio =
       scheduler.runningJobs.length > 0
         ? checkpointActiveJobs.reduce((sum, job) => sum + job.checkpointPauseRatio, 0) / scheduler.runningJobs.length
         : 0;
+
+    const effectiveWorkByJobId = Object.fromEntries(
+      scheduler.runningJobs.map((job) => [
+        job.id,
+        computeEffectiveProgressForJob(job, deliveredDataRatio, metadataServiceRatio, waitOnDataRatio, isCheckpointActiveThisTick(job)),
+      ]),
+    );
+
+    scheduler = applyRunningJobProgress(scheduler, tick, effectiveWorkByJobId);
 
     timeline.push({
       tick,
@@ -88,6 +118,7 @@ export const simulateHpcLab = (config: HpcLabConfig, options?: Partial<HpcLabSim
       "Deterministic tick-based simulation with no randomness.",
       "Throughput and metadata service levels model relative behavior, not vendor-certified benchmark numbers.",
       "Storage throughput depends on OST inventory, effective stripe width, and metadata latency pressure.",
+      "Per-job effective progress is deterministic and can be fractional based on data delivery, metadata service, and checkpoint pause conditions.",
       "Distributed AI training jobs produce deterministic checkpoint bursts based on checkpoint interval.",
       "Network caps aggregate delivered storage throughput per tick.",
     ],

--- a/ui/partner-hub/lib/hpc-lab/scheduler.test.ts
+++ b/ui/partner-hub/lib/hpc-lab/scheduler.test.ts
@@ -3,14 +3,14 @@ import test from "node:test";
 
 import { normalizeHpcLabConfig, normalizeSimulationOptions } from "./config";
 import { HPC_LAB_PRESETS } from "./presets";
-import { advanceSchedulerTick, createSchedulerState } from "./scheduler";
+import { admitQueuedJobs, applyRunningJobProgress, createSchedulerState } from "./scheduler";
 import { buildDeterministicJobPlan } from "./workloads";
 
 test("scheduler queues jobs when nodes are insufficient", () => {
   const config = normalizeHpcLabConfig({ ...HPC_LAB_PRESETS[0].initialConfig, computeNodes: 2, concurrentJobs: 6 });
   const jobs = buildDeterministicJobPlan(config, normalizeSimulationOptions());
 
-  const state = advanceSchedulerTick(createSchedulerState(jobs), config, 1);
+  const state = admitQueuedJobs(createSchedulerState(jobs), config, 1);
 
   assert.equal(state.queuedJobs.length > 0, true);
   assert.equal(state.runningJobs.length > 0, true);
@@ -21,11 +21,13 @@ test("scheduler allocates and releases CPU/GPU resources correctly", () => {
   const jobs = buildDeterministicJobPlan(config, normalizeSimulationOptions());
 
   let state = createSchedulerState(jobs);
-  state = advanceSchedulerTick(state, config, 1);
+  state = admitQueuedJobs(state, config, 1);
   const initialRunning = state.runningJobs.length;
 
-  for (let tick = 2; tick <= 120; tick += 1) {
-    state = advanceSchedulerTick(state, config, tick);
+  for (let tick = 1; tick <= 120; tick += 1) {
+    const effective = Object.fromEntries(state.runningJobs.map((job) => [job.id, 1]));
+    state = applyRunningJobProgress(state, tick, effective);
+    state = admitQueuedJobs(state, config, tick + 1);
   }
 
   assert.equal(initialRunning > 0, true);
@@ -38,7 +40,7 @@ test("scheduler does not oversubscribe nodes", () => {
   const config = normalizeHpcLabConfig({ ...HPC_LAB_PRESETS[1].initialConfig, gpuNodes: 4, concurrentJobs: 8 });
   const jobs = buildDeterministicJobPlan(config, normalizeSimulationOptions());
 
-  const state = advanceSchedulerTick(createSchedulerState(jobs), config, 1);
+  const state = admitQueuedJobs(createSchedulerState(jobs), config, 1);
 
   assert.equal(state.allocatedGpuNodes <= config.gpuNodes, true);
   assert.equal(state.allocatedCpuNodes <= config.computeNodes, true);

--- a/ui/partner-hub/lib/hpc-lab/scheduler.ts
+++ b/ui/partner-hub/lib/hpc-lab/scheduler.ts
@@ -13,36 +13,22 @@ export const createSchedulerState = (jobs: HpcLabJobInstance[]): HpcLabScheduler
   allocatedGpuNodes: 0,
 });
 
-export const advanceSchedulerTick = (
+export const admitQueuedJobs = (
   state: HpcLabSchedulerState,
   config: HpcLabNormalizedConfig,
   tick: number,
 ): HpcLabSchedulerState => {
   const completedJobs = [...state.completedJobs];
-  const queuedJobs = [...state.queuedJobs];
+  const runningJobs = [...state.runningJobs];
 
-  let allocatedCpuNodes = 0;
-  let allocatedGpuNodes = 0;
-
-  const stillRunning: HpcLabJobInstance[] = [];
-  for (const running of state.runningJobs) {
-    const progressed = { ...running, progressTicks: running.progressTicks + 1 };
-    if (progressed.progressTicks >= progressed.runtimeTicks) {
-      completedJobs.push({ ...progressed, state: "completed", completedTick: tick });
-    } else {
-      stillRunning.push(progressed);
-      allocatedCpuNodes += progressed.requiredCpuNodes;
-      allocatedGpuNodes += progressed.requiredGpuNodes;
-    }
-  }
-
-  const runningJobs = [...stillRunning];
+  let allocatedCpuNodes = runningJobs.reduce((sum, job) => sum + job.requiredCpuNodes, 0);
+  let allocatedGpuNodes = runningJobs.reduce((sum, job) => sum + job.requiredGpuNodes, 0);
 
   let availableCpu = config.computeNodes - allocatedCpuNodes;
   let availableGpu = config.gpuNodes - allocatedGpuNodes;
 
   const nextQueue: HpcLabJobInstance[] = [];
-  for (const queued of queuedJobs) {
+  for (const queued of state.queuedJobs) {
     if (canAllocate(queued, availableCpu, availableGpu)) {
       const started: HpcLabJobInstance = {
         ...queued,
@@ -62,6 +48,44 @@ export const advanceSchedulerTick = (
   return {
     queuedJobs: nextQueue,
     runningJobs,
+    completedJobs,
+    allocatedCpuNodes,
+    allocatedGpuNodes,
+  };
+};
+
+export const applyRunningJobProgress = (
+  state: HpcLabSchedulerState,
+  tick: number,
+  effectiveWorkByJobId: Readonly<Record<string, number>>,
+): HpcLabSchedulerState => {
+  const completedJobs = [...state.completedJobs];
+  const stillRunning: HpcLabJobInstance[] = [];
+
+  let allocatedCpuNodes = 0;
+  let allocatedGpuNodes = 0;
+
+  for (const running of state.runningJobs) {
+    const effectiveProgressLastTick = Math.max(0, effectiveWorkByJobId[running.id] ?? 0);
+    const progressed: HpcLabJobInstance = {
+      ...running,
+      progressTicks: running.progressTicks + 1,
+      effectiveProgressLastTick,
+      completedWorkTicks: running.completedWorkTicks + effectiveProgressLastTick,
+    };
+
+    if (progressed.completedWorkTicks >= progressed.runtimeTicks) {
+      completedJobs.push({ ...progressed, state: "completed", completedTick: tick });
+    } else {
+      stillRunning.push(progressed);
+      allocatedCpuNodes += progressed.requiredCpuNodes;
+      allocatedGpuNodes += progressed.requiredGpuNodes;
+    }
+  }
+
+  return {
+    queuedJobs: [...state.queuedJobs],
+    runningJobs: stillRunning,
     completedJobs,
     allocatedCpuNodes,
     allocatedGpuNodes,

--- a/ui/partner-hub/lib/hpc-lab/storage.ts
+++ b/ui/partner-hub/lib/hpc-lab/storage.ts
@@ -22,14 +22,16 @@ const distributeAcrossOsts = (totalGbps: number, totalOsts: number, spreadWidth:
   return loads;
 };
 
+export const isCheckpointActiveThisTick = (job: HpcLabJobInstance): boolean =>
+  job.checkpointIntervalTicks !== null && (job.progressTicks + 1) % job.checkpointIntervalTicks === 0;
+
 export const buildStorageRequest = (runningJobs: HpcLabJobInstance[], tick: number): HpcLabStorageRequest => {
   let requestedReadGbps = 0;
   let requestedWriteGbps = 0;
   let metadataOpsRequested = 0;
 
   for (const job of runningJobs) {
-    const hasCheckpoint =
-      job.checkpointIntervalTicks !== null && job.progressTicks > 0 && job.progressTicks % job.checkpointIntervalTicks === 0;
+    const hasCheckpoint = isCheckpointActiveThisTick(job);
     requestedReadGbps += job.baseReadGbps;
     requestedWriteGbps += hasCheckpoint ? job.baseWriteGbps * job.checkpointWriteMultiplier : job.baseWriteGbps;
     metadataOpsRequested += hasCheckpoint ? job.metadataOpsPerTick * 1.2 : job.metadataOpsPerTick;

--- a/ui/partner-hub/lib/hpc-lab/types.ts
+++ b/ui/partner-hub/lib/hpc-lab/types.ts
@@ -67,6 +67,8 @@ export type HpcLabJobDefinition = {
 export type HpcLabJobInstance = HpcLabJobDefinition & {
   state: HpcLabJobState;
   progressTicks: number;
+  completedWorkTicks: number;
+  effectiveProgressLastTick: number;
   startTick: number | null;
   completedTick: number | null;
 };

--- a/ui/partner-hub/lib/hpc-lab/workloads.ts
+++ b/ui/partner-hub/lib/hpc-lab/workloads.ts
@@ -71,6 +71,8 @@ export const buildDeterministicJobPlan = (
     ...job,
     state: "queued",
     progressTicks: 0,
+    completedWorkTicks: 0,
+    effectiveProgressLastTick: 0,
     startTick: null,
     completedTick: null,
   }));


### PR DESCRIPTION
### Motivation
- Running jobs previously advanced by a blind `+1` runtime tick so storage/network/metadata pressure only produced metrics, not outcome changes.  The simulation must make bottlenecks and checkpointing affect actual completion timing and queue behavior.
- Progress semantics and checkpoint timing needed to be deterministic and explicit so newly admitted jobs can accrue useful work on their start tick and identical inputs remain reproducible.

### Description
- Split scheduler responsibilities by adding `admitQueuedJobs` (admission/allocation) and `applyRunningJobProgress` (per-tick progress application) while preserving scheduler resource accounting. (see `scheduler.ts`).
- Added explicit per-job effective-work fields `completedWorkTicks` and `effectiveProgressLastTick` and initialized them in deterministic job plan generation. (see `types.ts`, `workloads.ts`).
- Aligned checkpoint detection to same-tick semantics with `isCheckpointActiveThisTick(job)` and updated storage request construction to use it so checkpoint write bursts and pause signals remain deterministic. (see `storage.ts`).
- Engine now computes deterministic per-job effective work each tick and applies it to `completedWorkTicks` using a documented model: `traditional-hpc` ≈ `dataRatio^2`, `distributed-ai-training` ≈ `dataRatio * (1 - checkpointPause)` during checkpoint ticks, and `metadata-heavy` ≈ `metadataRatio^2 * waitFreeRatio`; completion is based on accumulated effective work, not raw elapsed ticks. (see `engine.ts`).
- Updated docs to describe the effective-work model and expanded/rewrote tests to be outcome-sensitive (engine and scheduler tests); top-level API shape (`simulateHpcLab(...)`) and Phase 3/4 deferral remain unchanged. (see `docs/hpc-lab.md`, `engine.test.ts`, `scheduler.test.ts`).

### Testing
- Ran `npm run lint` from `ui/partner-hub`, which failed in this environment with `next: not found` (execution environment missing Next binaries), so lint could not be completed. (`sh: 1: next: not found`).
- Ran `npm run typecheck`, which failed with numerous TS resolution/type errors from missing external packages/type declarations in the execution environment (e.g. `next/*`, `react`, `node:*`, `zod`), so global typecheck could not be completed here. (output truncated due to length). 
- Ran `npm test`, which attempted TypeScript compilation and then tests but failed during TS compile for the same missing dependency/type issues; the updated HPC Lab unit tests were added and exercise determinism, network/metadata/checkpoint outcome sensitivity, queued-job behavior, and same-tick start progress but could not complete in this environment.
- Unit tests added/modified: `ui/partner-hub/lib/hpc-lab/engine.test.ts` and `ui/partner-hub/lib/hpc-lab/scheduler.test.ts`, and they assert identical-config determinism, network/metadata/checkpoint impact on completed work or completed job count, queued job behavior under insufficient nodes, and that newly started jobs accrue effective work on their start tick.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d68e20da208330950288c958abac77)