### PR TITLE
Centralize stale-run live announcements in HPC Lab

### DIFF
--- a/ui/partner-hub/components/hpc-lab/bottleneck-summary.tsx
+++ b/ui/partner-hub/components/hpc-lab/bottleneck-summary.tsx
@@ -23,7 +23,7 @@ export function BottleneckSummary({ attribution, stale }: BottleneckSummaryProps
   return (
     <section className="space-y-3" aria-label="Run-level bottleneck summary">
       {stale ? (
-        <p className="rounded bg-amber-500/10 px-2 py-1 text-xs text-amber-700" aria-live="polite">
+        <p className="rounded bg-amber-500/10 px-2 py-1 text-xs text-amber-700">
           Attribution reflects the last run and is currently stale.
         </p>
       ) : null}

--- a/ui/partner-hub/components/hpc-lab/charts/chart-frame.tsx
+++ b/ui/partner-hub/components/hpc-lab/charts/chart-frame.tsx
@@ -19,7 +19,7 @@ export function ChartFrame({ title, showTitle = true, subtitle, stale = false, e
         {showTitle ? <h3 className="text-sm font-semibold text-foreground">{title}</h3> : null}
         {subtitle ? <p className="break-words text-xs text-foreground/65">{subtitle}</p> : null}
         {stale ? (
-          <p className="break-words text-xs text-amber-700" aria-live="polite">
+          <p className="break-words text-xs text-amber-700">
             Showing last run result (stale).
           </p>
         ) : null}

--- a/ui/partner-hub/docs/hpc-lab.md
+++ b/ui/partner-hub/docs/hpc-lab.md
@@ -89,6 +89,7 @@ This guidance is directional and educational. It does not guarantee a fixed outc
 ## Phase 6 polish and hardening notes (implemented)
 - Removed residual phase-number language from end-user UI copy.
 - Improved accessibility for validation messaging, stale notices, and chart labeling/legend readability.
+- Centralized stale-run live announcements to the run summary and kept repeated stale badges in bottleneck/chart areas visual-only to reduce screen-reader announcement noise.
 - Hardened empty/minimal rendering paths for charts and helper outputs without synthetic fallback data.
 - Tightened responsive wrapping/overflow behavior for dense panels, guidance text, and long explanatory content.
 - Kept deterministic simulation and attribution contracts intact.


### PR DESCRIPTION
### Motivation
- Reduce repeated polite screen-reader announcements when a run becomes stale by centralizing live-region announcements while preserving visible stale messaging.

### Description
- Removed `aria-live="polite"` from the stale notice in `BottleneckSummary` so it remains visual-only (`ui/partner-hub/components/hpc-lab/bottleneck-summary.tsx`).
- Removed `aria-live="polite"` from the stale notice in `ChartFrame` so chart badges are visual-only (`ui/partner-hub/components/hpc-lab/charts/chart-frame.tsx`).
- Kept the existing `aria-live="polite"` stale notice in the Run summary as the single canonical live-announcement region (`ui/partner-hub/components/hpc-lab/hpc-lab-tool.tsx`).
- Updated docs to note that stale-run live announcements are centralized for reduced announcement noise (`ui/partner-hub/docs/hpc-lab.md`).

### Testing
- Ran `npm run lint` from `ui/partner-hub` and it failed with `next: not found` as shown: `> partner-hub@0.0.1 lint` then `sh: 1: next: not found`.
- Ran `npm run typecheck` from `ui/partner-hub` and it failed with many pre-existing TypeScript resolution/errors starting with errors like `Cannot find module 'next/link' or its corresponding type declarations.'` and numerous other TS errors from the workspace.
- Ran `npm test` from `ui/partner-hub` and it failed with pre-existing test/TS environment errors including missing `node:test` and multiple module/typing failures as reported by `tsc`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7bbca9734833091ff9d6fb1181852)