### PR TITLE
Refine HPC Lab bottleneck evidence presentation

### DIFF
--- a/ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx
+++ b/ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx
@@ -163,7 +163,7 @@ export function HpcLabTool() {
       <header className="space-y-2">
         <h1 className="text-3xl font-semibold tracking-tight text-foreground">HPC / AI Infrastructure Learning Lab</h1>
         <p className="max-w-4xl text-sm text-foreground/70">
-          Phase 5 adds user-facing bottleneck attribution and derived metrics on top of the existing deterministic visualization layer.
+          Explore deterministic HPC/AI simulation outputs with run-level bottleneck attribution and supporting evidence charts.
         </p>
       </header>
 
@@ -484,10 +484,7 @@ export function HpcLabTool() {
                         bottleneckChart ? (
                           <div className="space-y-3">
                             <MultiSeriesLineChart model={bottleneckChart} />
-                            <p className="text-xs text-foreground/70">
-                              This raw signal chart is the primary evidence view. Phase 5 attribution summarizes these pressures at run level.
-                            </p>
-                            <BottleneckSummary attribution={bottleneckAttribution} stale={isRunResultStale} />
+                            <p className="text-xs text-foreground/70">This chart shows the raw pressure signals behind the run-level bottleneck summary.</p>
                           </div>
                         ) : null
                       }

--- a/ui/partner-hub/docs/hpc-lab.md
+++ b/ui/partner-hub/docs/hpc-lab.md
@@ -38,7 +38,7 @@ When the flag is not set to `"true"`, `/hpc-lab` renders a disabled message card
 
 ## Current architecture
 - **`app/(routes)/hpc-lab/page.tsx`**: route-level feature gate and top-level rendering.
-- **`components/hpc-lab/hpc-lab-tool.tsx`**: client-side controls, preset switching, validation UX, run summary, and Phase 5 attribution rendering.
+- **`components/hpc-lab/hpc-lab-tool.tsx`**: client-side controls, preset switching, validation UX, run summary, dedicated run-level bottleneck summary card, and raw evidence chart rendering.
 - **`components/hpc-lab/bottleneck-summary.tsx`**: presentational UI for run-level bottleneck explanation, confidence, suggestions, and derived metrics.
 - **`lib/hpc-lab/types.ts`**: stable type boundary for preset/config types, simulation domain types, and bottleneck analysis types.
 - **`lib/hpc-lab/presets.ts`**: centrally defined preset catalog, preset-aware simulation defaults, and learning guidance metadata.
@@ -81,6 +81,11 @@ Run-level labels are conservative and deterministic:
 - **network-bound**: network pressure is clearly dominant.
 - **mixed**: no single pressure is consistently dominant (close competition or frequent transitions).
 - **balanced**: pressure signals remain broadly low, so no strong bottleneck is currently active.
+
+UI presentation for bottlenecks is intentionally split and non-duplicative:
+- **Phase 5 bottleneck summary card**: the single full run-level attribution view (dominant label, confidence, explanation, next levers, and derived metrics).
+- **Bottleneck attribution panel**: raw compute/storage/metadata/network pressure signals plus a compact note linking those signals to the run-level summary.
+- Stale messaging remains clear without stacked duplicates: the summary card owns attribution staleness, while chart-level stale indicators remain in panel frames.
 
 Derived metrics are based on observed run data only:
 - Throughput fulfillment ratio: delivered total throughput / requested total throughput.

--- a/ui/partner-hub/lib/hpc-lab/visualization.ts
+++ b/ui/partner-hub/lib/hpc-lab/visualization.ts
@@ -244,7 +244,7 @@ export const buildConstraintSignalsChartModel = (
     downsampled,
     result.timeline.length,
     sampled.length,
-    "Phase 5 adds dominant bottleneck labeling.",
+    "Raw pressure signals behind run-level bottleneck attribution.",
   );
 };
 


### PR DESCRIPTION
### Motivation
- Remove a duplicated full run-level attribution view that was rendering both in the dedicated Phase 5 summary card and again inside the bottleneck evidence panel to avoid confusing, duplicated output.
- Replace stale Phase-oriented wording that implied Phase 5 labeling was still pending with accurate, concise evidence-focused text describing the role of the raw pressure chart.
- Reduce stacked stale-state messaging so stale notices are not repeated needlessly while preserving clear stale indicators where appropriate.

### Description
- Removed the duplicated `<BottleneckSummary />` from the bottleneck evidence panel so the single full run-level attribution remains in the dedicated **Phase 5 bottleneck summary** card only (`ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx`).
- Replaced stale UI wording in the page header and the bottleneck panel note with concise evidence wording, e.g. the bottleneck panel now says: "This chart shows the raw pressure signals behind the run-level bottleneck summary." (`ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx`).
- Updated the constraint-signals chart subtitle to remove the old "Phase 5 adds dominant bottleneck labeling." phrasing and instead describe the chart as raw evidence (`ui/partner-hub/lib/hpc-lab/visualization.ts`).
- Updated documentation so the `hpc-lab.md` description matches the UI split (single summary card + raw evidence chart) and notes non-duplicative stale messaging (`ui/partner-hub/docs/hpc-lab.md`).
- No analysis logic or derived-metrics code was changed; this is presentation-only cleanup and preserves all Phase 5 behavior.

### Testing
- Ran `npm run lint` from `ui/partner-hub`, which failed in this environment with a missing `next` executable; exact output:
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> partner-hub@0.0.1 lint
> next lint

sh: 1: next: not found
```
- Ran `npm run typecheck` from `ui/partner-hub`, which invoked `tsc --noEmit` and failed due to unresolved module/type declarations across the repository; the process reported many TypeScript "Cannot find module" and related errors (truncated here because the full stream is large), starting with:
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> partner-hub@0.0.1 typecheck
> tsc --noEmit

app/(routes)/about/page.tsx(1,18): error TS2307: Cannot find module 'next/link' or its corresponding type declarations.
app/(routes)/about/page.tsx(2,44): error TS2307: Cannot find module 'lucide-react' or its corresponding type declarations.
... (many additional missing module/type errors across the repo)
```
- Ran `npm test` from `ui/partner-hub`, which runs a `tsc` compile pass for tests and then `node --test`, and that run failed for the same root reasons (missing test/Node type declarations and unresolved modules); the invocation began as:
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> partner-hub@0.0.1 test
> tsc --noEmit false --module commonjs --moduleResolution node --target ES2020 --outDir .tmp-tests --rootDir . lib/energy/energy-calc.ts ...

components/ui/comboboxUtils.test.ts(1,30): error TS2307: Cannot find module 'node:test' or its corresponding type declarations.
lib/account-mapping/csv.test.ts(1,30): error TS2307: Cannot find module 'node:test' or its corresponding type declarations.
... (many additional missing node/test + dependency/type declaration errors)
```
- All three automated checks failed in this execution environment due to repository-wide type/dependency resolution issues and environment missing executables rather than as a result of the presentation-only code edits; the changes themselves are limited to text/UI presentation and documentation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7a863b2bc8330aa1e063e37646918)