### PR TITLE
DDN FSI: add symptom‑led Deal Qualifier whiteboard

### DIFF
--- a/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx
+++ b/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx
@@ -5,12 +5,22 @@ import styles from "./whiteboard.module.css";
 
 type WorkloadKey = "quantResearch" | "riskModeling" | "fraudDetection" | "aiGenAI";
 type StageKey = "dataSources" | "ingest" | "dataAccessLayer" | "compute" | "workloads" | "businessOutcomes";
+type SymptomKey = "backtests" | "riskRuns" | "gpuUnderutilized" | "fraudDelayed" | "aiPilotsStuck";
 
 type WorkloadContent = {
   label: string;
   stages: Record<StageKey, string[]>;
   discoveryQuestion: string;
   ddnFit: string;
+};
+
+type SymptomContent = {
+  label: string;
+  workload: WorkloadKey;
+  constraint: string;
+  businessOutcome: string;
+  nextQuestion: string;
+  ddnHypothesis: string;
 };
 
 const STAGE_ORDER: Array<{ key: StageKey; label: string; step: number }> = [
@@ -79,23 +89,136 @@ const WORKLOADS: Record<WorkloadKey, WorkloadContent> = {
   },
 };
 
+const SYMPTOMS: Record<SymptomKey, SymptomContent> = {
+  backtests: {
+    label: "Backtests take too long",
+    workload: "quantResearch",
+    constraint: "High-concurrency reads against shared historical and alternative datasets.",
+    businessOutcome: "Shorter research cycles, faster strategy iteration, and improved time-to-alpha.",
+    nextQuestion: "Where do jobs queue today — compute, scheduler, network, or data access?",
+    ddnHypothesis: "Validate whether parallel data access is limiting research throughput.",
+  },
+  riskRuns: {
+    label: "Risk runs are still overnight",
+    workload: "riskModeling",
+    constraint: "Simulation throughput and batch-window pressure as model complexity and data volumes grow.",
+    businessOutcome: "Move toward intraday risk visibility and faster decision windows.",
+    nextQuestion: "Which step owns the batch window — data prep, model execution, or result aggregation?",
+    ddnHypothesis: "Validate whether throughput and data wait time are extending the risk cycle.",
+  },
+  gpuUnderutilized: {
+    label: "GPUs are underutilized",
+    workload: "aiGenAI",
+    constraint: "Data feeding, checkpointing, or dataset reuse is limiting expensive compute.",
+    businessOutcome: "Higher GPU ROI, faster time-to-model, and better use of AI infrastructure spend.",
+    nextQuestion: "What does GPU utilization look like during training, and when does it drop?",
+    ddnHypothesis: "Validate whether the data pipeline is starving GPUs or slowing checkpoint/restart cycles.",
+  },
+  fraudDelayed: {
+    label: "Fraud response is delayed",
+    workload: "fraudDetection",
+    constraint: "Real-time scoring needs fast access to both streaming events and historical feature context.",
+    businessOutcome: "Reduced loss exposure, faster fraud response, and improved detection accuracy.",
+    nextQuestion: "What is the cost of delayed detection, and where does latency enter the flow?",
+    ddnHypothesis: "Validate whether real-time and historical data access are slowing detection workflows.",
+  },
+  aiPilotsStuck: {
+    label: "AI pilots are stuck",
+    workload: "aiGenAI",
+    constraint: "Data preparation, retrieval, checkpointing, and dataset reuse are not production-ready.",
+    businessOutcome: "Move AI initiatives from pilot to production faster with better infrastructure leverage.",
+    nextQuestion: "Where are pilots slowing down — data prep, training, retrieval, governance, or inference?",
+    ddnHypothesis: "Validate whether the AI data pipeline can support repeatable production workloads.",
+  },
+};
+
+const SYMPTOM_ORDER: SymptomKey[] = ["backtests", "riskRuns", "gpuUnderutilized", "fraudDelayed", "aiPilotsStuck"];
+
 const CALL_OUTS = ["Where does it slow down?", "Is compute waiting on data?", "What outcome matters?"];
