### PR TITLE
Refine DDN FSI whiteboard into guided discovery timeline

### DIFF
--- a/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx
+++ b/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx
@@ -121,7 +121,7 @@ export default function DdnFsiWhiteboardPage() {
       <section className={styles.workspace} aria-label="DDN guided discovery flow">
         <aside className={styles.symptomRail}>
           <h2 className={styles.railTitle}>Customer symptom</h2>
-          <div className={styles.symptomList} role="listbox" aria-label="Select a customer symptom">
+          <div className={styles.symptomList} role="group" aria-label="Select a customer symptom">
             {SYMPTOM_ORDER.map((symptomKey) => {
               const symptom = SYMPTOM_FLOWS[symptomKey];
               const isSelected = selectedSymptom === symptomKey;
@@ -130,8 +130,7 @@ export default function DdnFsiWhiteboardPage() {
                 <button
                   key={symptomKey}
                   type="button"
-                  role="option"
-                  aria-selected={isSelected}
+                  aria-pressed={isSelected}
                   className={`${styles.symptomButton} ${isSelected ? styles.symptomButtonActive : ""}`}
                   onClick={() => setSelectedSymptom(symptomKey)}
                 >
@@ -142,24 +141,40 @@ export default function DdnFsiWhiteboardPage() {
           </div>
         </aside>
 
-        <section className={styles.flowArea}>
-          <div className={styles.flowCards}>
-            {FLOW_STAGE_ORDER.map((stage) => (
-              <article key={stage.key} className={styles.flowCard}>
-                <h3>{stage.label}</h3>
-                <p>{selectedFlow.stages[stage.key]}</p>
-              </article>
-            ))}
-          </div>
+        <section className={styles.flowArea} aria-live="polite">
+          <h2 className={styles.selectedSymptomHeading}>Selected symptom: “{selectedFlow.label}”</h2>
 
-          <aside className={styles.validationBox}>
-            <h2>Validate before positioning DDN</h2>
-            <ul>
-              <li>What metric proves or disproves the constraint?</li>
-              <li>Who owns the delayed workflow?</li>
-              <li>What changes if the delay is removed?</li>
-            </ul>
-          </aside>
+          <div className={styles.flowAndValidation}>
+            <ol className={styles.timeline}>
+              {FLOW_STAGE_ORDER.map((stage, index) => {
+                const isBestQuestion = stage.key === "bestNextQuestion";
+                const isHypothesis = stage.key === "ddnHypothesis";
+
+                return (
+                  <li key={stage.key} className={styles.timelineItem}>
+                    <article
+                      className={`${styles.flowCard} ${isBestQuestion ? styles.bestNextQuestionCard : ""} ${isHypothesis ? styles.hypothesisCard : ""}`}
+                    >
+                      <div className={styles.cardHeader}>
+                        <span className={styles.stepNumber}>{index + 1}</span>
+                        <h3>{stage.label}</h3>
+                      </div>
+                      <p>{selectedFlow.stages[stage.key]}</p>
+                    </article>
+                  </li>
+                );
+              })}
+            </ol>
+
+            <aside className={styles.validationBox}>
+              <h2>Validate before positioning DDN</h2>
+              <ul>
+                <li>What metric proves or disproves the constraint?</li>
+                <li>Who owns the delayed workflow?</li>
+                <li>What changes if the delay is removed?</li>
+              </ul>
+            </aside>
+          </div>
         </section>
       </section>
 

--- a/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/whiteboard.module.css
+++ b/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/whiteboard.module.css
@@ -1,6 +1,6 @@
 .page {
   min-height: 100vh;
-  padding: clamp(1.1rem, 2vw, 2rem);
+  padding: clamp(1rem, 1.9vw, 1.8rem);
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(247, 249, 252, 0.96)),
     repeating-linear-gradient(0deg, rgba(15, 23, 42, 0.03), rgba(15, 23, 42, 0.03) 1px, transparent 1px, transparent 30px);
@@ -13,31 +13,31 @@
 
 .title {
   margin: 0;
-  font-size: clamp(1.75rem, 2.8vw, 2.4rem);
+  font-size: clamp(1.72rem, 2.7vw, 2.3rem);
   line-height: 1.15;
 }
 
 .subtitle {
-  margin: 0.45rem 0 0;
-  font-size: clamp(1rem, 1.4vw, 1.12rem);
+  margin: 0.4rem 0 0;
+  font-size: clamp(1rem, 1.4vw, 1.1rem);
   color: #334155;
 }
 
 .anchorQuestion {
-  margin: 0.85rem 0 0;
-  padding: 0.75rem 0.95rem;
+  margin: 0.8rem 0 0;
+  padding: 0.72rem 0.9rem;
   border-left: 4px solid #1d4ed8;
   border-radius: 10px;
   background: #eef4ff;
-  font-size: clamp(1rem, 1.45vw, 1.2rem);
+  font-size: clamp(1rem, 1.4vw, 1.16rem);
   font-weight: 700;
   color: #1e3a8a;
 }
 
 .workspace {
-  margin-top: 1.15rem;
+  margin-top: 1rem;
   display: grid;
-  grid-template-columns: minmax(220px, 270px) minmax(0, 1fr);
+  grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
   gap: 1rem;
   align-items: start;
 }
@@ -46,7 +46,7 @@
   border: 1px solid #cbd5e1;
   border-radius: 14px;
   background: #ffffff;
-  padding: 0.9rem;
+  padding: 0.85rem;
   box-shadow: 0 6px 20px rgba(15, 23, 42, 0.06);
 }
 
@@ -68,7 +68,7 @@
   border: 1px solid #cbd5e1;
   border-radius: 10px;
   background: #f8fafc;
-  padding: 0.63rem 0.7rem;
+  padding: 0.62rem 0.7rem;
   text-align: left;
   font-size: 0.95rem;
   line-height: 1.35;
@@ -94,21 +94,80 @@
 
 .flowArea {
   display: grid;
-  gap: 0.8rem;
+  gap: 0.6rem;
 }
 
-.flowCards {
+.selectedSymptomHeading {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1e3a8a;
+}
+
+.flowAndValidation {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.65rem;
+  grid-template-columns: minmax(0, 1fr) minmax(230px, 280px);
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.timeline {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.timelineItem {
+  position: relative;
+  padding-bottom: 0.25rem;
+}
+
+.timelineItem::after {
+  content: "";
+  position: absolute;
+  left: 1rem;
+  top: 100%;
+  width: 2px;
+  height: 0.42rem;
+  background: linear-gradient(to bottom, #94a3b8, #cbd5e1);
+}
+
+.timelineItem:last-child {
+  padding-bottom: 0;
+}
+
+.timelineItem:last-child::after {
+  display: none;
 }
 
 .flowCard {
   border: 1px solid #cbd5e1;
   border-radius: 12px;
   background: #ffffff;
-  padding: 0.85rem;
+  padding: 0.7rem 0.85rem;
   box-shadow: 0 4px 16px rgba(15, 23, 42, 0.05);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.52rem;
+}
+
+.stepNumber {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.45rem;
+  height: 1.45rem;
+  border-radius: 999px;
+  background: #e2e8f0;
+  color: #334155;
+  font-size: 0.8rem;
+  font-weight: 700;
+  flex-shrink: 0;
 }
 
 .flowCard h3 {
@@ -118,52 +177,77 @@
 }
 
 .flowCard p {
-  margin: 0.45rem 0 0;
-  font-size: 1rem;
-  line-height: 1.45;
+  margin: 0.38rem 0 0;
+  font-size: 0.96rem;
+  line-height: 1.4;
   color: #1e293b;
 }
 
+.bestNextQuestionCard {
+  border-color: #93c5fd;
+  background: linear-gradient(180deg, #ffffff, #f8fbff);
+  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.18), 0 6px 20px rgba(37, 99, 235, 0.08);
+}
+
+.bestNextQuestionCard .stepNumber {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.hypothesisCard {
+  border-color: #c7d2fe;
+  background: linear-gradient(180deg, #eef2ff, #ffffff 40%);
+}
+
+.hypothesisCard .stepNumber {
+  background: #c7d2fe;
+  color: #3730a3;
+}
+
 .validationBox {
-  border: 1px solid #bfdbfe;
+  border: 1px solid #dbeafe;
   border-radius: 12px;
   background: #f8fbff;
-  padding: 0.9rem;
+  padding: 0.72rem 0.82rem;
+  box-shadow: inset 0 0 0 1px rgba(147, 197, 253, 0.2);
 }
 
 .validationBox h2 {
   margin: 0;
-  font-size: 0.98rem;
+  font-size: 0.93rem;
   color: #1e3a8a;
 }
 
 .validationBox ul {
-  margin: 0.5rem 0 0;
-  padding-left: 1.15rem;
+  margin: 0.45rem 0 0;
+  padding-left: 1.1rem;
   display: grid;
-  gap: 0.35rem;
+  gap: 0.3rem;
 }
 
 .validationBox li {
-  font-size: 0.96rem;
-  line-height: 1.4;
+  font-size: 0.9rem;
+  line-height: 1.35;
+  color: #334155;
 }
 
 .footerNote {
-  margin-top: 0.95rem;
+  margin-top: 0.9rem;
   border-top: 1px solid #cbd5e1;
-  padding-top: 0.72rem;
-  font-size: 0.9rem;
-  line-height: 1.45;
+  padding-top: 0.68rem;
+  font-size: 0.88rem;
+  line-height: 1.42;
   color: #334155;
+}
+
+@media (max-width: 1100px) {
+  .flowAndValidation {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 980px) {
   .workspace {
-    grid-template-columns: 1fr;
-  }
-
-  .flowCards {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
### Motivation
- Turn the flow from a card grid into a clear, narrated discovery talk track that reads top-to-bottom for Loom recordings. 
- Surface the currently-selected symptom and guide the viewer step-by-step from customer quote to a validation-oriented DDN hypothesis. 
- Emphasize the discovery behavior (the Best next question) and make the DDN hypothesis feel like the final landing point while keeping validation secondary. 
- Keep the page lightweight, accessible, and one-screen friendly without adding libraries or backend dependencies.

### Description
- Replaced the two-column flow card grid with a vertical numbered timeline (an ordered list) and connector lines so stages read in sequence from Customer says → DDN hypothesis. (modified `page.tsx` and `whiteboard.module.css`).
- Added a dynamic selected-symptom heading `Selected symptom: “…”` that updates on click and added `aria-live="polite"` for announced updates. (in `page.tsx`).
- Visually emphasized the `bestNextQuestion` step and gave the `ddnHypothesis` step a distinct final-state style via new CSS classes such as `.stepNumber`, `.bestNextQuestionCard`, and `.hypothesisCard`. (in `whiteboard.module.css`).
- Made the symptom selector a keyboard-friendly button group using `aria-pressed` (replacing listbox/option semantics), and placed the validation box to the right on wide screens and stacked below the timeline on smaller screens for secondary prominence. (in `page.tsx` and `whiteboard.module.css`).

### Testing
- Ran `npm run lint` in the workspace and it failed in this environment with: `sh: 1: next: not found`.
- Ran `npm run typecheck` and it failed due to missing project types/dependencies (examples: `error TS2307: Cannot find module 'next/link'` and `error TS2307: Cannot find module 'react'` and many related TS errors; full output is environment-truncated). 
- Ran `npm run build` and it failed during `prebuild` with: `sh: 1: prisma: not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11492bc0483308abe4f4b5aba1414)