### PR TITLE
Polish /ddn-fsi-whiteboard for clearer 2-minute Loom walkthrough

### DIFF
--- a/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx
+++ b/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx
@@ -13,13 +13,13 @@ type WorkloadContent = {
   ddnFit: string;
 };
 
-const STAGE_ORDER: Array<{ key: StageKey; label: string }> = [
-  { key: "dataSources", label: "Data Sources" },
-  { key: "ingest", label: "Ingest" },
-  { key: "dataAccessLayer", label: "Data Access Layer" },
-  { key: "compute", label: "Compute" },
-  { key: "workloads", label: "Workloads" },
-  { key: "businessOutcomes", label: "Business Outcomes" },
+const STAGE_ORDER: Array<{ key: StageKey; label: string; step: number }> = [
+  { key: "dataSources", label: "Data Sources", step: 1 },
+  { key: "ingest", label: "Ingest", step: 2 },
+  { key: "dataAccessLayer", label: "Data Access", step: 3 },
+  { key: "compute", label: "Compute", step: 4 },
+  { key: "workloads", label: "Workloads", step: 5 },
+  { key: "businessOutcomes", label: "Outcomes", step: 6 },
 ];
 
 const WORKLOADS: Record<WorkloadKey, WorkloadContent> = {
@@ -95,9 +95,7 @@ export default function DdnFsiWhiteboardPage() {
           impact.
         </p>
         <p className={styles.structureNote}>The structure stays consistent. The pressure points change by workload.</p>
-        <p className={styles.loomHint}>
-          Use this view to walk left-to-right, then switch workloads to show how the pressure point changes.
-        </p>
+        <p className={styles.loomHint}>Walk left-to-right. Identify the constraint. Tie it to an outcome.</p>
       </section>
 
       <section className={styles.tabSection} aria-label="Workload selector">
@@ -139,20 +137,32 @@ export default function DdnFsiWhiteboardPage() {
               <article
                 className={`${styles.stageCard} ${isDataAccess ? styles.dataAccessCard : ""} ${isBusinessOutcome ? styles.outcomeCard : ""}`}
               >
-                <h2 className={styles.stageTitle}>{stage.label}</h2>
+                <div className={styles.stageHeader}>
+                  <span className={styles.stageBadge} aria-hidden="true">
+                    {stage.step}
+                  </span>
+                  <h2 className={styles.stageTitle}>{stage.label}</h2>
+                </div>
                 <ul className={styles.stageList}>
                   {workload.stages[stage.key].map((item) => (
                     <li key={item}>{item}</li>
                   ))}
                 </ul>
                 {isDataAccess ? (
-                  <div className={styles.ddnFitPanel}>
-                    <p className={styles.ddnFitLabel}>DDN fit: remove the data bottleneck</p>
-                    <p className={styles.ddnFitCopy}>{workload.ddnFit}</p>
-                  </div>
+                  <>
+                    <p className={styles.dataAccessCallout}>This is usually where DDN enters the conversation.</p>
+                    <div className={styles.ddnFitPanel}>
+                      <p className={styles.ddnFitLabel}>DDN fit: remove the data bottleneck</p>
+                      <p className={styles.ddnFitCopy}>{workload.ddnFit}</p>
+                    </div>
+                  </>
                 ) : null}
               </article>
-              {index < STAGE_ORDER.length - 1 ? <span className={styles.arrow} aria-hidden="true">→</span> : null}
+              {index < STAGE_ORDER.length - 1 ? (
+                <span className={styles.arrow} aria-hidden="true">
+                  →
+                </span>
+              ) : null}
             </div>
           );
         })}