+
+const DIAGNOSIS_COLUMNS: Array<{ title: string; getCopy: (symptom: SymptomContent) => string }> = [
+  { title: "Customer symptom", getCopy: (symptom) => symptom.label },
+  { title: "Likely constraint", getCopy: (symptom) => symptom.constraint },
+  { title: "Business outcome", getCopy: (symptom) => symptom.businessOutcome },
+  { title: "Best next question", getCopy: (symptom) => symptom.nextQuestion },
+  { title: "DDN hypothesis", getCopy: (symptom) => symptom.ddnHypothesis },
+];
 
 export default function DdnFsiWhiteboardPage() {
   const [selectedWorkload, setSelectedWorkload] = useState<WorkloadKey>("quantResearch");
+  const [selectedSymptom, setSelectedSymptom] = useState<SymptomKey>("backtests");
+
   const workload = useMemo(() => WORKLOADS[selectedWorkload], [selectedWorkload]);
+  const symptom = useMemo(() => SYMPTOMS[selectedSymptom], [selectedSymptom]);
+
+  const setWorkloadWithSymptomAlignment = (nextWorkload: WorkloadKey) => {
+    const currentSymptom = SYMPTOMS[selectedSymptom];
+    const keepCurrent = currentSymptom.workload === nextWorkload;
+
+    if (!keepCurrent) {
+      const firstMatching = SYMPTOM_ORDER.find((symptomKey) => SYMPTOMS[symptomKey].workload === nextWorkload);
+      if (firstMatching) {
+        setSelectedSymptom(firstMatching);
+      }
+    }
+
+    setSelectedWorkload(nextWorkload);
+  };
+
+  const setSymptomAndWorkload = (symptomKey: SymptomKey) => {
+    const nextSymptom = SYMPTOMS[symptomKey];
+    setSelectedSymptom(symptomKey);
+    setSelectedWorkload(nextSymptom.workload);
+  };
 
   return (
     <main className={styles.page}>
       <section className={styles.headerSection}>
         <p className={styles.kicker}>DDN FSI conversation whiteboard</p>
-        <h1 className={styles.title}>DDN FSI Pipeline Whiteboard</h1>
+        <h1 className={styles.title}>DDN FSI Deal Qualifier</h1>
         <p className={styles.subtitle}>
-          A simple way to identify where financial services data pipelines break — and where DDN creates measurable
-          impact.
+          A whiteboard-style way to turn customer symptoms into workload constraints, business outcomes, discovery
+          questions, and measurable next steps.
         </p>
-        <p className={styles.structureNote}>The structure stays consistent. The pressure points change by workload.</p>
-        <p className={styles.loomHint}>Walk left-to-right. Identify the constraint. Tie it to an outcome.</p>
+        <p className={styles.loomHint}>Start with the symptom. Diagnose the constraint. Quantify the outcome.</p>
+      </section>
+
+      <section className={styles.diagnosisSection} aria-label="Symptom-driven qualification">
+        <div className={styles.diagnosisHeader}>
+          <h2 className={styles.panelTitle}>Start with what the customer says</h2>
+          <p className={styles.diagnosisSubtitle}>
+            Translate the symptom into a constraint, business outcome, discovery question, and DDN hypothesis.
+          </p>
+        </div>
+
+        <div className={styles.symptomGrid}>
+          {SYMPTOM_ORDER.map((symptomKey) => {
+            const item = SYMPTOMS[symptomKey];
+            const isSelected = selectedSymptom === symptomKey;
+
+            return (
+              <button
+                key={symptomKey}
+                type="button"
+                className={`${styles.symptomCard} ${isSelected ? styles.symptomCardSelected : ""}`}
+                onClick={() => setSymptomAndWorkload(symptomKey)}
+                aria-pressed={isSelected}
+              >
+                <span className={styles.symptomLabel}>“{item.label}”</span>
+                <span className={styles.symptomWorkload}>{WORKLOADS[item.workload].label}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className={styles.diagnosisPanel}>
+          {DIAGNOSIS_COLUMNS.map((column) => (
+            <article key={column.title} className={styles.diagnosisCard}>
+              <h3>{column.title}</h3>
+              <p>{column.getCopy(symptom)}</p>
+            </article>
+          ))}
+        </div>
       </section>
 
       <section className={styles.tabSection} aria-label="Workload selector">
@@ -110,7 +233,7 @@ export default function DdnFsiWhiteboardPage() {
                 role="tab"
                 aria-selected={isSelected}
                 className={`${styles.tabButton} ${isSelected ? styles.tabButtonActive : ""}`}
-                onClick={() => setSelectedWorkload(workloadKey)}
+                onClick={() => setWorkloadWithSymptomAlignment(workloadKey)}
               >
                 {WORKLOADS[workloadKey].label}
               </button>
@@ -120,8 +243,11 @@ export default function DdnFsiWhiteboardPage() {
         <button
           type="button"
           className={styles.resetButton}
-          onClick={() => setSelectedWorkload("quantResearch")}
-          disabled={selectedWorkload === "quantResearch"}
+          onClick={() => {
+            setSelectedSymptom("backtests");
+            setSelectedWorkload("quantResearch");
+          }}
+          disabled={selectedWorkload === "quantResearch" && selectedSymptom === "backtests"}
         >
           Reset to Quant Research
         </button>
@@ -150,9 +276,9 @@ export default function DdnFsiWhiteboardPage() {
                 </ul>
                 {isDataAccess ? (
                   <>
-                    <p className={styles.dataAccessCallout}>This is usually where DDN enters the conversation.</p>
+                    <p className={styles.dataAccessCallout}>Validate this before pitching architecture.</p>
                     <div className={styles.ddnFitPanel}>
-                      <p className={styles.ddnFitLabel}>DDN fit: remove the data bottleneck</p>
+                      <p className={styles.ddnFitLabel}>DDN hypothesis: data access may be limiting the workload</p>
                       <p className={styles.ddnFitCopy}>{workload.ddnFit}</p>
                     </div>
                   </>
@@ -172,10 +298,10 @@ export default function DdnFsiWhiteboardPage() {
         <article className={styles.conversationMode}>
           <h2 className={styles.panelTitle}>Customer conversation flow</h2>
           <ul>
-            <li>Start with the business workload</li>
-            <li>Map the data flow</li>
-            <li>Find where data access slows the pipeline</li>
-            <li>Connect DDN to a measurable outcome</li>
+            <li>Start with the customer symptom</li>
+            <li>Identify the workload behind it</li>
+            <li>Diagnose the likely constraint</li>
+            <li>Quantify the business impact</li>
           </ul>
         </article>
 

--- a/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/whiteboard.module.css
+++ b/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/whiteboard.module.css
@@ -15,14 +15,16 @@
 }
 
 .kicker,
-.structureNote,
 .loomHint,
 .callout,
 .ddnFitLabel,
 .stickyLabel,
 .stageBadge,
 .dataAccessCallout,
-.talkTrackTitle {
+.symptomLabel,
+.panelTitle,
+.stageTitle,
+.diagnosisCard h3 {
   font-family: "Comic Sans MS", "Bradley Hand", "Segoe Print", cursive;
 }
 
@@ -41,25 +43,117 @@
 
 .subtitle {
   margin: 0;
-  max-width: 68ch;
+  max-width: 75ch;
   font-size: 1rem;
   color: #344054;
 }
 
-.structureNote {
-  margin-top: 0.6rem;
-  font-size: 1.05rem;
-}
-
 .loomHint {
-  margin-top: 0.25rem;
+  margin-top: 0.4rem;
   font-size: 1rem;
   color: #334155;
   font-weight: 700;
 }
 
-.tabSection {
+.diagnosisSection {
   margin-top: 1rem;
+  border: 2px solid #8d99aa;
+  border-radius: 16px;
+  background: #fffffff0;
+  padding: 0.8rem;
+  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.08);
+}
+
+.diagnosisHeader {
+  margin-bottom: 0.55rem;
+}
+
+.panelTitle {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.diagnosisSubtitle {
+  margin: 0.2rem 0 0;
+  font-size: 0.94rem;
+  color: #334155;
+}
+
+.symptomGrid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(130px, 1fr));
+  gap: 0.55rem;
+}
+
+.symptomCard {
+  border: 2px solid #8f7f4d;
+  border-radius: 12px;
+  background: #fff4af;
+  padding: 0.55rem;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
+}
+
+.symptomCard:hover {
+  transform: translateY(-1px);
+}
+
+.symptomCard:focus-visible {
+  outline: 3px solid #1d4ed8;
+  outline-offset: 2px;
+}
+
+.symptomCardSelected {
+  border-color: #1d4ed8;
+  box-shadow: 0 0 0 2px rgba(29, 78, 216, 0.2);
+  background: #ffef88;
+}
+
+.symptomLabel {
+  display: block;
+  font-size: 0.92rem;
+  color: #302613;
+}
+
+.symptomWorkload {
+  margin-top: 0.35rem;
+  display: inline-block;
+  font-size: 0.78rem;
+  color: #5c4d20;
+  border-top: 1px dashed rgba(92, 77, 32, 0.4);
+  padding-top: 0.22rem;
+}
+
+.diagnosisPanel {
+  margin-top: 0.65rem;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(140px, 1fr));
+  gap: 0.55rem;
+}
+
+.diagnosisCard {
+  border: 2px solid #8d99aa;
+  border-radius: 12px;
+  background: #fffdf4;
+  padding: 0.58rem;
+  min-height: 118px;
+}
+
+.diagnosisCard h3 {
+  margin: 0;
+  font-size: 0.89rem;
+  color: #1e3a8a;
+}
+
+.diagnosisCard p {
+  margin: 0.35rem 0 0;
+  font-size: 0.84rem;
+  line-height: 1.33;
+}
+
+.tabSection {
+  margin-top: 0.8rem;
   display: flex;
   flex-wrap: wrap;
   gap: 0.7rem;
@@ -108,7 +202,7 @@
 }
 
 .pipelineSection {
-  margin-top: 1rem;
+  margin-top: 0.9rem;
   display: grid;
   grid-template-columns: repeat(6, minmax(140px, 1fr));
   gap: 0.55rem;
@@ -166,7 +260,6 @@
 .stageTitle {
   margin: 0;
   font-size: 0.95rem;
-  font-family: "Comic Sans MS", "Bradley Hand", "Segoe Print", cursive;
 }
 
 .stageList {
@@ -228,7 +321,7 @@
 }
 
 .bottomGrid {
-  margin-top: 0.95rem;
+  margin-top: 0.85rem;
   display: grid;
   grid-template-columns: minmax(320px, 1.4fr) minmax(260px, 1fr);
   gap: 0.8rem;
@@ -242,23 +335,12 @@
   padding: 0.8rem;
 }
 
-.panelTitle {
-  margin: 0;
-  font-size: 1.05rem;
-  font-family: "Comic Sans MS", "Bradley Hand", "Segoe Print", cursive;
-}
-
 .conversationMode ol,
 .conversationMode ul {
   margin: 0.45rem 0 0;
   padding-left: 1.2rem;
   font-size: 0.94rem;
   line-height: 1.45;
-}
-
-.talkTrackTitle {
-  margin: 0.55rem 0 0;
-  font-size: 1rem;
 }
 
 .stickyNote {
@@ -314,6 +396,14 @@
 }
 
 @media (max-width: 1200px) {
+  .symptomGrid {
+    grid-template-columns: repeat(3, minmax(140px, 1fr));
+  }
+
+  .diagnosisPanel {
+    grid-template-columns: repeat(3, minmax(150px, 1fr));
+  }
+
   .pipelineSection {
     grid-template-columns: repeat(3, minmax(170px, 1fr));
   }
@@ -329,6 +419,8 @@
 }
 
 @media (max-width: 800px) {
+  .symptomGrid,
+  .diagnosisPanel,
   .pipelineSection {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
### Motivation
- Reframe the DDN FSI page from a pipeline diagram into a symptom‑led Deal Qualifier so an SE can drive a live discovery conversation. 
- Surface a simple qualification workflow that maps customer symptoms to constraints, business outcomes, discovery questions, and a DDN hypothesis while keeping the existing pipeline and workload tabs as secondary context. 
- Keep the change static and client‑side with minimal UI behavior and no backend/API/auth/database/AI added.

### Description
- Add symptom model and UI: introduce `SYMPTOMS`/`SymptomKey`, symptom cards, and a 5‑column diagnosis panel driven by `DIAGNOSIS_COLUMNS` in `ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx`. 
- Implement interaction linking so selecting a symptom auto‑selects its workload tab, and selecting a workload preserves the current symptom only if it belongs to that workload (otherwise picks the first matching symptom); also add a symptom + workload reset. 
- Update copy per brief: page title to "DDN FSI Deal Qualifier", top lead line to "Start with the symptom. Diagnose the constraint. Quantify the outcome.", change Data Access callout to `Validate this before pitching architecture.`, change DDN label to `DDN hypothesis: data access may be limiting the workload`, and update conversation flow bullets. 
- Style updates in `whiteboard.module.css` preserve the off‑white whiteboard feel, add sticky‑note symptom cards, make selected symptom visually obvious, add diagnosis grid styles, and keep responsive behavior compact.

### Testing
- Ran `npm run lint` (in this environment) which failed because `next` is not available here (`sh: 1: next: not found`). 
- Ran `npm run typecheck` (in this environment) which failed due to repo‑wide dependency/type resolution issues (many `Cannot find module 'next/*'`, `Cannot find module 'react'`, and missing Node type declarations), and these failures are not specific to this page. 
- No automated tests were added for this UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f30098c48330802cd7dd830920de)