### PR TITLE
Polish DDN whiteboard stage label to Constraint

### DIFF
--- a/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx
+++ b/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx
@@ -26,7 +26,7 @@ type SymptomContent = {
 const STAGE_ORDER: Array<{ key: StageKey; label: string; step: number }> = [
   { key: "dataSources", label: "Data Sources", step: 1 },
   { key: "ingest", label: "Ingest", step: 2 },
-  { key: "dataAccessLayer", label: "Data Access", step: 3 },
+  { key: "dataAccessLayer", label: "Constraint", step: 3 },
   { key: "compute", label: "Compute", step: 4 },
   { key: "workloads", label: "Workloads", step: 5 },
   { key: "businessOutcomes", label: "Outcomes", step: 6 },


### PR DESCRIPTION
### Motivation
- Reinforce that the visual focuses on diagnosing the customer constraint (not just placing DDN in data access) by updating the displayed pipeline label while keeping the data model unchanged.

### Description
- Changed the displayed Stage 3 label in `STAGE_ORDER` from `{ key: "dataAccessLayer", label: "Data Access", step: 3 }` to `{ key: "dataAccessLayer", label: "Constraint", step: 3 }` in `ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx`, and preserved the `dataAccessLayer` key, the pipeline callout "Validate this before pitching architecture.", and the DDN hypothesis text with no other copy, interaction, styling, or workload changes.

### Testing
- Ran `npm run lint` in `ui/partner-hub` which failed with `next: not found`; and ran `npm run typecheck` in `ui/partner-hub` which failed due to repository-wide type/dependency resolution errors (missing `next`, `react`, and Node type declarations).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10aff45948330a80fc03abe45fc21)