### PR TITLE
Polish HPC Lab Phase 3 validation UX and stale-result signaling

### DIFF
--- a/ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx
+++ b/ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   buildFormStateFromPreset,
   isFormDirtyAgainstPreset,
+  isSameFormStateValues,
   parseFormStateToSimulationInput,
   resetFormStateToPreset,
   type HpcLabFormNumericField,
@@ -70,7 +71,8 @@ export function HpcLabTool() {
   const [selectedPresetId, setSelectedPresetId] = useState<HpcLabPresetId>(initialPreset.id);
   const [formState, setFormState] = useState<HpcLabFormState>(() => buildFormStateFromPreset(initialPreset));
   const [runResult, setRunResult] = useState<HpcLabSimulationResult | null>(null);
-  const [submitted, setSubmitted] = useState(false);
+  const [touchedFields, setTouchedFields] = useState<Partial<Record<HpcLabFormNumericField, boolean>>>({});
+  const [lastRunFormState, setLastRunFormState] = useState<HpcLabFormState | null>(null);
 
   const selectedPreset = useMemo(
     () => getHpcLabPresetById(selectedPresetId) ?? initialPreset,
@@ -80,32 +82,45 @@ export function HpcLabTool() {
   const parsed = useMemo(() => parseFormStateToSimulationInput(formState), [formState]);
   const validationErrors = parsed.ok ? {} : parsed.errors;
   const isDirty = useMemo(() => isFormDirtyAgainstPreset(formState, selectedPreset), [formState, selectedPreset]);
+  const isRunResultStale = useMemo(
+    () => !!runResult && !!lastRunFormState && !isSameFormStateValues(formState, lastRunFormState),
+    [formState, lastRunFormState, runResult],
+  );
 
   const onNumericChange = (field: HpcLabFormNumericField, value: string) => {
     setFormState((current) => ({ ...current, [field]: value }));
+    setTouchedFields((current) => ({ ...current, [field]: true }));
   };
 
   const onPresetChange = (presetId: HpcLabPresetId) => {
     const preset = getHpcLabPresetById(presetId) ?? initialPreset;
     setSelectedPresetId(preset.id);
     setFormState(resetFormStateToPreset(preset));
-    setSubmitted(false);
+    setTouchedFields({});
+    setLastRunFormState(null);
     setRunResult(null);
   };
 
   const onRunSimulation = () => {
-    setSubmitted(true);
     const current = parseFormStateToSimulationInput(formState);
     if (!current.ok) {
+      setTouchedFields((existing) =>
+        numericFieldMetadata.reduce<Partial<Record<HpcLabFormNumericField, boolean>>>(
+          (next, { field }) => ({ ...next, [field]: true }),
+          existing,
+        ),
+      );
       return;
     }
 
     setRunResult(simulateHpcLab(current.config, current.options));
+    setLastRunFormState(formState);
   };
 
   const onResetToPreset = () => {
     setFormState(resetFormStateToPreset(selectedPreset));
-    setSubmitted(false);
+    setTouchedFields({});
+    setLastRunFormState(null);
     setRunResult(null);
   };
 
@@ -160,6 +175,11 @@ export function HpcLabTool() {
             <div className="grid gap-3 sm:grid-cols-2">
               {numericFieldMetadata.map(({ field, label, suffix }) => (
                 <div key={field} className="space-y-1">
+                  {touchedFields[field] && validationErrors[field] ? (
+                    <p id={`hpc-lab-${field}-error`} className="text-xs text-destructive">
+                      {validationErrors[field]}
+                    </p>
+                  ) : null}
                   <label htmlFor={`hpc-lab-${field}`} className="text-xs font-semibold uppercase tracking-wide text-foreground/60">
                     {label}
                   </label>
@@ -168,12 +188,14 @@ export function HpcLabTool() {
                       id={`hpc-lab-${field}`}
                       value={formState[field]}
                       onChange={(event) => onNumericChange(field, event.target.value)}
+                      onBlur={() => setTouchedFields((current) => ({ ...current, [field]: true }))}
                       className="h-10 w-full rounded-md border border-border/70 bg-card px-3 text-sm text-foreground"
                       inputMode="decimal"
+                      aria-invalid={touchedFields[field] && validationErrors[field] ? true : undefined}
+                      aria-describedby={touchedFields[field] && validationErrors[field] ? `hpc-lab-${field}-error` : undefined}
                     />
                     {suffix ? <span className="text-xs text-foreground/60">{suffix}</span> : null}
                   </div>
-                  {submitted && validationErrors[field] ? <p className="text-xs text-destructive">{validationErrors[field]}</p> : null}
                 </div>
               ))}
 
@@ -224,6 +246,16 @@ export function HpcLabTool() {
                 Reset to preset defaults
               </Button>
             </div>
+            {parsed.ok ? (
+              <div className="rounded-md border border-border/70 bg-muted/40 px-3 py-2 text-xs text-foreground/80">
+                <p>
+                  Total OSTs: <span className="font-medium text-foreground">{parsed.config.totalOsts}</span>
+                </p>
+                <p>
+                  Effective stripe width: <span className="font-medium text-foreground">{parsed.config.effectiveStripeWidth}</span>
+                </p>
+              </div>
+            ) : null}
           </CardContent>
         </Card>
 
@@ -234,6 +266,11 @@ export function HpcLabTool() {
                 <CardTitle className="text-base">Phase 3 run summary</CardTitle>
               </CardHeader>
               <CardContent className="grid gap-2 text-sm sm:grid-cols-2">
+                {isRunResultStale ? (
+                  <p className="sm:col-span-2 rounded bg-amber-500/10 px-2 py-1 text-xs text-amber-700">
+                    Results reflect the last run. Run simulation again to update.
+                  </p>
+                ) : null}
                 <p>Total completed jobs: <span className="font-medium text-foreground">{runResult.summary.totalCompletedJobs}</span></p>
                 <p>Peak queued jobs: <span className="font-medium text-foreground">{runResult.summary.peakQueuedJobs}</span></p>
                 <p>Avg CPU utilization: <span className="font-medium text-foreground">{formatPercent(runResult.summary.avgCpuUtilization)}</span></p>
@@ -262,7 +299,9 @@ export function HpcLabTool() {
                 <CardContent>
                   <p className="text-sm text-foreground/70">
                     {runResult
-                      ? "Simulation run complete. Visualization arrives in Phase 4."
+                      ? isRunResultStale
+                        ? "Last run is stale after control changes. Run simulation again. Visualization arrives in Phase 4."
+                        : "Simulation run complete. Visualization arrives in Phase 4."
                       : "Run a simulation to prepare data. Visualization arrives in Phase 4."}
                   </p>
                 </CardContent>

--- a/ui/partner-hub/docs/hpc-lab.md
+++ b/ui/partner-hub/docs/hpc-lab.md
@@ -13,8 +13,9 @@ Included in Phase 3:
 - Real local control state for infrastructure and workload parameters.
 - Preset-aware defaults for both infrastructure config and simulation options.
 - Explicit **Run simulation** and **Reset to preset defaults** actions.
-- Inline validation for all required positive numeric fields before execution.
+- Inline validation for all required positive numeric fields before execution, shown during editing (blur/change) rather than only after submit attempts.
 - Local execution via `simulateHpcLab(config, options)` and compact run summary rendering.
+- Last run summary remains visible after control edits but is clearly marked stale until the next run.
 - Simulation duration controls (`totalTicks`, `tickDurationSeconds`) exposed in the UI so users can extend run horizon without code edits.
 
 Preset simulation defaults now intentionally use longer horizons than the engine baseline for better out-of-the-box behavior exploration:

--- a/ui/partner-hub/lib/hpc-lab/form.test.ts
+++ b/ui/partner-hub/lib/hpc-lab/form.test.ts
@@ -5,6 +5,7 @@ import { getHpcLabPresetById } from "./presets";
 import {
   buildFormStateFromPreset,
   isFormDirtyAgainstPreset,
+  isSameFormStateValues,
   parseFormStateToSimulationInput,
   resetFormStateToPreset,
 } from "./form";
@@ -49,11 +50,13 @@ test("parseFormStateToSimulationInput returns clear errors for invalid numeric f
   const parsed = parseFormStateToSimulationInput(state);
 
   assert.equal(parsed.ok, false);
-  if (!parsed.ok) {
-    assert.equal(parsed.errors.computeNodes, "Compute nodes must be a finite number greater than 0.");
-    assert.equal(parsed.errors.networkBandwidthGbps, "Network bandwidth must be a finite number greater than 0.");
-    assert.equal(parsed.errors.totalTicks, "Simulation duration must be a finite number greater than 0.");
+  if (parsed.ok) {
+    throw new Error("Expected invalid form parse");
   }
+
+  assert.equal(parsed.errors.computeNodes, "Compute nodes must be a finite number greater than 0.");
+  assert.equal(parsed.errors.networkBandwidthGbps, "Network bandwidth must be a finite number greater than 0.");
+  assert.equal(parsed.errors.totalTicks, "Simulation duration must be a finite number greater than 0.");
 });
 
 test("resetFormStateToPreset restores defaults and clears dirty comparison", () => {
@@ -65,4 +68,15 @@ test("resetFormStateToPreset restores defaults and clears dirty comparison", () 
   const reset = resetFormStateToPreset(aiPreset);
   assert.equal(isFormDirtyAgainstPreset(reset, aiPreset), false);
   assert.equal(reset.concurrentJobs, String(aiPreset.initialConfig.concurrentJobs));
+});
+
+test("isSameFormStateValues compares trimmed numeric fields and exact categorical fields", () => {
+  const left = buildFormStateFromPreset(aiPreset);
+  const right = buildFormStateFromPreset(aiPreset);
+  right.computeNodes = `  ${right.computeNodes}  `;
+
+  assert.equal(isSameFormStateValues(left, right), true);
+
+  right.workloadType = "metadata-heavy";
+  assert.equal(isSameFormStateValues(left, right), false);
 });

--- a/ui/partner-hub/lib/hpc-lab/form.ts
+++ b/ui/partner-hub/lib/hpc-lab/form.ts
@@ -159,19 +159,20 @@ export const parseFormStateToSimulationInput = (state: HpcLabFormState): ParsedH
 export const isFormDirtyAgainstPreset = (state: HpcLabFormState, preset: HpcLabPreset): boolean => {
   const baseline = buildFormStateFromPreset(preset);
 
-  return (
-    state.computeNodes.trim() !== baseline.computeNodes ||
-    state.gpuNodes.trim() !== baseline.gpuNodes ||
-    state.ossCount.trim() !== baseline.ossCount ||
-    state.ostPerOss.trim() !== baseline.ostPerOss ||
-    state.stripeWidth.trim() !== baseline.stripeWidth ||
-    state.metadataLatencyMs.trim() !== baseline.metadataLatencyMs ||
-    state.networkBandwidthGbps.trim() !== baseline.networkBandwidthGbps ||
-    state.workloadType !== baseline.workloadType ||
-    state.fileSizeDistribution !== baseline.fileSizeDistribution ||
-    state.checkpointFrequencyMinutes.trim() !== baseline.checkpointFrequencyMinutes ||
-    state.concurrentJobs.trim() !== baseline.concurrentJobs ||
-    state.totalTicks.trim() !== baseline.totalTicks ||
-    state.tickDurationSeconds.trim() !== baseline.tickDurationSeconds
-  );
+  return !isSameFormStateValues(state, baseline);
 };
+
+export const isSameFormStateValues = (left: HpcLabFormState, right: HpcLabFormState): boolean =>
+  left.computeNodes.trim() === right.computeNodes.trim() &&
+  left.gpuNodes.trim() === right.gpuNodes.trim() &&
+  left.ossCount.trim() === right.ossCount.trim() &&
+  left.ostPerOss.trim() === right.ostPerOss.trim() &&
+  left.stripeWidth.trim() === right.stripeWidth.trim() &&
+  left.metadataLatencyMs.trim() === right.metadataLatencyMs.trim() &&
+  left.networkBandwidthGbps.trim() === right.networkBandwidthGbps.trim() &&
+  left.workloadType === right.workloadType &&
+  left.fileSizeDistribution === right.fileSizeDistribution &&
+  left.checkpointFrequencyMinutes.trim() === right.checkpointFrequencyMinutes.trim() &&
+  left.concurrentJobs.trim() === right.concurrentJobs.trim() &&
+  left.totalTicks.trim() === right.totalTicks.trim() &&
+  left.tickDurationSeconds.trim() === right.tickDurationSeconds.trim();


### PR DESCRIPTION
### Motivation
- Make inline numeric validation visible while editing so a disabled Run button has an explanation, instead of only revealing errors after a submit attempt. 
- Prevent stale run summaries from appearing current by clearly marking the last run as stale when controls change after a run. 
- Provide a small, honest derived preview (Total OSTs and Effective stripe width) derived from the current parsable form input to aid users while editing. 
- Keep all Phase 3 behaviors intact and avoid starting Phase 4 visualization work. 

### Description
- Surface per-field validation during editing by tracking `touchedFields` (onChange + onBlur) and rendering inline errors when a field is touched and invalid, while keeping the Run button disabled when `parsed.ok` is false and adding `aria-invalid`/`aria-describedby` on invalid inputs. 
- Add `lastRunFormState` and `isRunResultStale` (computed via a new pure helper `isSameFormStateValues`) to detect when controls diverge from the last successful run and display a concise stale-results banner and stale-aware Phase 4 placeholder messaging. 
- On Run attempts that fail validation, mark all numeric fields as touched so users immediately see the form-level validation failures. 
- Add a compact derived-preview block that shows `Total OSTs` and `Effective stripe width` from the current parsed/normalized config when parsing succeeds. 
- Introduce `isSameFormStateValues` in `lib/hpc-lab/form.ts` and add focused unit tests in `lib/hpc-lab/form.test.ts` to cover trimmed numeric equality and categorical equality; do not change the normalization/simulation logic. 
- Update docs in `ui/partner-hub/docs/hpc-lab.md` to note that validation is shown during editing and that the last run is marked stale after edits. 
- Files changed: `ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx`, `ui/partner-hub/lib/hpc-lab/form.ts`, `ui/partner-hub/lib/hpc-lab/form.test.ts`, and `ui/partner-hub/docs/hpc-lab.md`. 
- This change preserves preset switching, preset-aware defaults, Run simulation, Reset to preset defaults, the compact Phase 3 run summary, and Phase 4 placeholders (no Phase 4 visualization work was added). 

### Testing
- Ran `cd ui/partner-hub && npm run lint` and it failed in this environment because the `next` binary is not available; output: `> partner-hub@0.0.1 lint \n> next lint\nsh: 1: next: not found`. 
- Ran `cd ui/partner-hub && npm run typecheck` and `tsc --noEmit` produced many project-level type errors (missing framework/type deps), e.g. `app/(routes)/about/page.tsx(1,18): error TS2307: Cannot find module 'next/link' or its corresponding type declarations.` and the run generated a 340-line typecheck log. 
- Ran `cd ui/partner-hub && npm test` and the test harness failed early for the same missing deps/types (multiple `Cannot find module 'node:test'` / `Cannot find module 'react'` / `Cannot find module 'next/*'` style errors). 

Note: the failures above are environment dependency/type-resolution issues (missing project toolchain in this sandbox) and not regressions introduced by this patch; the added unit test for `isSameFormStateValues` is a pure helper test and is compatible with the existing node:test harness. 

This is Phase 3 polish only; Phase 4 visualization has not been implemented in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d58e2a4483309ff8aa4b61985d86)