@@ -167,9 +177,16 @@ export default function DdnFsiWhiteboardPage() {
             <li>Find the constraint</li>
             <li>Tie DDN to measurable impact</li>
           </ol>
+          <h3 className={styles.talkTrackTitle}>2-minute talk track</h3>
+          <ul>
+            <li>Start with the business workload</li>
+            <li>Map the data flow</li>
+            <li>Find where data access slows the pipeline</li>
+            <li>Connect DDN to the measurable outcome</li>
+          </ul>
         </article>
 
-        <aside className={styles.stickyNote}>
+        <aside key={selectedWorkload} className={styles.stickyNote}>
           <p className={styles.stickyLabel}>Discovery question:</p>
           <p className={styles.stickyText}>“{workload.discoveryQuestion}”</p>
           <p className={styles.stickyWorkload}>{workload.label}</p>

--- a/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/whiteboard.module.css
+++ b/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/whiteboard.module.css
@@ -1,6 +1,6 @@
 .page {
   min-height: 100vh;
-  padding: clamp(1.25rem, 2vw, 2.5rem);
+  padding: clamp(1rem, 1.4vw, 1.8rem);
   background:
     radial-gradient(circle at 10% 10%, rgba(255, 255, 255, 0.8), transparent 40%),
     radial-gradient(circle at 90% 20%, rgba(255, 252, 235, 0.6), transparent 35%),
@@ -19,64 +19,68 @@
 .loomHint,
 .callout,
 .ddnFitLabel,
-.stickyLabel {
+.stickyLabel,
+.stageBadge,
+.dataAccessCallout,
+.talkTrackTitle {
   font-family: "Comic Sans MS", "Bradley Hand", "Segoe Print", cursive;
 }
 
 .kicker {
   margin: 0;
   color: #3d4b60;
-  font-size: 1rem;
+  font-size: 0.95rem;
 }
 
 .title {
-  margin: 0.35rem 0;
-  font-size: clamp(2rem, 3vw, 2.8rem);
-  line-height: 1.1;
+  margin: 0.2rem 0;
+  font-size: clamp(1.8rem, 2.6vw, 2.4rem);
+  line-height: 1.08;
   font-family: "Comic Sans MS", "Bradley Hand", "Segoe Print", cursive;
 }
 
 .subtitle {
   margin: 0;
-  max-width: 72ch;
-  font-size: 1.1rem;
+  max-width: 68ch;
+  font-size: 1rem;
   color: #344054;
 }
 
 .structureNote {
-  margin-top: 0.85rem;
-  font-size: 1.15rem;
+  margin-top: 0.6rem;
+  font-size: 1.05rem;
 }
 
 .loomHint {
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
   font-size: 1rem;
-  color: #4a5565;
+  color: #334155;
+  font-weight: 700;
 }
 
 .tabSection {
-  margin-top: 1.5rem;
+  margin-top: 1rem;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.8rem;
+  gap: 0.7rem;
   align-items: center;
 }
 
 .tabs {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65rem;
+  gap: 0.6rem;
 }
 
 .tabButton,
 .resetButton {
   border: 2px solid #7f8da6;
   border-radius: 999px;
-  padding: 0.55rem 1rem;
+  padding: 0.5rem 0.92rem;
   background: #fff;
-  font-size: 0.98rem;
+  font-size: 0.94rem;
   cursor: pointer;
-  transition: transform 120ms ease, background-color 120ms ease;
+  transition: transform 120ms ease, background-color 120ms ease, box-shadow 120ms ease;
 }
 
 .tabButton:hover,
@@ -94,7 +98,8 @@
 .tabButtonActive {
   background: #dceafe;
   border-color: #1d4ed8;
-  box-shadow: 0 0 0 2px rgba(29, 78, 216, 0.2);
+  font-weight: 700;
+  box-shadow: 0 0 0 2px rgba(29, 78, 216, 0.22);
 }
 
 .resetButton:disabled {
@@ -103,31 +108,29 @@
 }
 
 .pipelineSection {
-  margin-top: 1.35rem;
+  margin-top: 1rem;
   display: grid;
-  grid-template-columns: repeat(6, minmax(180px, 1fr));
-  gap: 0.75rem;
+  grid-template-columns: repeat(6, minmax(140px, 1fr));
+  gap: 0.55rem;
   align-items: start;
-  overflow-x: auto;
-  padding-bottom: 0.5rem;
 }
 
 .stageWithArrow {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.35rem;
   min-width: 0;
 }
 
 .stageCard {
   position: relative;
   width: 100%;
-  min-height: 270px;
-  border-radius: 18px;
+  min-height: 220px;
+  border-radius: 16px;
   border: 2px solid #8d99aa;
   background: #ffffffee;
-  padding: 0.85rem;
-  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.08);
+  padding: 0.7rem;
+  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.08);
 }
 
 .stageCard::before {
@@ -135,25 +138,46 @@
   position: absolute;
   inset: 5px;
   border: 1px dashed rgba(71, 85, 105, 0.28);
-  border-radius: 14px;
+  border-radius: 12px;
   pointer-events: none;
+}
+
+.stageHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.42rem;
+}
+
+.stageBadge {
+  display: inline-flex;
+  width: 1.45rem;
+  height: 1.45rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 2px solid #475569;
+  background: #fffdf4;
+  color: #1f2937;
+  font-size: 0.88rem;
+  line-height: 1;
+  transform: rotate(-8deg);
 }
 
 .stageTitle {
   margin: 0;
-  font-size: 1.02rem;
+  font-size: 0.95rem;
   font-family: "Comic Sans MS", "Bradley Hand", "Segoe Print", cursive;
 }
 
 .stageList {
-  margin: 0.65rem 0 0;
-  padding-left: 1.15rem;
-  font-size: 0.94rem;
-  line-height: 1.45;
+  margin: 0.45rem 0 0;
+  padding-left: 1rem;
+  font-size: 0.88rem;
+  line-height: 1.35;
 }
 
 .arrow {
-  font-size: 1.4rem;
+  font-size: 1.15rem;
   color: #55637a;
   font-family: "Comic Sans MS", "Bradley Hand", "Segoe Print", cursive;
 }
