### PR TITLE
Phase 4 polish: separate mixed chart units and make chart colors theme-safe

### DIFF
--- a/ui/partner-hub/components/hpc-lab/charts/bar-distribution-chart.tsx
+++ b/ui/partner-hub/components/hpc-lab/charts/bar-distribution-chart.tsx
@@ -30,12 +30,17 @@ export function BarDistributionChart({ model }: { model: HpcLabBarChartModel }) 
 
   return (
     <div className="space-y-2">
-      <svg viewBox={`0 0 ${width} ${height}`} className="h-56 w-full" role="img" aria-label={model.title}>
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        className="h-56 w-full text-sky-600 dark:text-sky-400"
+        role="img"
+        aria-label={model.title}
+      >
         {bars.map((bar, index) => {
           const x = padding.left + index * barWidth;
           const y = toY(bar.value);
           const h = height - padding.bottom - y;
-          return <rect key={bar.label} x={x} y={y} width={Math.max(1, barWidth - 1)} height={h} fill="#0ea5e9" opacity={0.85} />;
+          return <rect key={bar.label} x={x} y={y} width={Math.max(1, barWidth - 1)} height={h} fill="currentColor" opacity={0.85} />;
         })}
         <text x={6} y={16} className="fill-foreground/70 text-[10px]">
           max {formatValue(yMax, model.valueFormat)}

--- a/ui/partner-hub/components/hpc-lab/charts/chart-frame.tsx
+++ b/ui/partner-hub/components/hpc-lab/charts/chart-frame.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 type ChartFrameProps = {
   title: string;
+  showTitle?: boolean;
   subtitle?: string;
   stale?: boolean;
   emptyMessage: string;
@@ -9,13 +10,13 @@ type ChartFrameProps = {
   note?: string;
 };
 
-export function ChartFrame({ title, subtitle, stale = false, emptyMessage, children, note }: ChartFrameProps) {
+export function ChartFrame({ title, showTitle = true, subtitle, stale = false, emptyMessage, children, note }: ChartFrameProps) {
   const hasContent = children !== null;
 
   return (
     <section className="space-y-2" aria-label={title}>
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+        {showTitle ? <h3 className="text-sm font-semibold text-foreground">{title}</h3> : null}
         {subtitle ? <p className="text-xs text-foreground/65">{subtitle}</p> : null}
         {stale ? <p className="text-xs text-amber-700">Showing last run result (stale).</p> : null}
       </div>

--- a/ui/partner-hub/components/hpc-lab/charts/multi-series-line-chart.tsx
+++ b/ui/partner-hub/components/hpc-lab/charts/multi-series-line-chart.tsx
@@ -1,6 +1,12 @@
 import type { HpcLabLineChartModel } from "@/lib/hpc-lab/types";
 
-const COLORS = ["#2563eb", "#16a34a", "#7c3aed", "#f97316"];
+const SERIES_COLOR_CLASSES = [
+  "text-sky-600 dark:text-sky-400",
+  "text-emerald-600 dark:text-emerald-400",
+  "text-violet-600 dark:text-violet-400",
+  "text-amber-600 dark:text-amber-400",
+];
+const SERIES_STROKE_PATTERNS = ["0", "6 3", "2 2", "10 4"];
 
 const formatValue = (value: number, format: HpcLabLineChartModel["valueFormat"]) => {
   if (format === "percent") {
@@ -65,7 +71,17 @@ export function MultiSeriesLineChart({ model }: { model: HpcLabLineChartModel })
 
         {model.series.map((series, seriesIndex) => {
           const coordinates = series.points.map((point, index) => ({ x: toX(index), y: toY(point.value) }));
-          return <path key={series.key} d={buildPath(coordinates)} fill="none" stroke={COLORS[seriesIndex]} strokeWidth={2} />;
+          return (
+            <g key={series.key} className={SERIES_COLOR_CLASSES[seriesIndex % SERIES_COLOR_CLASSES.length]}>
+              <path
+                d={buildPath(coordinates)}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeDasharray={SERIES_STROKE_PATTERNS[seriesIndex % SERIES_STROKE_PATTERNS.length]}
+              />
+            </g>
+          );
         })}
 
         <text x={padding.left} y={height - 6} className="fill-foreground/70 text-[10px]">Tick</text>
@@ -73,8 +89,11 @@ export function MultiSeriesLineChart({ model }: { model: HpcLabLineChartModel })
 
       <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
         {model.series.map((series, seriesIndex) => (
-          <span key={series.key} className="inline-flex items-center gap-1 text-foreground/80">
-            <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: COLORS[seriesIndex] }} aria-hidden />
+          <span
+            key={series.key}
+            className={`inline-flex items-center gap-1 text-foreground/80 ${SERIES_COLOR_CLASSES[seriesIndex % SERIES_COLOR_CLASSES.length]}`}
+          >
+            <span className="inline-block h-2 w-2 rounded-full bg-current" aria-hidden />
             {series.label}
           </span>
         ))}

--- a/ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx
+++ b/ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx
@@ -20,10 +20,12 @@ import {
 import { simulateHpcLab } from "@/lib/hpc-lab/engine";
 import { getHpcLabPresetById, HPC_LAB_PRESETS } from "@/lib/hpc-lab/presets";
 import {
+  buildCheckpointActiveJobsStats,
   buildCheckpointChartModel,
   buildComputeUtilizationChartModel,
   buildConstraintSignalsChartModel,
   buildMetadataChartModel,
+  buildMetadataUtilizationStats,
   buildOstLoadDistributionChartModel,
   buildQueueChartModel,
   buildThroughputChartModel,
@@ -111,6 +113,8 @@ export function HpcLabTool() {
   const waitOnDataChart = useMemo(() => (runResult ? buildWaitOnDataChartModel(runResult) : null), [runResult]);
   const checkpointChart = useMemo(() => (runResult ? buildCheckpointChartModel(runResult) : null), [runResult]);
   const bottleneckChart = useMemo(() => (runResult ? buildConstraintSignalsChartModel(runResult) : null), [runResult]);
+  const metadataUtilizationStats = useMemo(() => (runResult ? buildMetadataUtilizationStats(runResult) : null), [runResult]);
+  const checkpointActiveJobsStats = useMemo(() => (runResult ? buildCheckpointActiveJobsStats(runResult) : null), [runResult]);
 
   const onNumericChange = (field: HpcLabFormNumericField, value: string) => {
     setFormState((current) => ({ ...current, [field]: value }));
@@ -327,6 +331,7 @@ export function HpcLabTool() {
                   {panelKey === "cluster-topology" ? (
                     <ChartFrame
                       title="Cluster topology"
+                      showTitle={false}
                       stale={isRunResultStale}
                       emptyMessage="Run a simulation to render topology from normalized configuration."
                       children={topology ? <TopologyDiagram model={topology} /> : null}
@@ -336,6 +341,7 @@ export function HpcLabTool() {
                   {panelKey === "throughput-over-time" ? (
                     <ChartFrame
                       title="Throughput over time"
+                      showTitle={false}
                       stale={isRunResultStale}
                       emptyMessage="Run a simulation to view requested vs delivered throughput."
                       note={throughputChart ? chartNote(throughputChart.downsampled) : undefined}
@@ -346,16 +352,34 @@ export function HpcLabTool() {
                   {panelKey === "metadata-load" ? (
                     <ChartFrame
                       title="Metadata load"
+                      showTitle={false}
                       stale={isRunResultStale}
                       emptyMessage="Run a simulation to view metadata requested and served over time."
                       note={metadataChart ? chartNote(metadataChart.downsampled) : undefined}
-                      children={metadataChart ? <MultiSeriesLineChart model={metadataChart} /> : null}
+                      children={
+                        metadataChart ? (
+                          <div className="space-y-3">
+                            <MultiSeriesLineChart model={metadataChart} />
+                            {metadataUtilizationStats ? (
+                              <div className="rounded-md border border-border/70 bg-muted/30 px-3 py-2 text-xs text-foreground/75">
+                                <p>
+                                  Metadata utilization (separate from ops axis): latest{" "}
+                                  <span className="font-medium text-foreground">{formatPercent(metadataUtilizationStats.latest)}</span> · avg{" "}
+                                  <span className="font-medium text-foreground">{formatPercent(metadataUtilizationStats.average)}</span> · peak{" "}
+                                  <span className="font-medium text-foreground">{formatPercent(metadataUtilizationStats.peak)}</span>
+                                </p>
+                              </div>
+                            ) : null}
+                          </div>
+                        ) : null
+                      }
                     />
                   ) : null}
 
                   {panelKey === "ost-load-distribution" ? (
                     <ChartFrame
                       title="OST load distribution"
+                      showTitle={false}
                       subtitle="Average load per OST across the run"
                       stale={isRunResultStale}
                       emptyMessage="Run a simulation to view average OST distribution."
@@ -366,6 +390,7 @@ export function HpcLabTool() {
                   {panelKey === "job-queue-active-jobs" ? (
                     <ChartFrame
                       title="Job queue / active jobs"
+                      showTitle={false}
                       stale={isRunResultStale}
                       emptyMessage="Run a simulation to view queued, running, and completed jobs."
                       note={queueChart ? chartNote(queueChart.downsampled) : undefined}
@@ -376,6 +401,7 @@ export function HpcLabTool() {
                   {panelKey === "compute-utilization" ? (
                     <ChartFrame
                       title="Compute utilization"
+                      showTitle={false}
                       stale={isRunResultStale}
                       emptyMessage="Run a simulation to view CPU and GPU utilization."
                       note={computeUtilChart ? chartNote(computeUtilChart.downsampled) : undefined}
@@ -386,6 +412,7 @@ export function HpcLabTool() {
                   {panelKey === "waiting-on-data" ? (
                     <ChartFrame
                       title="Waiting on data"
+                      showTitle={false}
                       stale={isRunResultStale}
                       emptyMessage="Run a simulation to view wait-on-data ratio over time."
                       note={waitOnDataChart ? chartNote(waitOnDataChart.downsampled) : undefined}
@@ -396,16 +423,34 @@ export function HpcLabTool() {
                   {panelKey === "checkpoint-pause-impact" ? (
                     <ChartFrame
                       title="Checkpoint pause impact"
+                      showTitle={false}
                       stale={isRunResultStale}
-                      emptyMessage="Run a simulation to view checkpoint pause ratio and active checkpointing jobs."
+                      emptyMessage="Run a simulation to view checkpoint pause ratio and checkpoint-active jobs."
                       note={checkpointChart ? chartNote(checkpointChart.downsampled) : undefined}
-                      children={checkpointChart ? <MultiSeriesLineChart model={checkpointChart} /> : null}
+                      children={
+                        checkpointChart ? (
+                          <div className="space-y-3">
+                            <MultiSeriesLineChart model={checkpointChart} />
+                            {checkpointActiveJobsStats ? (
+                              <div className="rounded-md border border-border/70 bg-muted/30 px-3 py-2 text-xs text-foreground/75">
+                                <p>
+                                  Checkpoint-active jobs (separate from pause-ratio axis): latest{" "}
+                                  <span className="font-medium text-foreground">{checkpointActiveJobsStats.latest.toFixed(0)}</span> · avg{" "}
+                                  <span className="font-medium text-foreground">{checkpointActiveJobsStats.average.toFixed(2)}</span> · peak{" "}
+                                  <span className="font-medium text-foreground">{checkpointActiveJobsStats.peak.toFixed(0)}</span>
+                                </p>
+                              </div>
+                            ) : null}
+                          </div>
+                        ) : null
+                      }
                     />
                   ) : null}
 
                   {panelKey === "bottleneck-attribution" ? (
                     <ChartFrame
                       title="Bottleneck attribution"
+                      showTitle={false}
                       subtitle="Raw constraint signals"
                       stale={isRunResultStale}
                       emptyMessage="Run a simulation to view compute/storage/metadata/network pressure signals."

--- a/ui/partner-hub/docs/hpc-lab.md
+++ b/ui/partner-hub/docs/hpc-lab.md
@@ -65,6 +65,7 @@ When the flag is not set to `"true"`, `/hpc-lab` renders a disabled message card
 ## Phase 4 visualization additions
 - New pure visualization mapping helpers in `lib/hpc-lab/visualization.ts` transform `HpcLabSimulationResult` into deterministic render models.
 - Panel grid now renders real views when a run result exists: cluster topology, throughput over time, metadata load, average OST load distribution, job queue/active jobs, compute utilization, waiting on data, checkpoint pause impact, and raw bottleneck constraint signals.
+- Phase 4 chart models now keep unit systems separated per view: metadata ops remain on the metadata ops chart while metadata utilization is shown as separate panel stats, and checkpoint pause ratio remains on its own chart while checkpoint-active job counts are shown separately as panel stats.
 - Long timelines are deterministically downsampled for render responsiveness while preserving first/last ticks.
 - Stale run handling remains explicit; charts remain visible but marked as last-run output when controls changed after execution.
 - Bottleneck panel intentionally shows only raw pressure signals in Phase 4. User-facing dominant bottleneck attribution labeling remains deferred to Phase 5.

--- a/ui/partner-hub/lib/hpc-lab/visualization.test.ts
+++ b/ui/partner-hub/lib/hpc-lab/visualization.test.ts
@@ -4,7 +4,11 @@ import test from "node:test";
 import { simulateHpcLab } from "./engine";
 import { HPC_LAB_PRESETS } from "./presets";
 import {
+  buildCheckpointActiveJobsStats,
+  buildCheckpointChartModel,
   buildConstraintSignalsChartModel,
+  buildMetadataChartModel,
+  buildMetadataUtilizationStats,
   buildOstLoadDistributionChartModel,
   buildThroughputChartModel,
   buildTopologyModel,
@@ -77,4 +81,46 @@ test("visualization layer only transforms existing run data", () => {
     assert.equal(constraints.series[2].points[index].value, tick.constraintSignals.metadataPressure);
     assert.equal(constraints.series[3].points[index].value, tick.constraintSignals.networkPressure);
   }
+});
+
+test("metadata chart keeps ops-only series and utilization is separate deterministic stats", () => {
+  const result = simulateHpcLab(HPC_LAB_PRESETS[2].initialConfig, { totalTicks: 30 });
+  const metadataChart = buildMetadataChartModel(result, 30);
+  const metadataStats = buildMetadataUtilizationStats(result);
+
+  assert.deepEqual(
+    metadataChart.series.map((series) => series.key),
+    ["metadata-requested", "metadata-served"],
+  );
+  assert.equal(metadataChart.valueFormat, "ops");
+  assert.equal(metadataChart.yAxisLabel, "Ops/tick");
+
+  const lastTick = result.timeline[result.timeline.length - 1];
+  const expectedAverage = result.timeline.reduce((sum, tick) => sum + tick.metadataUtilization, 0) / result.timeline.length;
+  const expectedPeak = result.timeline.reduce((max, tick) => Math.max(max, tick.metadataUtilization), 0);
+
+  assert.equal(metadataStats.latest, lastTick.metadataUtilization);
+  assert.equal(metadataStats.average, expectedAverage);
+  assert.equal(metadataStats.peak, expectedPeak);
+});
+
+test("checkpoint panel keeps ratio-only line chart and separate active-job stats", () => {
+  const result = simulateHpcLab(HPC_LAB_PRESETS[1].initialConfig, { totalTicks: 60 });
+  const checkpointChart = buildCheckpointChartModel(result, 60);
+  const checkpointStats = buildCheckpointActiveJobsStats(result);
+
+  assert.deepEqual(
+    checkpointChart.series.map((series) => series.key),
+    ["checkpoint-pause-ratio"],
+  );
+  assert.equal(checkpointChart.valueFormat, "percent");
+  assert.equal(checkpointChart.yAxisLabel, "Pause ratio");
+
+  const lastTick = result.timeline[result.timeline.length - 1];
+  const expectedAverage = result.timeline.reduce((sum, tick) => sum + tick.checkpointActiveJobs, 0) / result.timeline.length;
+  const expectedPeak = result.timeline.reduce((max, tick) => Math.max(max, tick.checkpointActiveJobs), 0);
+
+  assert.equal(checkpointStats.latest, lastTick.checkpointActiveJobs);
+  assert.equal(checkpointStats.average, expectedAverage);
+  assert.equal(checkpointStats.peak, expectedPeak);
 });

--- a/ui/partner-hub/lib/hpc-lab/visualization.ts
+++ b/ui/partner-hub/lib/hpc-lab/visualization.ts
@@ -103,7 +103,6 @@ export const buildMetadataChartModel = (result: HpcLabSimulationResult, maxPoint
     [
       toSeries("metadata-requested", "Requested ops", fromTimeline(sampled, (tick) => tick.metadataOpsRequested)),
       toSeries("metadata-served", "Served ops", fromTimeline(sampled, (tick) => tick.metadataOpsServed)),
-      toSeries("metadata-utilization", "Utilization", fromTimeline(sampled, (tick) => tick.metadataUtilization)),
     ],
     downsampled,
     result.timeline.length,
@@ -164,16 +163,67 @@ export const buildCheckpointChartModel = (result: HpcLabSimulationResult, maxPoi
   const { sampled, downsampled } = downsampleTimelineDeterministic(result.timeline, maxPoints);
   return chartModel(
     "Checkpoint pause impact",
-    "Ratio / count",
-    "decimal",
-    [
-      toSeries("checkpoint-pause-ratio", "Pause ratio", fromTimeline(sampled, (tick) => tick.checkpointPauseRatio)),
-      toSeries("checkpoint-active-jobs", "Checkpoint-active jobs", fromTimeline(sampled, (tick) => tick.checkpointActiveJobs)),
-    ],
+    "Pause ratio",
+    "percent",
+    [toSeries("checkpoint-pause-ratio", "Pause ratio", fromTimeline(sampled, (tick) => tick.checkpointPauseRatio))],
     downsampled,
     result.timeline.length,
     sampled.length,
   );
+};
+
+export type HpcLabMetadataUtilizationStats = {
+  latest: number;
+  average: number;
+  peak: number;
+};
+
+export const buildMetadataUtilizationStats = (result: HpcLabSimulationResult): HpcLabMetadataUtilizationStats => {
+  const timeline = result.timeline;
+  if (timeline.length === 0) {
+    return {
+      latest: 0,
+      average: 0,
+      peak: 0,
+    };
+  }
+
+  const latest = timeline[timeline.length - 1].metadataUtilization;
+  const peak = timeline.reduce((max, tick) => Math.max(max, tick.metadataUtilization), 0);
+  const average = timeline.reduce((sum, tick) => sum + tick.metadataUtilization, 0) / timeline.length;
+
+  return {
+    latest,
+    average,
+    peak,
+  };
+};
+
+export type HpcLabCheckpointActiveJobsStats = {
+  latest: number;
+  average: number;
+  peak: number;
+};
+
+export const buildCheckpointActiveJobsStats = (result: HpcLabSimulationResult): HpcLabCheckpointActiveJobsStats => {
+  const timeline = result.timeline;
+  if (timeline.length === 0) {
+    return {
+      latest: 0,
+      average: 0,
+      peak: 0,
+    };
+  }
+
+  const latest = timeline[timeline.length - 1].checkpointActiveJobs;
+  const peak = timeline.reduce((max, tick) => Math.max(max, tick.checkpointActiveJobs), 0);
+  const average = timeline.reduce((sum, tick) => sum + tick.checkpointActiveJobs, 0) / timeline.length;
+
+  return {
+    latest,
+    average,
+    peak,
+  };
 };
 
 export const buildConstraintSignalsChartModel = (


### PR DESCRIPTION
### Motivation
- Prevent mixed-unit visualizations by keeping each line chart semantically honest (ops vs percent vs count) so users are not misled by shared axes.
- Surface utilization / counts deterministically as compact, separate panel stats rather than plotting incompatible units on one axis.
- Make chart rendering theme-safe (no hardcoded hex colors) and remove duplicate intra-card chart headings for a cleaner Phase 4 presentation while preserving all existing Phase 4 behavior.

### Description
- Metadata/checkpoint chart model changes: `buildMetadataChartModel` now contains only metadata ops series (requested/served) and `buildCheckpointChartModel` now contains only checkpoint pause ratio; added `buildMetadataUtilizationStats` and `buildCheckpointActiveJobsStats` to produce deterministic latest/avg/peak stats from run timeline. (file: `ui/partner-hub/lib/hpc-lab/visualization.ts`)
- UI wiring: panels for Metadata and Checkpoint now show the line chart for the ops/ratio and render the corresponding utilization/active-job stats as compact panel text below the chart; `ChartFrame` gained a `showTitle` prop to avoid duplicate headings where a card title is already present. (file: `ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx`, `ui/partner-hub/components/hpc-lab/charts/chart-frame.tsx`)
- Theme-safe chart styling: replaced hardcoded `#...` colors with Tailwind-safe classes and `currentColor` rendering; multi-series lines use color classes + stroke dash patterns for distinguishability; bar chart uses `currentColor` with a Tailwind text color class on the SVG. (files: `ui/partner-hub/components/hpc-lab/charts/multi-series-line-chart.tsx`, `ui/partner-hub/components/hpc-lab/charts/bar-distribution-chart.tsx`)
- Tests and docs: updated `visualization.test.ts` to assert metadata chart contains only ops series, checkpoint chart contains only ratio series, and that the new stats are deterministic and mapped from run timeline; added Phase 4 note in `ui/partner-hub/docs/hpc-lab.md`. (files: `ui/partner-hub/lib/hpc-lab/visualization.test.ts`, `ui/partner-hub/docs/hpc-lab.md`)

### Testing
- Updated unit tests: `ui/partner-hub/lib/hpc-lab/visualization.test.ts` includes new assertions verifying separation of units and deterministic stats mapping; these tests were added in the change set.
- Commands executed in this environment (repo path `ui/partner-hub`):
  - `npm run lint` — failed in this environment: `next: not found` (output: "sh: 1: next: not found").
  - `npm run typecheck` — failed due to missing dependencies/types across the repository (TypeScript reported many module/type resolution errors in this environment while attempting to typecheck the whole workspace).
  - `npm test` — full test harness failed to run in this environment due to compile/type errors (the TypeScript compile step produced missing-module/type errors before test execution).
- Note: the changes are pure TypeScript/React UI and unit-test updates and were implemented to preserve deterministic mapping from `simulateHpcLab` output; however the full lint/typecheck/test harness could not be completed here because required toolchain/dependencies for the workspace are not available in this environment.

Files changed:
- `ui/partner-hub/lib/hpc-lab/visualization.ts`
- `ui/partner-hub/lib/hpc-lab/visualization.test.ts`
- `ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx`
- `ui/partner-hub/components/hpc-lab/charts/multi-series-line-chart.tsx`
- `ui/partner-hub/components/hpc-lab/charts/bar-distribution-chart.tsx`
- `ui/partner-hub/components/hpc-lab/charts/chart-frame.tsx`
- `ui/partner-hub/docs/hpc-lab.md`

Preservation and scope statement: topology rendering, throughput, OST distribution, job queue/active jobs, compute utilization, wait-on-data, raw bottleneck constraint signals, stale-result handling, downsampling behavior, Phase 3 summary, and all control/run/reset/preset/validation behavior were left intact; this is strictly Phase 4 polish and does not implement Phase 5 bottleneck-labeling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6dd6a70688330851d9e0a1ac8e5a9)