### PR TITLE
ui(hpc-lab): neutralize phase labels in result card titles

### DIFF
--- a/ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx
+++ b/ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx
@@ -308,7 +308,7 @@ export function HpcLabTool() {
           {runResult ? (
             <Card className="border-border/70">
               <CardHeader>
-                <CardTitle className="text-base">Phase 3 run summary</CardTitle>
+                <CardTitle className="text-base">Run summary</CardTitle>
               </CardHeader>
               <CardContent className="grid gap-2 text-sm sm:grid-cols-2">
                 {isRunResultStale ? (
@@ -338,7 +338,7 @@ export function HpcLabTool() {
           {runResult ? (
             <Card className="border-border/70">
               <CardHeader>
-                <CardTitle className="text-base">Phase 5 bottleneck summary</CardTitle>
+                <CardTitle className="text-base">Bottleneck summary</CardTitle>
               </CardHeader>
               <CardContent>
                 <BottleneckSummary attribution={bottleneckAttribution} stale={isRunResultStale} />


### PR DESCRIPTION
### Motivation
- Make HPC Lab user-facing result cards phase-neutral by removing explicit Phase numbers from card titles so labels remain stable and user-focused over time.

### Description
- Replace the card titles in `ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx`: change `"Phase 3 run summary"` to `"Run summary"` and `"Phase 5 bottleneck summary"` to `"Bottleneck summary"`, with no other code, logic, state, layout, styling, or dependency changes; files changed: `ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx`.

### Testing
- Ran `npm run lint` in `ui/partner-hub`, which failed in this environment because the `next` binary is not available, producing:
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> partner-hub@0.0.1 lint
> next lint

sh: 1: next: not found
```
- Ran `npm run typecheck` in `ui/partner-hub`, which failed due to missing dependency/type resolution and repo-wide type errors (output truncated here because of length), beginning with:
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> partner-hub@0.0.1 typecheck
> tsc --noEmit

app/(routes)/about/page.tsx(1,18): error TS2307: Cannot find module 'next/link' or its corresponding type declarations.
app/(routes)/about/page.tsx(2,44): error TS2307: Cannot find module 'lucide-react' or its corresponding type declarations.
app/(routes)/bookings/CancelBookingForm.tsx(3,45): error TS2307: Cannot find module 'react-dom' or its corresponding type declarations.
... (many repo-wide type errors unrelated to this cosmetic change)
```
- Ran `npm test` in `ui/partner-hub`, which failed during TypeScript compilation for the test run for the same missing dependencies/type issues (output truncated), beginning with:
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> partner-hub@0.0.1 test
> tsc --noEmit false --module commonjs --moduleResolution node --target ES2020 --outDir .tmp-tests --rootDir . lib/energy/energy-calc.ts lib/energy/energy-calc.test.ts ...

components/ui/comboboxUtils.test.ts(1,30): error TS2307: Cannot find module 'node:test' or its corresponding type declarations.
lib/account-mapping/csv.test.ts(1,30): error TS2307: Cannot find module 'node:test' or its corresponding type declarations.
... (many repo-wide test/TS errors unrelated to this cosmetic change)
```

All failures are environmental or pre-existing repository-wide type/dependency issues and are unrelated to this small copy-only change; the modification is cosmetic only with no behavior changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7b005bedc83308f9fb9f63a76adb7)