### PR TITLE
Initialize Phase 01 foundation scaffold for local Fivetran ELT lab

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+- Describe what changed.
+- Describe why it changed.
+
+## Contract & standards checklist
+
+- [ ] I verified no modified/new file exceeds 500 lines, or I documented an approved exception.
+- [ ] I updated relevant documentation for all new functionality.
+- [ ] I updated `README.md` for user-facing setup changes.
+- [ ] I updated the relevant phase document under `docs/phases/`.
+- [ ] I avoided hidden fallbacks and documented any explicit fallback behavior.
+- [ ] I kept responsibilities separated by folder.
+- [ ] I documented any new or changed scripts.
+
+## Validation
+
+Paste command output for:
+
+- `python3 tools/validate/check_file_lengths.py`
+- `python3 tools/validate/check_required_docs.py`
+- `python3 tools/validate/check_required_top_level.py`
+- `make validate`

--- a/.github/workflows/validate-foundation.yml
+++ b/.github/workflows/validate-foundation.yml
@@ -1,0 +1,29 @@
+name: Validate Foundation
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - work
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate file lengths
+        run: python3 tools/validate/check_file_lengths.py
+
+      - name: Validate required docs
+        run: python3 tools/validate/check_required_docs.py
+
+      - name: Validate required top-level files
+        run: python3 tools/validate/check_required_top_level.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,32 @@
-# dependencies
-node_modules/
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+.pytest_cache/
+.mypy_cache/
+.venv/
+venv/
 
-# Next.js
-.next/
-out/
+# dbt
+.dbt/
+target/
+logs/
+dbt_packages/
 
-# env
-.env.local
-.env.*.local
+# Docker
+*.pid
+docker-compose.override.yml
 
-# logs
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
+# Environment files
+.env
+.env.*
+!.env.example
 
-# OS
+# OS / editor clutter
 .DS_Store
 Thumbs.db