@@ -161,15 +185,26 @@
 .dataAccessCard {
   border-width: 3px;
   border-color: #1d4ed8;
-  background: linear-gradient(165deg, #f6f9ff 0%, #ffffff 70%);
-  box-shadow: 0 10px 20px rgba(29, 78, 216, 0.2);
+  background: linear-gradient(165deg, #f3f8ff 0%, #ffffff 70%);
+  box-shadow: 0 10px 18px rgba(29, 78, 216, 0.2);
+}
+
+.dataAccessCallout {
+  margin: 0.5rem 0 0;
+  padding: 0.28rem 0.45rem;
+  border-left: 3px solid #1d4ed8;
+  background: #edf4ff;
+  color: #0f2f71;
+  font-size: 0.85rem;
+  line-height: 1.25;
+  transform: rotate(-1deg);
 }
 
 .ddnFitPanel {
-  margin-top: 0.65rem;
+  margin-top: 0.5rem;
   border: 1px solid #1d4ed8;
-  border-radius: 12px;
-  padding: 0.55rem;
+  border-radius: 10px;
+  padding: 0.5rem;
   background: #eaf1ff;
 }
 
@@ -177,12 +212,14 @@
   margin: 0;
   color: #12357e;
   font-weight: 700;
+  font-size: 0.87rem;
 }
 
 .ddnFitCopy {
-  margin: 0.45rem 0 0;
-  font-size: 0.88rem;
+  margin: 0.35rem 0 0;
+  font-size: 0.82rem;
   color: #1e293b;
+  line-height: 1.3;
 }
 
 .outcomeCard {
@@ -191,37 +228,55 @@
 }
 
 .bottomGrid {
-  margin-top: 1.35rem;
+  margin-top: 0.95rem;
   display: grid;
-  grid-template-columns: minmax(270px, 1fr) minmax(270px, 1fr);
-  gap: 0.95rem;
+  grid-template-columns: minmax(320px, 1.4fr) minmax(260px, 1fr);
+  gap: 0.8rem;
 }
 
 .conversationMode,
 .stickyNote {
-  border-radius: 18px;
+  border-radius: 16px;
   border: 2px solid #7f8da6;
   background: #ffffffea;
-  padding: 1rem;
+  padding: 0.8rem;
 }
 
 .panelTitle {
   margin: 0;
-  font-size: 1.2rem;
+  font-size: 1.05rem;
   font-family: "Comic Sans MS", "Bradley Hand", "Segoe Print", cursive;
 }
 
-.conversationMode ol {
-  margin: 0.7rem 0 0;
-  padding-left: 1.3rem;
+.conversationMode ol,
+.conversationMode ul {
+  margin: 0.45rem 0 0;
+  padding-left: 1.2rem;
+  font-size: 0.94rem;
+  line-height: 1.45;
+}
+
+.talkTrackTitle {
+  margin: 0.55rem 0 0;
   font-size: 1rem;
-  line-height: 1.55;
 }
 
 .stickyNote {
   background: #fff4af;
   border-color: #876f11;
   transform: rotate(-1deg);
+  animation: stickyRefresh 220ms ease-out;
+}
+
+@keyframes stickyRefresh {
+  from {
+    opacity: 0.7;
+    transform: rotate(-1.6deg) scale(0.988);
+  }
+  to {
+    opacity: 1;
+    transform: rotate(-1deg) scale(1);
+  }
 }
 
 .stickyLabel {
@@ -231,40 +286,39 @@
 }
 
 .stickyText {
-  margin: 0.5rem 0 0;
-  font-size: 1.2rem;
-  line-height: 1.4;
+  margin: 0.4rem 0 0;
+  font-size: 1.08rem;
+  line-height: 1.32;
   color: #312607;
 }
 
 .stickyWorkload {
-  margin: 0.65rem 0 0;
-  font-size: 0.95rem;
+  margin: 0.55rem 0 0;
+  font-size: 0.9rem;
   color: #4c3f0a;
 }
 
 .calloutRow {
-  margin-top: 1rem;
+  margin-top: 0.8rem;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65rem;
+  gap: 0.55rem;
 }
 
 .callout {
   border-radius: 999px;
   border: 2px dashed #7f8da6;
   background: #ffffffc7;
-  padding: 0.3rem 0.85rem;
-  font-size: 1rem;
+  padding: 0.22rem 0.72rem;
+  font-size: 0.92rem;
 }
 
 @media (max-width: 1200px) {
   .pipelineSection {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(3, minmax(170px, 1fr));
   }
 
   .stageWithArrow {
-    flex-direction: column;
     align-items: stretch;
   }
 
@@ -272,14 +326,22 @@
     align-self: center;
     transform: rotate(90deg);
   }
-
-  .stageCard {
-    min-height: auto;
-  }
 }
 
 @media (max-width: 800px) {
+  .pipelineSection {
+    grid-template-columns: 1fr;
+  }
+
+  .stageWithArrow {
+    flex-direction: column;
+  }
+
   .bottomGrid {
     grid-template-columns: 1fr;
+  }
+
+  .stageCard {
+    min-height: auto;
   }
 }


### PR DESCRIPTION
### Motivation
- Make the existing DDN FSI whiteboard feel like a guided, customer-facing sketch for a 2-minute Loom without changing functionality or adding backend work.
- Emphasize the Data Access layer as the conversation entry point so the demo flow naturally points viewers to where DDN drives measurable outcomes.

### Description
- Replace Loom copy with the customer-facing line `Walk left-to-right. Identify the constraint. Tie it to an outcome.` and tighten header spacing for screen-share friendliness (file: `page.tsx`, `whiteboard.module.css`).
- Add hand-drawn-style numbered badges (1–6) to pipeline cards and expose a `step` number in `STAGE_ORDER` so stages render badges next to titles (file: `page.tsx`, `whiteboard.module.css`).
- Make Data Access the visual hero by adding a small handwritten callout `This is usually where DDN enters the conversation.` while keeping the existing DDN fit panel and stronger card styling (file: `page.tsx`, `whiteboard.module.css`).
- Merge the existing Customer conversation guidance with the requested `2-minute talk track` into one compact panel, add a keyed sticky discovery note to force a light re-mount on workload switch, and introduce a subtle CSS refresh animation for the sticky note (files: `page.tsx`, `whiteboard.module.css`).
- Tighten card sizing, spacing, and responsive grid rules so the main pipeline fits well on a typical laptop screen and reduces unnecessary vertical whitespace (file: `whiteboard.module.css`).

### Testing
- Ran `npm run lint` in `ui/partner-hub`; environment failed because Next.js is not installed in this environment: `sh: 1: next: not found`.
- Ran `npm run build` in `ui/partner-hub`; prebuild step failed due to missing Prisma binary: `sh: 1: prisma: not found`.
- Ran `npm test` in `ui/partner-hub`; TypeScript/test runner failed with environment/dependency issues (examples shown):
  - `components/ui/comboboxUtils.test.ts(1,30): error TS2307: Cannot find module 'node:test' or its corresponding type declarations.`
  - `lib/account-mapping/schema.ts(1,19): error TS2307: Cannot find module 'zod' or its corresponding type declarations.`
  - Multiple `Cannot find module 'node:assert/strict'` and other missing-typings/package errors.

These failures appear to be environment/dependency related (missing `next`, `prisma`, Node test typings and some packages) and are not introduced by the whiteboard UI changes; the updated page still renders client-side props and interactions in-code and preserves all workload content and tab behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e9daf2f88330b64e4ab87d5681d8)