### PR TITLE
Polish DDN FSI whiteboard bottom guidance copy

### DIFF
--- a/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx
+++ b/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx
@@ -170,19 +170,12 @@ export default function DdnFsiWhiteboardPage() {
 
       <section className={styles.bottomGrid}>
         <article className={styles.conversationMode}>
-          <h2 className={styles.panelTitle}>Customer conversation mode</h2>
-          <ol>
-            <li>Start with the business workload</li>
-            <li>Map the pipeline</li>
-            <li>Find the constraint</li>
-            <li>Tie DDN to measurable impact</li>
-          </ol>
-          <h3 className={styles.talkTrackTitle}>2-minute talk track</h3>
+          <h2 className={styles.panelTitle}>Customer conversation flow</h2>
           <ul>
             <li>Start with the business workload</li>
             <li>Map the data flow</li>
             <li>Find where data access slows the pipeline</li>
-            <li>Connect DDN to the measurable outcome</li>
+            <li>Connect DDN to a measurable outcome</li>
           </ul>
         </article>
 


### PR DESCRIPTION
### Motivation
- Consolidate duplicated bottom guidance into a single, customer-facing panel and tighten the wording for a Loom-ready whiteboard.

### Description
- Replaced the two sections (`Customer conversation mode` + `2-minute talk track`) with one titled `Customer conversation flow`, updated the list to the four requested bullets, and left the discovery sticky note, workload content, numbered pipeline stages, and Data Access callout unchanged (see `ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx`).

### Testing
- Ran `npm run lint` (in `ui/partner-hub`) which failed with `sh: 1: next: not found`.
- Ran `npm ci` (in `ui/partner-hub`) which failed with `npm ERR! 403 Forbidden - GET https://registry.npmjs.org/react` due to registry access restrictions.
- Ran `npm run typecheck` (in `ui/partner-hub`) which failed with many `Cannot find module ...` type resolution errors consistent with missing dependencies in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0eb7568688330b54ab431c7eac172)