### PR TITLE
Redesign DDN FSI whiteboard into a single-screen discovery talk track

### DIFF
--- a/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx
+++ b/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx
@@ -3,322 +3,170 @@
 import { useMemo, useState } from "react";
 import styles from "./whiteboard.module.css";
 
-type WorkloadKey = "quantResearch" | "riskModeling" | "fraudDetection" | "aiGenAI";
-type StageKey = "dataSources" | "ingest" | "dataAccessLayer" | "compute" | "workloads" | "businessOutcomes";
-type SymptomKey = "backtests" | "riskRuns" | "gpuUnderutilized" | "fraudDelayed" | "aiPilotsStuck";
+type SymptomKey = "backtests" | "riskRuns" | "fraudDelayed" | "gpuUnderutilized" | "aiPilotsStuck";
+type FlowStageKey =
+  | "customerSays"
+  | "outcomeAtRisk"
+  | "workflowDelay"
+  | "likelyConstraint"
+  | "businessImpact"
+  | "bestNextQuestion"
+  | "ddnHypothesis";
 
-type WorkloadContent = {
+type FlowContent = {
   label: string;
-  stages: Record<StageKey, string[]>;
-  discoveryQuestion: string;
-  ddnFit: string;
+  stages: Record<FlowStageKey, string>;
 };
 
-type SymptomContent = {
-  label: string;
-  workload: WorkloadKey;
-  constraint: string;
-  businessOutcome: string;
-  nextQuestion: string;
-  ddnHypothesis: string;
-};
+const SYMPTOM_ORDER: SymptomKey[] = ["backtests", "riskRuns", "fraudDelayed", "gpuUnderutilized", "aiPilotsStuck"];
 
-const STAGE_ORDER: Array<{ key: StageKey; label: string; step: number }> = [
-  { key: "dataSources", label: "Data Sources", step: 1 },
-  { key: "ingest", label: "Ingest", step: 2 },
-  { key: "dataAccessLayer", label: "Constraint", step: 3 },
-  { key: "compute", label: "Compute", step: 4 },
-  { key: "workloads", label: "Workloads", step: 5 },
-  { key: "businessOutcomes", label: "Outcomes", step: 6 },
+const FLOW_STAGE_ORDER: Array<{ key: FlowStageKey; label: string }> = [
+  { key: "customerSays", label: "Customer says" },
+  { key: "outcomeAtRisk", label: "Outcome at risk" },
+  { key: "workflowDelay", label: "Workflow delay" },
+  { key: "likelyConstraint", label: "Likely constraint" },
+  { key: "businessImpact", label: "Business impact" },
+  { key: "bestNextQuestion", label: "Best next question" },
+  { key: "ddnHypothesis", label: "DDN hypothesis" },
 ];
 
-const WORKLOADS: Record<WorkloadKey, WorkloadContent> = {
-  quantResearch: {
-    label: "Quant Research",
-    stages: {
-      dataSources: ["Tick data", "Historical market data", "Alternative data", "Research datasets"],
-      ingest: ["Batch ingest", "Market feeds", "Data normalization"],
-      dataAccessLayer: ["High concurrency", "Parallel reads", "Shared datasets", "Backtesting bottlenecks"],
-      compute: ["CPU grids", "GPU clusters", "Research environments"],
-      workloads: ["Backtesting", "Simulation", "Strategy research"],
-      businessOutcomes: ["Faster strategy iteration", "Shorter time-to-alpha", "Higher compute utilization"],
-    },
-    discoveryQuestion: "How long do backtesting cycles take today, and where do jobs queue?",
-    ddnFit: "Parallel data access at scale helps keep research compute fed instead of waiting on data.",
-  },
-  riskModeling: {
-    label: "Risk Modeling",
-    stages: {
-      dataSources: ["Portfolio data", "Market scenarios", "Reference data", "Historical positions"],
-      ingest: ["Batch loads", "Scenario feeds", "Data preparation"],
-      dataAccessLayer: ["Large batch reads", "Simulation throughput", "Concurrent model runs", "Data growth pressure"],
-      compute: ["HPC grids", "Analytics engines", "Risk platforms"],
-      workloads: ["Stress testing", "Scenario modeling", "Monte Carlo"],
-      businessOutcomes: ["Move toward intraday risk", "Faster decision windows", "Regulatory responsiveness"],
-    },
-    discoveryQuestion: "Are risk runs still overnight, or is the goal intraday visibility?",
-    ddnFit: "High-throughput data access supports large-scale simulation workflows and reduces data wait time.",
-  },
-  fraudDetection: {
-    label: "Fraud Detection",
-    stages: {
-      dataSources: ["Transactions", "Customer behavior", "Device signals", "Historical fraud patterns"],
-      ingest: ["Streaming events", "Real-time enrichment", "Historical joins"],
-      dataAccessLayer: ["Real-time + historical access", "Feature retrieval", "Model refresh", "Latency pressure"],
-      compute: ["ML scoring", "Streaming analytics", "Detection engines"],
-      workloads: ["Fraud scoring", "Pattern detection", "Model retraining"],
-      businessOutcomes: ["Faster fraud response", "Reduced loss exposure", "Better model accuracy"],
-    },
-    discoveryQuestion: "What is the business cost when detection is delayed?",
-    ddnFit:
-      "A scalable AI data foundation helps teams access current and historical data quickly for detection and model improvement.",
-  },
-  aiGenAI: {
-    label: "AI / GenAI",
-    stages: {
-      dataSources: ["Documents", "Market data", "Research content", "Customer data", "Training datasets"],
-      ingest: ["Data prep", "Embedding pipelines", "Dataset curation"],
-      dataAccessLayer: ["GPU feeding", "Checkpointing", "Dataset reuse", "RAG retrieval pressure"],
-      compute: ["GPU clusters", "Inference services", "Vector / RAG stack"],
-      workloads: ["Model training", "Fine-tuning", "RAG", "AI assistants"],
-      businessOutcomes: ["Higher GPU ROI", "Faster time-to-model", "AI pilots into production"],
-    },
-    discoveryQuestion: "What GPU utilization are you seeing, and where does the pipeline slow down?",
-    ddnFit:
-      "High-performance data access helps feed GPUs, support training/checkpointing, and reduce AI pipeline friction.",
-  },
-};
-
-const SYMPTOMS: Record<SymptomKey, SymptomContent> = {
+const SYMPTOM_FLOWS: Record<SymptomKey, FlowContent> = {
   backtests: {
     label: "Backtests take too long",
-    workload: "quantResearch",
-    constraint: "High-concurrency reads against shared historical and alternative datasets.",
-    businessOutcome: "Shorter research cycles, faster strategy iteration, and improved time-to-alpha.",
-    nextQuestion: "Where do jobs queue today — compute, scheduler, network, or data access?",
-    ddnHypothesis: "Validate whether parallel data access is limiting research throughput.",
+    stages: {
+      customerSays: "Backtests take too long.",
+      outcomeAtRisk: "Research velocity slows down and fewer strategies get tested.",
+      workflowDelay: "Large historical datasets take too long to access, reuse, or process across research runs.",
+      likelyConstraint: "Data movement, metadata overhead, or shared filesystem performance may be limiting throughput.",
+      businessImpact: "Slower time-to-alpha and fewer opportunities evaluated before markets move.",
+      bestNextQuestion:
+        "How many strategies are delayed because backtests cannot complete inside the target window?",
+      ddnHypothesis:
+        "Validate whether the data path is slowing research iteration and whether a high-performance shared data layer would reduce wait time.",
+    },
   },
   riskRuns: {
     label: "Risk runs are still overnight",
-    workload: "riskModeling",
-    constraint: "Simulation throughput and batch-window pressure as model complexity and data volumes grow.",
-    businessOutcome: "Move toward intraday risk visibility and faster decision windows.",
-    nextQuestion: "Which step owns the batch window — data prep, model execution, or result aggregation?",
-    ddnHypothesis: "Validate whether throughput and data wait time are extending the risk cycle.",
-  },
-  gpuUnderutilized: {
-    label: "GPUs are underutilized",
-    workload: "aiGenAI",
-    constraint: "Data feeding, checkpointing, or dataset reuse is limiting expensive compute.",
-    businessOutcome: "Higher GPU ROI, faster time-to-model, and better use of AI infrastructure spend.",
-    nextQuestion: "What does GPU utilization look like during training, and when does it drop?",
-    ddnHypothesis: "Validate whether the data pipeline is starving GPUs or slowing checkpoint/restart cycles.",
+    stages: {
+      customerSays: "Risk runs are still overnight.",
+      outcomeAtRisk: "The firm cannot make faster risk decisions during the trading day.",
+      workflowDelay: "Risk models and stress scenarios are waiting on data access, preparation, or processing windows.",
+      likelyConstraint:
+        "The bottleneck may be data throughput, concurrent access, or infrastructure unable to support intraday runs.",
+      businessImpact: "Exposure remains open longer and the business has less time to react.",
+      bestNextQuestion: "What would change operationally if that risk run finished in hours instead of overnight?",
+      ddnHypothesis:
+        "Validate whether faster access to model inputs and scenario data could compress the risk window.",
+    },
   },
   fraudDelayed: {
     label: "Fraud response is delayed",
-    workload: "fraudDetection",
-    constraint: "Real-time scoring needs fast access to both streaming events and historical feature context.",
-    businessOutcome: "Reduced loss exposure, faster fraud response, and improved detection accuracy.",
-    nextQuestion: "What is the cost of delayed detection, and where does latency enter the flow?",
-    ddnHypothesis: "Validate whether real-time and historical data access are slowing detection workflows.",
+    stages: {
+      customerSays: "Fraud response is delayed.",
+      outcomeAtRisk: "Fraud decisions happen too late to prevent loss or customer impact.",
+      workflowDelay:
+        "Detection, scoring, or investigation workflows are slowed by data availability and analysis time.",
+      likelyConstraint:
+        "The issue may be ingest, feature access, model scoring latency, or analytics pipeline performance.",
+      businessImpact: "Loss exposure increases and customer trust can be damaged.",
+      bestNextQuestion: "Where does the fraud workflow lose the most time between event, score, and action?",
+      ddnHypothesis: "Validate whether data pipeline performance is delaying fraud analytics or model response.",
+    },
+  },
+  gpuUnderutilized: {
+    label: "GPUs are underutilized",
+    stages: {
+      customerSays: "GPUs are underutilized.",
+      outcomeAtRisk: "AI infrastructure spend is not translating into model velocity.",
+      workflowDelay: "Training, checkpointing, or data loading is slowing the AI pipeline.",
+      likelyConstraint: "Data feeding, checkpointing, or dataset reuse may be limiting expensive compute.",
+      businessImpact: "Higher GPU ROI, faster time-to-model, and better use of AI infrastructure spend.",
+      bestNextQuestion: "What does GPU utilization look like during training, and when does it drop?",
+      ddnHypothesis: "Validate whether the data pipeline is starving GPUs or slowing checkpoint and restart cycles.",
+    },
   },
   aiPilotsStuck: {
     label: "AI pilots are stuck",
-    workload: "aiGenAI",
-    constraint: "Data preparation, retrieval, checkpointing, and dataset reuse are not production-ready.",
-    businessOutcome: "Move AI initiatives from pilot to production faster with better infrastructure leverage.",
-    nextQuestion: "Where are pilots slowing down — data prep, training, retrieval, governance, or inference?",
-    ddnHypothesis: "Validate whether the AI data pipeline can support repeatable production workloads.",
+    stages: {
+      customerSays: "AI pilots are stuck.",
+      outcomeAtRisk: "The organization is not converting AI experimentation into repeatable production value.",
+      workflowDelay:
+        "Data preparation, model iteration, governance, or infrastructure scaling is slowing the move from pilot to production.",
+      likelyConstraint:
+        "The infrastructure may not support repeatable access to large datasets across teams and pipelines.",
+      businessImpact: "AI investment remains trapped in experimentation instead of business outcomes.",
+      bestNextQuestion: "What is preventing the pilot from becoming a repeatable production workflow?",
+      ddnHypothesis:
+        "Validate whether a production-grade data foundation is needed to support repeatable AI workloads.",
+    },
   },
 };
 
-const SYMPTOM_ORDER: SymptomKey[] = ["backtests", "riskRuns", "gpuUnderutilized", "fraudDelayed", "aiPilotsStuck"];
-
-const CALL_OUTS = ["Where does it slow down?", "Is compute waiting on data?", "What outcome matters?"];
-
-const DIAGNOSIS_COLUMNS: Array<{ title: string; getCopy: (symptom: SymptomContent) => string }> = [
-  { title: "Customer symptom", getCopy: (symptom) => symptom.label },
-  { title: "Likely constraint", getCopy: (symptom) => symptom.constraint },
-  { title: "Business outcome", getCopy: (symptom) => symptom.businessOutcome },
-  { title: "Best next question", getCopy: (symptom) => symptom.nextQuestion },
-  { title: "DDN hypothesis", getCopy: (symptom) => symptom.ddnHypothesis },
-];
-
 export default function DdnFsiWhiteboardPage() {
-  const [selectedWorkload, setSelectedWorkload] = useState<WorkloadKey>("quantResearch");
-  const [selectedSymptom, setSelectedSymptom] = useState<SymptomKey>("backtests");
-
-  const workload = useMemo(() => WORKLOADS[selectedWorkload], [selectedWorkload]);
-  const symptom = useMemo(() => SYMPTOMS[selectedSymptom], [selectedSymptom]);
-
-  const setWorkloadWithSymptomAlignment = (nextWorkload: WorkloadKey) => {
-    const currentSymptom = SYMPTOMS[selectedSymptom];
-    const keepCurrent = currentSymptom.workload === nextWorkload;
-
-    if (!keepCurrent) {
-      const firstMatching = SYMPTOM_ORDER.find((symptomKey) => SYMPTOMS[symptomKey].workload === nextWorkload);
-      if (firstMatching) {
-        setSelectedSymptom(firstMatching);
-      }
-    }
-
-    setSelectedWorkload(nextWorkload);
-  };
-
-  const setSymptomAndWorkload = (symptomKey: SymptomKey) => {
-    const nextSymptom = SYMPTOMS[symptomKey];
-    setSelectedSymptom(symptomKey);
-    setSelectedWorkload(nextSymptom.workload);
-  };
+  const [selectedSymptom, setSelectedSymptom] = useState<SymptomKey>("gpuUnderutilized");
+  const selectedFlow = useMemo(() => SYMPTOM_FLOWS[selectedSymptom], [selectedSymptom]);
 
   return (
     <main className={styles.page}>
-      <section className={styles.headerSection}>
-        <p className={styles.kicker}>DDN FSI conversation whiteboard</p>
-        <h1 className={styles.title}>DDN FSI Deal Qualifier</h1>
+      <header className={styles.header}>
+        <h1 className={styles.title}>DDN FSI Discovery Talk Track</h1>
         <p className={styles.subtitle}>
-          A whiteboard-style way to turn customer symptoms into workload constraints, business outcomes, discovery
-          questions, and measurable next steps.
+          Start with the customer outcome, then validate whether data is the constraint.
         </p>
-        <p className={styles.loomHint}>Start with the symptom. Diagnose the constraint. Quantify the outcome.</p>
-      </section>
+        <p className={styles.anchorQuestion}>
+          What outcome needs to happen faster — and what happens when it doesn’t?
+        </p>
+      </header>
 
-      <section className={styles.diagnosisSection} aria-label="Symptom-driven qualification">
-        <div className={styles.diagnosisHeader}>
-          <h2 className={styles.panelTitle}>Start with what the customer says</h2>
-          <p className={styles.diagnosisSubtitle}>
-            Translate the symptom into a constraint, business outcome, discovery question, and DDN hypothesis.
-          </p>
-        </div>
+      <section className={styles.workspace} aria-label="DDN guided discovery flow">
+        <aside className={styles.symptomRail}>
+          <h2 className={styles.railTitle}>Customer symptom</h2>
+          <div className={styles.symptomList} role="listbox" aria-label="Select a customer symptom">
+            {SYMPTOM_ORDER.map((symptomKey) => {
+              const symptom = SYMPTOM_FLOWS[symptomKey];
+              const isSelected = selectedSymptom === symptomKey;
 
-        <div className={styles.symptomGrid}>
-          {SYMPTOM_ORDER.map((symptomKey) => {
-            const item = SYMPTOMS[symptomKey];
-            const isSelected = selectedSymptom === symptomKey;
-
-            return (
-              <button
-                key={symptomKey}
-                type="button"
-                className={`${styles.symptomCard} ${isSelected ? styles.symptomCardSelected : ""}`}
-                onClick={() => setSymptomAndWorkload(symptomKey)}
-                aria-pressed={isSelected}
-              >
-                <span className={styles.symptomLabel}>“{item.label}”</span>
-                <span className={styles.symptomWorkload}>{WORKLOADS[item.workload].label}</span>
-              </button>
-            );
-          })}
-        </div>
-
-        <div className={styles.diagnosisPanel}>
-          {DIAGNOSIS_COLUMNS.map((column) => (
-            <article key={column.title} className={styles.diagnosisCard}>
-              <h3>{column.title}</h3>
-              <p>{column.getCopy(symptom)}</p>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className={styles.tabSection} aria-label="Workload selector">
-        <div className={styles.tabs} role="tablist" aria-label="FSI workload tabs">
-          {(Object.keys(WORKLOADS) as WorkloadKey[]).map((workloadKey) => {
-            const isSelected = workloadKey === selectedWorkload;
-
-            return (
-              <button
-                key={workloadKey}
-                type="button"
-                role="tab"
-                aria-selected={isSelected}
-                className={`${styles.tabButton} ${isSelected ? styles.tabButtonActive : ""}`}
-                onClick={() => setWorkloadWithSymptomAlignment(workloadKey)}
-              >
-                {WORKLOADS[workloadKey].label}
-              </button>
-            );
-          })}
-        </div>
-        <button
-          type="button"
-          className={styles.resetButton}
-          onClick={() => {
-            setSelectedSymptom("backtests");
-            setSelectedWorkload("quantResearch");
-          }}
-          disabled={selectedWorkload === "quantResearch" && selectedSymptom === "backtests"}
-        >
-          Reset to Quant Research
-        </button>
-      </section>
-
-      <section className={styles.pipelineSection}>
-        {STAGE_ORDER.map((stage, index) => {
-          const isDataAccess = stage.key === "dataAccessLayer";
-          const isBusinessOutcome = stage.key === "businessOutcomes";
-
-          return (
-            <div key={stage.key} className={styles.stageWithArrow}>
-              <article
-                className={`${styles.stageCard} ${isDataAccess ? styles.dataAccessCard : ""} ${isBusinessOutcome ? styles.outcomeCard : ""}`}
-              >
-                <div className={styles.stageHeader}>
-                  <span className={styles.stageBadge} aria-hidden="true">
-                    {stage.step}
-                  </span>
-                  <h2 className={styles.stageTitle}>{stage.label}</h2>
-                </div>
-                <ul className={styles.stageList}>
-                  {workload.stages[stage.key].map((item) => (
-                    <li key={item}>{item}</li>
-                  ))}
-                </ul>
-                {isDataAccess ? (
-                  <>
-                    <p className={styles.dataAccessCallout}>Validate this before pitching architecture.</p>
-                    <div className={styles.ddnFitPanel}>
-                      <p className={styles.ddnFitLabel}>DDN hypothesis: data access may be limiting the workload</p>
-                      <p className={styles.ddnFitCopy}>{workload.ddnFit}</p>
-                    </div>
-                  </>
-                ) : null}
-              </article>
-              {index < STAGE_ORDER.length - 1 ? (
-                <span className={styles.arrow} aria-hidden="true">
-                  →
-                </span>
-              ) : null}
-            </div>
-          );
-        })}
-      </section>
-
-      <section className={styles.bottomGrid}>
-        <article className={styles.conversationMode}>
-          <h2 className={styles.panelTitle}>Customer conversation flow</h2>
-          <ul>
-            <li>Start with the customer symptom</li>
-            <li>Identify the workload behind it</li>
-            <li>Diagnose the likely constraint</li>
-            <li>Quantify the business impact</li>
-          </ul>
-        </article>
-
-        <aside key={selectedWorkload} className={styles.stickyNote}>
-          <p className={styles.stickyLabel}>Discovery question:</p>
-          <p className={styles.stickyText}>“{workload.discoveryQuestion}”</p>
-          <p className={styles.stickyWorkload}>{workload.label}</p>
+              return (
+                <button
+                  key={symptomKey}
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  className={`${styles.symptomButton} ${isSelected ? styles.symptomButtonActive : ""}`}
+                  onClick={() => setSelectedSymptom(symptomKey)}
+                >
+                  {symptom.label}
+                </button>
+              );
+            })}
+          </div>
         </aside>
+
+        <section className={styles.flowArea}>
+          <div className={styles.flowCards}>
+            {FLOW_STAGE_ORDER.map((stage) => (
+              <article key={stage.key} className={styles.flowCard}>
+                <h3>{stage.label}</h3>
+                <p>{selectedFlow.stages[stage.key]}</p>
+              </article>
+            ))}
+          </div>
+
+          <aside className={styles.validationBox}>
+            <h2>Validate before positioning DDN</h2>
+            <ul>
+              <li>What metric proves or disproves the constraint?</li>
+              <li>Who owns the delayed workflow?</li>
+              <li>What changes if the delay is removed?</li>
+            </ul>
+          </aside>
+        </section>
       </section>
 
-      <section className={styles.calloutRow} aria-label="conversation prompts">
-        {CALL_OUTS.map((callout) => (
-          <span key={callout} className={styles.callout}>
-            {callout}
-          </span>
-        ))}
-      </section>
+      <footer className={styles.footerNote}>
+        The goal is not to pitch storage first. The goal is to connect workflow delay to measurable business impact,
+        then test whether the data path is the constraint.
+      </footer>
     </main>
   );
 }

--- a/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/whiteboard.module.css
+++ b/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/whiteboard.module.css
@@ -1,439 +1,169 @@
 .page {
   min-height: 100vh;
-  padding: clamp(1rem, 1.4vw, 1.8rem);
+  padding: clamp(1.1rem, 2vw, 2rem);
   background:
-    radial-gradient(circle at 10% 10%, rgba(255, 255, 255, 0.8), transparent 40%),
-    radial-gradient(circle at 90% 20%, rgba(255, 252, 235, 0.6), transparent 35%),
-    repeating-linear-gradient(0deg, rgba(50, 50, 50, 0.03), rgba(50, 50, 50, 0.03) 1px, transparent 1px, transparent 22px),
-    #f8f5ea;
-  color: #1f2937;
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(247, 249, 252, 0.96)),
+    repeating-linear-gradient(0deg, rgba(15, 23, 42, 0.03), rgba(15, 23, 42, 0.03) 1px, transparent 1px, transparent 30px);
+  color: #0f172a;
 }
 
-.headerSection {
-  max-width: 1000px;
-}
-
-.kicker,
-.loomHint,
-.callout,
-.ddnFitLabel,
-.stickyLabel,
-.stageBadge,
-.dataAccessCallout,
-.symptomLabel,
-.panelTitle,
-.stageTitle,
-.diagnosisCard h3 {
-  font-family: "Comic Sans MS", "Bradley Hand", "Segoe Print", cursive;
-}
-
-.kicker {
-  margin: 0;
-  color: #3d4b60;
-  font-size: 0.95rem;
+.header {
+  max-width: 980px;
 }
 
 .title {
-  margin: 0.2rem 0;
-  font-size: clamp(1.8rem, 2.6vw, 2.4rem);
-  line-height: 1.08;
-  font-family: "Comic Sans MS", "Bradley Hand", "Segoe Print", cursive;
+  margin: 0;
+  font-size: clamp(1.75rem, 2.8vw, 2.4rem);
+  line-height: 1.15;
 }
 
 .subtitle {
-  margin: 0;
-  max-width: 75ch;
-  font-size: 1rem;
-  color: #344054;
+  margin: 0.45rem 0 0;
+  font-size: clamp(1rem, 1.4vw, 1.12rem);
+  color: #334155;
 }
 
-.loomHint {
-  margin-top: 0.4rem;
-  font-size: 1rem;
-  color: #334155;
+.anchorQuestion {
+  margin: 0.85rem 0 0;
+  padding: 0.75rem 0.95rem;
+  border-left: 4px solid #1d4ed8;
+  border-radius: 10px;
+  background: #eef4ff;
+  font-size: clamp(1rem, 1.45vw, 1.2rem);
   font-weight: 700;
-}
-
-.diagnosisSection {
-  margin-top: 1rem;
-  border: 2px solid #8d99aa;
-  border-radius: 16px;
-  background: #fffffff0;
-  padding: 0.8rem;
-  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.08);
-}
-
-.diagnosisHeader {
-  margin-bottom: 0.55rem;
-}
-
-.panelTitle {
-  margin: 0;
-  font-size: 1.05rem;
-}
-
-.diagnosisSubtitle {
-  margin: 0.2rem 0 0;
-  font-size: 0.94rem;
-  color: #334155;
-}
-
-.symptomGrid {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(130px, 1fr));
-  gap: 0.55rem;
-}
-
-.symptomCard {
-  border: 2px solid #8f7f4d;
-  border-radius: 12px;
-  background: #fff4af;
-  padding: 0.55rem;
-  text-align: left;
-  cursor: pointer;
-  transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
-}
-
-.symptomCard:hover {
-  transform: translateY(-1px);
-}
-
-.symptomCard:focus-visible {
-  outline: 3px solid #1d4ed8;
-  outline-offset: 2px;
-}
-
-.symptomCardSelected {
-  border-color: #1d4ed8;
-  box-shadow: 0 0 0 2px rgba(29, 78, 216, 0.2);
-  background: #ffef88;
-}
-
-.symptomLabel {
-  display: block;
-  font-size: 0.92rem;
-  color: #302613;
-}
-
-.symptomWorkload {
-  margin-top: 0.35rem;
-  display: inline-block;
-  font-size: 0.78rem;
-  color: #5c4d20;
-  border-top: 1px dashed rgba(92, 77, 32, 0.4);
-  padding-top: 0.22rem;
-}
-
-.diagnosisPanel {
-  margin-top: 0.65rem;
-  display: grid;
-  grid-template-columns: repeat(5, minmax(140px, 1fr));
-  gap: 0.55rem;
-}
-
-.diagnosisCard {
-  border: 2px solid #8d99aa;
-  border-radius: 12px;
-  background: #fffdf4;
-  padding: 0.58rem;
-  min-height: 118px;
-}
-
-.diagnosisCard h3 {
-  margin: 0;
-  font-size: 0.89rem;
   color: #1e3a8a;
 }
 
-.diagnosisCard p {
-  margin: 0.35rem 0 0;
-  font-size: 0.84rem;
-  line-height: 1.33;
-}
-
-.tabSection {
-  margin-top: 0.8rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.7rem;
-  align-items: center;
-}
-
-.tabs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.6rem;
-}
-
-.tabButton,
-.resetButton {
-  border: 2px solid #7f8da6;
-  border-radius: 999px;
-  padding: 0.5rem 0.92rem;
-  background: #fff;
-  font-size: 0.94rem;
-  cursor: pointer;
-  transition: transform 120ms ease, background-color 120ms ease, box-shadow 120ms ease;
-}
-
-.tabButton:hover,
-.resetButton:hover:not(:disabled) {
-  transform: translateY(-1px);
-  background: #f7fbff;
-}
-
-.tabButton:focus-visible,
-.resetButton:focus-visible {
-  outline: 3px solid #1d4ed8;
-  outline-offset: 2px;
-}
-
-.tabButtonActive {
-  background: #dceafe;
-  border-color: #1d4ed8;
-  font-weight: 700;
-  box-shadow: 0 0 0 2px rgba(29, 78, 216, 0.22);
-}
-
-.resetButton:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.pipelineSection {
-  margin-top: 0.9rem;
+.workspace {
+  margin-top: 1.15rem;
   display: grid;
-  grid-template-columns: repeat(6, minmax(140px, 1fr));
-  gap: 0.55rem;
+  grid-template-columns: minmax(220px, 270px) minmax(0, 1fr);
+  gap: 1rem;
   align-items: start;
 }
 
-.stageWithArrow {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  min-width: 0;
+.symptomRail {
+  border: 1px solid #cbd5e1;
+  border-radius: 14px;
+  background: #ffffff;
+  padding: 0.9rem;
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.06);
 }
 
-.stageCard {
-  position: relative;
-  width: 100%;
-  min-height: 220px;
-  border-radius: 16px;
-  border: 2px solid #8d99aa;
-  background: #ffffffee;
-  padding: 0.7rem;
-  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.08);
-}
-
-.stageCard::before {
-  content: "";
-  position: absolute;
-  inset: 5px;
-  border: 1px dashed rgba(71, 85, 105, 0.28);
-  border-radius: 12px;
-  pointer-events: none;
-}
-
-.stageHeader {
-  display: flex;
-  align-items: center;
-  gap: 0.42rem;
-}
-
-.stageBadge {
-  display: inline-flex;
-  width: 1.45rem;
-  height: 1.45rem;
-  align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  border: 2px solid #475569;
-  background: #fffdf4;
-  color: #1f2937;
-  font-size: 0.88rem;
-  line-height: 1;
-  transform: rotate(-8deg);
-}
-
-.stageTitle {
+.railTitle {
   margin: 0;
-  font-size: 0.95rem;
-}
-
-.stageList {
-  margin: 0.45rem 0 0;
-  padding-left: 1rem;
-  font-size: 0.88rem;
-  line-height: 1.35;
-}
-
-.arrow {
-  font-size: 1.15rem;
-  color: #55637a;
-  font-family: "Comic Sans MS", "Bradley Hand", "Segoe Print", cursive;
-}
-
-.dataAccessCard {
-  border-width: 3px;
-  border-color: #1d4ed8;
-  background: linear-gradient(165deg, #f3f8ff 0%, #ffffff 70%);
-  box-shadow: 0 10px 18px rgba(29, 78, 216, 0.2);
-}
-
-.dataAccessCallout {
-  margin: 0.5rem 0 0;
-  padding: 0.28rem 0.45rem;
-  border-left: 3px solid #1d4ed8;
-  background: #edf4ff;
-  color: #0f2f71;
-  font-size: 0.85rem;
-  line-height: 1.25;
-  transform: rotate(-1deg);
-}
-
-.ddnFitPanel {
-  margin-top: 0.5rem;
-  border: 1px solid #1d4ed8;
-  border-radius: 10px;
-  padding: 0.5rem;
-  background: #eaf1ff;
-}
-
-.ddnFitLabel {
-  margin: 0;
-  color: #12357e;
+  font-size: 0.96rem;
   font-weight: 700;
-  font-size: 0.87rem;
+  color: #334155;
 }
 
-.ddnFitCopy {
-  margin: 0.35rem 0 0;
-  font-size: 0.82rem;
-  color: #1e293b;
-  line-height: 1.3;
-}
-
-.outcomeCard {
-  background: linear-gradient(165deg, #f8fff8 0%, #ffffff 78%);
-  border-color: #4d8b58;
-}
-
-.bottomGrid {
-  margin-top: 0.85rem;
+.symptomList {
+  margin-top: 0.6rem;
   display: grid;
-  grid-template-columns: minmax(320px, 1.4fr) minmax(260px, 1fr);
+  gap: 0.45rem;
+}
+
+.symptomButton {
+  width: 100%;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  background: #f8fafc;
+  padding: 0.63rem 0.7rem;
+  text-align: left;
+  font-size: 0.95rem;
+  line-height: 1.35;
+  cursor: pointer;
+  transition: border-color 120ms ease, background-color 120ms ease, box-shadow 120ms ease;
+}
+
+.symptomButton:hover {
+  border-color: #94a3b8;
+}
+
+.symptomButton:focus-visible {
+  outline: 3px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.symptomButtonActive {
+  border-color: #1d4ed8;
+  background: #eaf1ff;
+  box-shadow: inset 0 0 0 1px rgba(29, 78, 216, 0.15);
+  font-weight: 600;
+}
+
+.flowArea {
+  display: grid;
   gap: 0.8rem;
 }
 
-.conversationMode,
-.stickyNote {
-  border-radius: 16px;
-  border: 2px solid #7f8da6;
-  background: #ffffffea;
-  padding: 0.8rem;
+.flowCards {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
 }
 
-.conversationMode ol,
-.conversationMode ul {
-  margin: 0.45rem 0 0;
-  padding-left: 1.2rem;
-  font-size: 0.94rem;
-  line-height: 1.45;
+.flowCard {
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
+  background: #ffffff;
+  padding: 0.85rem;
+  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.05);
 }
 
-.stickyNote {
-  background: #fff4af;
-  border-color: #876f11;
-  transform: rotate(-1deg);
-  animation: stickyRefresh 220ms ease-out;
-}
-
-@keyframes stickyRefresh {
-  from {
-    opacity: 0.7;
-    transform: rotate(-1.6deg) scale(0.988);
-  }
-  to {
-    opacity: 1;
-    transform: rotate(-1deg) scale(1);
-  }
-}
-
-.stickyLabel {
+.flowCard h3 {
   margin: 0;
-  font-weight: 700;
-  color: #4c3f0a;
+  font-size: 0.95rem;
+  color: #1e3a8a;
 }
 
-.stickyText {
-  margin: 0.4rem 0 0;
-  font-size: 1.08rem;
-  line-height: 1.32;
-  color: #312607;
+.flowCard p {
+  margin: 0.45rem 0 0;
+  font-size: 1rem;
+  line-height: 1.45;
+  color: #1e293b;
 }
 
-.stickyWorkload {
-  margin: 0.55rem 0 0;
+.validationBox {
+  border: 1px solid #bfdbfe;
+  border-radius: 12px;
+  background: #f8fbff;
+  padding: 0.9rem;
+}
+
+.validationBox h2 {
+  margin: 0;
+  font-size: 0.98rem;
+  color: #1e3a8a;
+}
+
+.validationBox ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.15rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.validationBox li {
+  font-size: 0.96rem;
+  line-height: 1.4;
+}
+
+.footerNote {
+  margin-top: 0.95rem;
+  border-top: 1px solid #cbd5e1;
+  padding-top: 0.72rem;
   font-size: 0.9rem;
-  color: #4c3f0a;
+  line-height: 1.45;
+  color: #334155;
 }
 
-.calloutRow {
-  margin-top: 0.8rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem;
-}
-
-.callout {
-  border-radius: 999px;
-  border: 2px dashed #7f8da6;
-  background: #ffffffc7;
-  padding: 0.22rem 0.72rem;
-  font-size: 0.92rem;
-}
-
-@media (max-width: 1200px) {
-  .symptomGrid {
-    grid-template-columns: repeat(3, minmax(140px, 1fr));
-  }
-
-  .diagnosisPanel {
-    grid-template-columns: repeat(3, minmax(150px, 1fr));
-  }
-
-  .pipelineSection {
-    grid-template-columns: repeat(3, minmax(170px, 1fr));
-  }
-
-  .stageWithArrow {
-    align-items: stretch;
-  }
-
-  .arrow {
-    align-self: center;
-    transform: rotate(90deg);
-  }
-}
-
-@media (max-width: 800px) {
-  .symptomGrid,
-  .diagnosisPanel,
-  .pipelineSection {
+@media (max-width: 980px) {
+  .workspace {
     grid-template-columns: 1fr;
   }
 
-  .stageWithArrow {
-    flex-direction: column;
-  }
-
-  .bottomGrid {
+  .flowCards {
     grid-template-columns: 1fr;
-  }
-
-  .stageCard {
-    min-height: auto;
   }
 }


### PR DESCRIPTION
### Motivation
- Convert the busy multi-panel DDN FSI whiteboard into a single-screen, Loom-ready guided discovery talk track that follows the motion: Outcome → Workflow → Delay → Constraint → Business Impact → Validation → DDN. 
- Surface the discovery anchor question prominently: “What outcome needs to happen faster — and what happens when it doesn’t?”
- Make the flow intentionally minimal, whiteboard-inspired, and outcome-first so a speaker can narrate a 2-minute walkthrough with one selected symptom.

### Description
- Replaced the existing page component with a focused client-side React component that stores all symptom content locally in `SYMPTOM_FLOWS` and renders a left-side single-select symptom rail (default: “GPUs are underutilized”).
- Implemented a central 7-stage guided flow (Customer says → Outcome at risk → Workflow delay → Likely constraint → Business impact → Best next question → DDN hypothesis) where each stage is one concise card with 1–2 sentences.
- Added the validation panel titled `Validate before positioning DDN` with the three required bullets and a footer note that emphasizes outcome-first discovery before positioning DDN.
- Replaced the prior multi-panel/workload/tab structure with simplified CSS in `whiteboard.module.css` to produce a clean, responsive, whiteboard-inspired layout suitable for desktop Loom recordings.

### Testing
- Ran `npm run lint` in `ui/partner-hub`, which failed in this environment with: `sh: 1: next: not found`.
- Ran `npm run build` in `ui/partner-hub`, which failed in this environment with: `sh: 1: prisma: not found`.
- Ran `npm run test` in `ui/partner-hub`, which failed due to TypeScript/module resolution issues in this environment, for example: `Cannot find module 'node:test'` and `Cannot find module 'zod'`.
- These failures appear to be environment/dependency/tooling related rather than problems introduced by the page changes; the updated page and styles are self-contained and use local static data only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11256a4b08330aac326629f9975fa)