-
-**/__pycache__/
-*.pyc
-
+*.swp
+*.swo
+.vscode/
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+# Foundation Makefile for registrations- local ELT lab
+
+.PHONY: validate check-file-lengths check-required-docs check-required-top-level
+
+# Run all phase-01 validation checks.
+validate:
+	python3 tools/validate/check_file_lengths.py
+	python3 tools/validate/check_required_docs.py
+	python3 tools/validate/check_required_top_level.py
+
+# Enforce the 500-line file-size policy.
+check-file-lengths:
+	python3 tools/validate/check_file_lengths.py
+
+# Verify required docs are present.
+check-required-docs:
+	python3 tools/validate/check_required_docs.py
+
+# Verify required top-level files are present.
+check-required-top-level:
+	python3 tools/validate/check_required_top_level.py
+
+# Future phase placeholder targets:
+# phase-02-up:      Start Docker + PostgreSQL stack.
+# phase-02-down:    Stop local runtime services.
+# phase-03-seed:    Load seed datasets.
+# phase-04-dbt:     Run dbt models and tests.
+# phase-05-sim:     Execute simulation workflows.
+# phase-06-runbook: Run operator runbook checks.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# registrations-: Fivetran ELT Lab Foundation
+
+This repository is the staged foundation for a **local Fivetran ELT lab**. Phase 01 intentionally focuses on structure, standards, and enforcement so future implementation phases can be built predictably.
+
+## What this repository is for
+
+The repo will host a local ELT lab workflow centered on:
+
+- Local infrastructure bootstrap (Docker + PostgreSQL).
+- Seeded source data for repeatable sync tests.
+- dbt transformations for modeled analytics layers.
+- Simulation and operator runbook workflows.
+
+Implementation details beyond this scaffold are deferred to later phases by design.
+
+## Planned future phases
+
+- **Phase 01**: Foundation and standards (this phase).
+- **Phase 02**: Docker + PostgreSQL local environment.
+- **Phase 03**: Seed data setup.
+- **Phase 04**: dbt project setup and transformations.
+- **Phase 05**: Simulation workflows.
+- **Phase 06**: Operator runbook and operationalization.
+
+See phase trackers in [`docs/phases/`](docs/phases/) for phase-by-phase scope.
+
+## Current status (after Phase 01)
+
+✅ Repository scaffold exists with docs, standards, validation scripts, CI workflow, and contributor templates.
+
+✅ Contract and standards are documented and enforceable with local checks.
+
+🚫 No full ELT lab implementation is included yet.
+
+## Standards enforcement
+
+Standards are enforced using:
+
+- Repository contract: [`docs/standards/repo-contract.md`](docs/standards/repo-contract.md)
+- Documentation standard: [`docs/standards/documentation-standard.md`](docs/standards/documentation-standard.md)
+- File size policy: [`docs/standards/file-size-policy.md`](docs/standards/file-size-policy.md)
+- Testing standard: [`docs/standards/testing-standard.md`](docs/standards/testing-standard.md)
+- Validation tooling: [`tools/validate/`](tools/validate/)
+- CI workflow: [`.github/workflows/validate-foundation.yml`](.github/workflows/validate-foundation.yml)
+- PR checklist template: [`.github/pull_request_template.md`](.github/pull_request_template.md)
+
+## Quickstart checks
+
+Run foundational checks locally:
+
+```bash
+python3 tools/validate/check_file_lengths.py
+python3 tools/validate/check_required_docs.py
+python3 tools/validate/check_required_top_level.py
+```
+
+Or run all checks:
+
+```bash
+make validate
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# Documentation Map
+
+This folder contains the authoritative project documentation for the Fivetran ELT lab foundation.
+
+## Structure
+
+- [`architecture/`](architecture/) — architecture overview and system boundaries.
+- [`operations/`](operations/) — operational guidance and runbook-oriented docs.
+- [`standards/`](standards/) — contract, policies, and quality standards.
+- [`phases/`](phases/) — phase trackers and delivery checkpoints.
+
+## Related docs
+
+- Top-level onboarding: [`../README.md`](../README.md)
+- Validation tooling: [`../tools/validate/README.md`](../tools/validate/README.md)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,13 @@
+# Architecture Docs
+
+This section will define architecture for each phase as implementation is introduced.
+
+## Current scope
+
+- Defines that this repository is scaffold-first.
+- Avoids implementation-specific details until relevant phase delivery.
+
+## Next updates
+
+- Phase 02 should add local container architecture diagrams and component responsibilities.
+- Phase 04 should add dbt model-layer architecture and data flow.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,13 @@
+# Operations Docs
+
+This section will evolve into operator documentation and runbooks.
+
+## Current scope
+
+- Documents operational standards and update expectations.
+- Tracks that no runtime operations are implemented in Phase 01.
+
+## Next updates
+
+- Phase 02+: include setup/start/stop workflows.
+- Phase 06: complete operator runbook with troubleshooting and maintenance tasks.

--- a/docs/phases/phase-01-foundation.md
+++ b/docs/phases/phase-01-foundation.md
@@ -1,0 +1,45 @@
+# Phase 01 — Foundation
+
+## Objective
+
+Establish repository structure, standards, validation tooling, and CI enforcement without implementing the full ELT lab.
+
+## Added in this phase
+
+- Top-level repository README with scope, status, and enforcement model.
+- Documentation hierarchy under `docs/` with architecture, operations, standards, and phases.
+- Repository contract and standards docs:
+  - Contract
+  - Documentation standard
+  - File size policy
+  - Testing standard
+- PR template enforcing docs and file-size compliance checks.
+- `.editorconfig` and practical `.gitignore`.
+- Placeholder `Makefile` for future phase commands.
+- Validation scripts in `tools/validate/` for:
+  - file length policy
+  - required docs presence
+  - required top-level files presence
+- Minimal CI workflow running the validation scripts.
+
+## Not included
+
+- No Docker/PostgreSQL implementation.
+- No seed data workflow implementation for this lab.
+- No dbt project implementation.
+- No simulation or operator runbook implementation.
+
+## Validation executed
+
+- `python3 tools/validate/check_file_lengths.py`
+- `python3 tools/validate/check_required_docs.py`
+- `python3 tools/validate/check_required_top_level.py`
+- `make validate`
+
+## Exit criteria status
+
+- [x] Clean documented skeleton exists.
+- [x] Contract exists and is actionable.
+- [x] Validation tooling exists and runs.
+- [x] CI runs validation tooling.
+- [x] README/docs alignment established for current phase.

--- a/docs/phases/phase-02-docker-postgres.md
+++ b/docs/phases/phase-02-docker-postgres.md
@@ -1,0 +1,20 @@
+# Phase 02 — Docker + PostgreSQL
+
+## Objective
+
+Define and implement local containerized runtime foundation for ELT lab execution.
+
+## Planned scope
+
+- Docker Compose baseline.
+- PostgreSQL service bootstrap.
+- Local startup and teardown commands.
+- Setup troubleshooting notes.
+
+## Dependencies
+
+- Phase 01 standards and validation baseline.
+
+## Status
+
+- Not started.

--- a/docs/phases/phase-03-seed-data.md
+++ b/docs/phases/phase-03-seed-data.md
@@ -1,0 +1,19 @@
+# Phase 03 — Seed Data
+
+## Objective
+
+Introduce deterministic seed datasets and ingestion prep for local ELT testing.
+
+## Planned scope
+
+- Seed data folder conventions.
+- Seed load scripts and documentation.
+- Validation checks for seed prerequisites.
+
+## Dependencies
+
+- Phase 02 runtime environment.
+
+## Status
+
+- Not started.

--- a/docs/phases/phase-04-dbt.md
+++ b/docs/phases/phase-04-dbt.md
@@ -1,0 +1,19 @@
+# Phase 04 — dbt
+
+## Objective
+
+Add dbt project structure and initial transform modeling workflow.
+
+## Planned scope
+
+- dbt project initialization.
+- Source and staging model definitions.
+- Basic model tests and run instructions.
+
+## Dependencies
+
+- Phase 02 infrastructure and Phase 03 seed data.
+
+## Status
+
+- Not started.

--- a/docs/phases/phase-05-simulation.md
+++ b/docs/phases/phase-05-simulation.md
@@ -1,0 +1,19 @@
+# Phase 05 — Simulation
+
+## Objective
+
+Introduce simulation workflows to exercise ELT behavior and validate operational assumptions.
+
+## Planned scope
+
+- Simulation script structure.
+- Documented execution patterns.
+- Observability outputs and checks.
+
+## Dependencies
+
+- Phases 02–04 complete.
+
+## Status
+
+- Not started.

--- a/docs/phases/phase-06-operator-runbook.md
+++ b/docs/phases/phase-06-operator-runbook.md
@@ -1,0 +1,19 @@
+# Phase 06 — Operator Runbook
+
+## Objective
+
+Finalize operational runbook procedures for maintaining and troubleshooting the local ELT lab.
+
+## Planned scope
+
+- Standard operating procedures.
+- Incident/troubleshooting guidance.
+- Maintenance cadence and handoff notes.
+
+## Dependencies
+
+- Phases 01–05 complete.
+
+## Status
+
+- Not started.

--- a/docs/standards/documentation-standard.md
+++ b/docs/standards/documentation-standard.md
@@ -1,0 +1,20 @@
+# Documentation Standard
+
+## Purpose
+
+Ensure repository documentation remains complete, consistent, and usable across phased delivery.
+
+## Requirements
+
+- Documentation updates are required for all functional changes.
+- New scripts/tools must include a usage section and expected outputs.
+- Cross-link related docs to reduce drift and discovery friction.
+- Document assumptions and non-goals when implementation details are intentionally deferred.
+- Keep docs concise, explicit, and operational.
+
+## Minimum documentation checklist for each phase
+
+- Update phase file in `docs/phases/`.
+- Update `README.md` if setup flow or user-facing behavior changed.
+- Update standards docs if policy/contract changed.
+- Confirm validation commands and output are captured in phase notes or PR.

--- a/docs/standards/file-size-policy.md
+++ b/docs/standards/file-size-policy.md
@@ -1,0 +1,18 @@
+# File Size Policy
+
+## Rule
+
+- No file should exceed **500 lines**.
+
+## Allowed exception process
+
+If a file must exceed 500 lines:
+
+1. Document the reason in the pull request.
+2. Add or update a standards note capturing the exception scope.
+3. Confirm why splitting by responsibility is not practical.
+
+## Enforcement
+
+- `tools/validate/check_file_lengths.py` enforces file size constraints.
+- CI fails when violating files are detected.

--- a/docs/standards/repo-contract.md
+++ b/docs/standards/repo-contract.md
@@ -1,0 +1,40 @@
+# Repository Contract
+
+This contract is mandatory for all contributors and all phases.
+
+## Non-negotiable rules
+
+1. **File length cap**
+   - Source and documentation files must remain at or below **500 lines**.
+   - Exceptions must be explicitly documented in the pull request and in a standards doc update.
+
+2. **Documentation parity**
+   - Any new functionality must include documentation updates in the relevant docs folder.
+   - If setup steps or user-facing behavior changes, update both `README.md` and the relevant phase doc.
+
+3. **Phase accountability**
+   - Every phase must update its own phase tracker under `docs/phases/`.
+   - Phase docs must list what was added, what remains, and what validation was run.
+
+4. **No hidden fallbacks**
+   - Do not add silent fallback paths, magic defaults, or undocumented bypass behavior.
+   - Any fallback behavior must be explicit, documented, and test-covered.
+
+5. **Separation of responsibilities**
+   - `docs/` for documentation.
+   - `tools/` for automation and validation scripts.
+   - `.github/` for CI and contribution workflows.
+   - Keep folder purpose clear; avoid mixing concerns.
+
+6. **Script documentation is required**
+   - Every script must have clear purpose, input/output expectations, and run instructions documented.
+
+7. **Explicit, readable naming**
+   - File, folder, script, and variable names must be descriptive.
+   - Avoid ambiguous abbreviations unless industry-standard and documented.
+
+## Enforcement
+
+- Local checks in `tools/validate/` enforce baseline compliance.
+- CI workflow `.github/workflows/validate-foundation.yml` runs these checks on pull requests.
+- PR template requires explicit confirmation of contract adherence.

--- a/docs/standards/testing-standard.md
+++ b/docs/standards/testing-standard.md
@@ -1,0 +1,23 @@
+# Testing Standard
+
+## Purpose
+
+Provide predictable validation quality across phases.
+
+## Phase 01 baseline
+
+At minimum, each pull request must run:
+
+- File length validation.
+- Required documentation presence validation.
+- Required top-level file presence validation.
+
+## Expectations for later phases
+
+- Add component-level tests as functionality is introduced.
+- Keep test commands deterministic and documented.
+- Avoid hidden test dependencies; document required tooling and versions.
+
+## CI policy
+
+Validation tooling under `tools/validate/` must run in CI for pull requests and main branch pushes.

--- a/tools/validate/README.md
+++ b/tools/validate/README.md
@@ -1,0 +1,25 @@
+# Validation Tools
+
+These scripts enforce the Phase 01 foundation contract.
+
+## Scripts
+
+- `check_file_lengths.py`
+  - Enforces a 500-line maximum per tracked text file.
+  - Exits non-zero when violations are found.
+
+- `check_required_docs.py`
+  - Validates presence of required documentation files for the scaffold.
+  - Exits non-zero when required docs are missing.
+
+- `check_required_top_level.py`
+  - Validates required top-level repository files exist.
+  - Exits non-zero when required files are missing.
+
+## Usage
+
+```bash
+python3 tools/validate/check_file_lengths.py
+python3 tools/validate/check_required_docs.py
+python3 tools/validate/check_required_top_level.py
+```

--- a/tools/validate/check_file_lengths.py
+++ b/tools/validate/check_file_lengths.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Enforce the phase-01 500-line file-size policy for foundation-managed files."""
+
+from pathlib import Path
+import sys
+
+MAX_LINES = 500
+ROOT = Path(__file__).resolve().parents[2]
+
+SCOPED_PATHS = [
+    ROOT / "README.md",
+    ROOT / "Makefile",
+    ROOT / ".editorconfig",
+    ROOT / ".gitignore",
+    ROOT / "docs",
+    ROOT / "tools",
+    ROOT / ".github",
+]
+
+SKIP_EXTENSIONS = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".svg",
+    ".pdf",
+    ".mp3",
+    ".wav",
+    ".pptx",
+    ".zip",
+    ".tar",
+    ".gz",
+    ".db",
+}
+
+
+def iter_scoped_files() -> list[Path]:
+    files: list[Path] = []
+    for item in SCOPED_PATHS:
+        if not item.exists():
+            continue
+        if item.is_file():
+            files.append(item)
+            continue
+        for path in item.rglob("*"):
+            if path.is_file() and path.suffix.lower() not in SKIP_EXTENSIONS:
+                files.append(path)
+    return sorted(set(files))
+
+
+def line_count(path: Path) -> int | None:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return sum(1 for _ in handle)
+    except UnicodeDecodeError:
+        return None
+
+
+def main() -> int:
+    violations: list[tuple[Path, int]] = []
+    checked = 0
+
+    for file_path in iter_scoped_files():
+        count = line_count(file_path)
+        if count is None:
+            continue
+        checked += 1
+        if count > MAX_LINES:
+            violations.append((file_path, count))
+
+    print(f"Checked {checked} file(s) against {MAX_LINES}-line limit.")
+
+    if violations:
+        print("\nFile length violations found:")
+        for path, count in violations:
+            rel = path.relative_to(ROOT)
+            print(f" - {rel}: {count} lines")
+        return 1
+
+    print("PASS: no file length violations in validation scope.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate/check_required_docs.py
+++ b/tools/validate/check_required_docs.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Verify required documentation files for the scaffold are present."""
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+
+REQUIRED_DOCS = [
+    "README.md",
+    "docs/README.md",
+    "docs/architecture/README.md",
+    "docs/operations/README.md",
+    "docs/standards/repo-contract.md",
+    "docs/standards/documentation-standard.md",
+    "docs/standards/file-size-policy.md",
+    "docs/standards/testing-standard.md",
+    "docs/phases/phase-01-foundation.md",
+    "docs/phases/phase-02-docker-postgres.md",
+    "docs/phases/phase-03-seed-data.md",
+    "docs/phases/phase-04-dbt.md",
+    "docs/phases/phase-05-simulation.md",
+    "docs/phases/phase-06-operator-runbook.md",
+    "tools/validate/README.md",
+]
+
+
+def main() -> int:
+    missing = [path for path in REQUIRED_DOCS if not (ROOT / path).exists()]
+
+    if missing:
+        print("FAIL: missing required documentation files:")
+        for path in missing:
+            print(f" - {path}")
+        return 1
+
+    print(f"PASS: all {len(REQUIRED_DOCS)} required documentation file(s) exist.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate/check_required_top_level.py
+++ b/tools/validate/check_required_top_level.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Verify required top-level repository files are present."""
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+
+REQUIRED_TOP_LEVEL = [
+    "README.md",
+    "Makefile",
+    ".editorconfig",
+    ".gitignore",
+    ".github/pull_request_template.md",
+    ".github/workflows/validate-foundation.yml",
+]
+
+
+def main() -> int:
+    missing = [path for path in REQUIRED_TOP_LEVEL if not (ROOT / path).exists()]
+
+    if missing:
+        print("FAIL: missing required top-level file(s):")
+        for path in missing:
+            print(f" - {path}")
+        return 1
+
+    print(f"PASS: all {len(REQUIRED_TOP_LEVEL)} required top-level file(s) exist.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation

- Establish a minimal, enforceable repository scaffold to support later phases of a local Fivetran ELT lab. 
- Provide explicit, actionable standards (contract, documentation, testing, file-size) so contributors follow a predictable delivery pattern. 
- Add lightweight validation and CI so the standards are automatically checked on changes.

### Description

- Added a top-level `README.md` and a `docs/` hierarchy with `architecture/`, `operations/`, `standards/`, and `phases/` and populated the phase tracker files for phases 01–06. 
- Introduced an explicit repository contract and separate standards docs at `docs/standards/` for documentation, file-size, and testing policies. 
- Added contributor and hygiene files including `.editorconfig`, a practical `.gitignore`, a placeholder `Makefile` with commented future targets, and a PR checklist at `.github/pull_request_template.md`. 
- Implemented validation tooling under `tools/validate/` (`check_file_lengths.py`, `check_required_docs.py`, `check_required_top_level.py`) and a minimal GitHub Actions workflow at `.github/workflows/validate-foundation.yml` to run those checks.

### Testing

- Ran `python3 tools/validate/check_file_lengths.py` which output `PASS: no file length violations in validation scope.`. 
- Ran `python3 tools/validate/check_required_docs.py` which output `PASS: all 15 required documentation file(s) exist.`. 
- Ran `python3 tools/validate/check_required_top_level.py` which output `PASS: all 6 required top-level file(s) exist.`. 
- Ran `make validate` which executed the three validation scripts and passed locally, and CI is configured to run the same checks on pull requests and pushes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfdf9673f08330b03667afba6fc750)