### PR TITLE
Pivot DDN FSI whiteboard into Loom-ready translation map

### DIFF
--- a/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx
+++ b/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/page.tsx
@@ -3,185 +3,240 @@
 import { useMemo, useState } from "react";
 import styles from "./whiteboard.module.css";
 
-type SymptomKey = "backtests" | "riskRuns" | "fraudDelayed" | "gpuUnderutilized" | "aiPilotsStuck";
-type FlowStageKey =
-  | "customerSays"
-  | "outcomeAtRisk"
-  | "workflowDelay"
-  | "likelyConstraint"
-  | "businessImpact"
-  | "bestNextQuestion"
-  | "ddnHypothesis";
+type WorkflowKey = "quantTrading" | "riskStress" | "fraudPayments" | "aiInfrastructure" | "aiProduction";
 
-type FlowContent = {
-  label: string;
-  stages: Record<FlowStageKey, string>;
+type Workflow = {
+  category: string;
+  delay: string;
+  pressure: string;
+  loomDeepDive?: boolean;
+  whyItMatters: string;
+  customerSignal: string;
+  translationQuestion: string;
+  evidenceRequest: string;
+  ddnHypothesis: string;
+  nextSalesAction: string;
+  stakeholders: string;
 };
 
-const SYMPTOM_ORDER: SymptomKey[] = ["backtests", "riskRuns", "fraudDelayed", "gpuUnderutilized", "aiPilotsStuck"];
+const WORKFLOW_ORDER: WorkflowKey[] = ["quantTrading", "riskStress", "fraudPayments", "aiInfrastructure", "aiProduction"];
 
-const FLOW_STAGE_ORDER: Array<{ key: FlowStageKey; label: string }> = [
-  { key: "customerSays", label: "Customer says" },
-  { key: "outcomeAtRisk", label: "Outcome at risk" },
-  { key: "workflowDelay", label: "Workflow delay" },
-  { key: "likelyConstraint", label: "Likely constraint" },
-  { key: "businessImpact", label: "Business impact" },
-  { key: "bestNextQuestion", label: "Best next question" },
-  { key: "ddnHypothesis", label: "DDN hypothesis" },
+const WORKFLOWS: Record<WorkflowKey, Workflow> = {
+  quantTrading: {
+    category: "Quant / Trading",
+    delay: "Backtests take too long",
+    pressure: "Algorithm development speed",
+    whyItMatters:
+      "Research speed drives competitive advantage. Slower backtesting means fewer strategies tested and slower algorithm development.",
+    customerSignal: "Backtests take too long.",
+    translationQuestion:
+      "Is research compute waiting on shared historical data access, metadata performance, or dataset reuse?",
+    evidenceRequest:
+      "Backtest completion windows, queue time, data read patterns, dataset size, concurrency, metadata behavior, and where jobs wait.",
+    ddnHypothesis:
+      "If research compute is waiting on data access or shared dataset performance, DDN may be relevant as the high-performance data layer behind faster research iteration.",
+    nextSalesAction:
+      "Create a backtesting workflow validation session with quant research, platform engineering, and infrastructure.",
+    stakeholders: "Head of research, quant researchers, platform engineering, infrastructure.",
+  },
+  riskStress: {
+    category: "Risk / Stress Testing",
+    delay: "Risk runs are still overnight",
+    pressure: "Exposure window",
+    whyItMatters:
+      "Risk timing affects decision-making. If risk remains overnight, exposure stays open longer during the trading day.",
+    customerSignal: "Risk runs are still overnight.",
+    translationQuestion: "Are model inputs, scenario data, data prep, or result aggregation extending the risk window?",
+    evidenceRequest:
+      "Batch window timeline, data prep duration, model runtime, scenario volume, concurrency, result aggregation time, and target intraday SLA.",
+    ddnHypothesis:
+      "If model inputs and scenario data are extending the risk window, DDN may be relevant to help compress the workflow.",
+    nextSalesAction:
+      "Create an intraday risk workflow review with risk analytics, application owners, trading stakeholders, and infrastructure.",
+    stakeholders: "CRO organization, risk analytics, application owners, trading stakeholders, infrastructure.",
+  },
+  fraudPayments: {
+    category: "Fraud / Payments",
+    delay: "Fraud response is delayed",
+    pressure: "Time-to-action",
+    whyItMatters:
+      "Fraud is a time-to-action problem. Delayed response increases loss exposure and customer impact.",
+    customerSignal: "Fraud response is delayed.",
+    translationQuestion: "Where is time lost between event, score, investigation, and action?",
+    evidenceRequest:
+      "Time from event to score, score to investigation, investigation to action, historical lookup latency, false positives, and model refresh timing.",
+    ddnHypothesis:
+      "If data access or analytics pipeline performance is slowing fraud response, DDN may be relevant to reduce decision latency.",
+    nextSalesAction:
+      "Create a fraud decision-latency mapping session with fraud analytics, data engineering, risk operations, security, and infrastructure.",
+    stakeholders: "Fraud analytics, data engineering, risk operations, security, infrastructure.",
+  },
+  aiInfrastructure: {
+    category: "AI Infrastructure",
+    delay: "GPUs are underutilized",
+    pressure: "GPU ROI",
+    loomDeepDive: true,
+    whyItMatters:
+      "AI infrastructure is highly visible, expensive, and executive-relevant. If GPUs are idle, AI spend is not converting into model velocity or business value.",
+    customerSignal: "GPUs are underutilized.",
+    translationQuestion: "Is expensive compute being starved by the data path?",
+    evidenceRequest:
+      "GPU utilization curve, data loader timing, checkpoint duration, restart time, job queue time, dataset size, and training throughput.",
+    ddnHypothesis:
+      "If the data path is limiting GPU efficiency, DDN may be relevant to improve utilization and accelerate model iteration.",
+    nextSalesAction:
+      "Create a GPU utilization validation workshop with AI platform, ML engineering, data engineering, and infrastructure.",
+    stakeholders: "AI platform owner, ML engineering, data engineering, infrastructure, research teams.",
+  },
+  aiProduction: {
+    category: "AI Production",
+    delay: "AI pilots are stuck",
+    pressure: "Production value",
+    whyItMatters:
+      "AI value comes from repeatable production workflows, not isolated pilots. If pilots are stuck, AI spend remains experimental.",
+    customerSignal: "AI pilots are stuck.",
+    translationQuestion: "Can teams repeatedly access, govern, and reuse large datasets across AI pipelines?",
+    evidenceRequest:
+      "Pilot-to-production blockers, dataset access time, data duplication, governance approval steps, model iteration time, production handoff gaps, and repeatable data access patterns.",
+    ddnHypothesis:
+      "If teams cannot repeatedly access and reuse large datasets across AI pipelines, DDN may be relevant as part of the production AI data foundation.",
+    nextSalesAction:
+      "Create an AI production-readiness workshop with AI leadership, data owners, governance/risk teams, infrastructure, and application owners.",
+    stakeholders: "AI leadership, data owners, governance/risk teams, infrastructure, application owners.",
+  },
+};
+
+const LANGUAGE_BRIDGE: Array<{ traditional: string; translated: string }> = [
+  { traditional: "VM performance issue", translated: "Workflow delay" },
+  { traditional: "Array latency", translated: "Data path bottleneck" },
+  { traditional: "Host waiting on storage", translated: "Compute / GPU starvation" },
+  { traditional: "Backup or DR window", translated: "Batch window / checkpoint / restart window" },
+  { traditional: "Datastore contention", translated: "Shared dataset concurrency" },
+  {
+    traditional: "App owner complaint",
+    translated: "Research / risk / fraud / AI pipeline owner pain",
+  },
+  {
+    traditional: "Capacity / performance sizing",
+    translated: "Dataset size, throughput, metadata, concurrency, data reuse",
+  },
+  {
+    traditional: "Business continuity",
+    translated: "Exposure window, fraud loss window, model iteration speed",
+  },
+  {
+    traditional: "Migration / refresh event",
+    translated: "Opportunity to modernize the data foundation",
+  },
 ];
 
-const SYMPTOM_FLOWS: Record<SymptomKey, FlowContent> = {
-  backtests: {
-    label: "Backtests take too long",
-    stages: {
-      customerSays: "Backtests take too long.",
-      outcomeAtRisk: "Research velocity slows down and fewer strategies get tested.",
-      workflowDelay: "Large historical datasets take too long to access, reuse, or process across research runs.",
-      likelyConstraint: "Data movement, metadata overhead, or shared filesystem performance may be limiting throughput.",
-      businessImpact: "Slower time-to-alpha and fewer opportunities evaluated before markets move.",
-      bestNextQuestion:
-        "How many strategies are delayed because backtests cannot complete inside the target window?",
-      ddnHypothesis:
-        "Validate whether the data path is slowing research iteration and whether a high-performance shared data layer would reduce wait time.",
-    },
-  },
-  riskRuns: {
-    label: "Risk runs are still overnight",
-    stages: {
-      customerSays: "Risk runs are still overnight.",
-      outcomeAtRisk: "The firm cannot make faster risk decisions during the trading day.",
-      workflowDelay: "Risk models and stress scenarios are waiting on data access, preparation, or processing windows.",
-      likelyConstraint:
-        "The bottleneck may be data throughput, concurrent access, or infrastructure unable to support intraday runs.",
-      businessImpact: "Exposure remains open longer and the business has less time to react.",
-      bestNextQuestion: "What would change operationally if that risk run finished in hours instead of overnight?",
-      ddnHypothesis:
-        "Validate whether faster access to model inputs and scenario data could compress the risk window.",
-    },
-  },
-  fraudDelayed: {
-    label: "Fraud response is delayed",
-    stages: {
-      customerSays: "Fraud response is delayed.",
-      outcomeAtRisk: "Fraud decisions happen too late to prevent loss or customer impact.",
-      workflowDelay:
-        "Detection, scoring, or investigation workflows are slowed by data availability and analysis time.",
-      likelyConstraint:
-        "The issue may be ingest, feature access, model scoring latency, or analytics pipeline performance.",
-      businessImpact: "Loss exposure increases and customer trust can be damaged.",
-      bestNextQuestion: "Where does the fraud workflow lose the most time between event, score, and action?",
-      ddnHypothesis: "Validate whether data pipeline performance is delaying fraud analytics or model response.",
-    },
-  },
-  gpuUnderutilized: {
-    label: "GPUs are underutilized",
-    stages: {
-      customerSays: "GPUs are underutilized.",
-      outcomeAtRisk: "AI infrastructure spend is not translating into model velocity.",
-      workflowDelay: "Training, checkpointing, or data loading is slowing the AI pipeline.",
-      likelyConstraint: "Data feeding, checkpointing, or dataset reuse may be limiting expensive compute.",
-      businessImpact: "Higher GPU ROI, faster time-to-model, and better use of AI infrastructure spend.",
-      bestNextQuestion: "What does GPU utilization look like during training, and when does it drop?",
-      ddnHypothesis: "Validate whether the data pipeline is starving GPUs or slowing checkpoint and restart cycles.",
-    },
-  },
-  aiPilotsStuck: {
-    label: "AI pilots are stuck",
-    stages: {
-      customerSays: "AI pilots are stuck.",
-      outcomeAtRisk: "The organization is not converting AI experimentation into repeatable production value.",
-      workflowDelay:
-        "Data preparation, model iteration, governance, or infrastructure scaling is slowing the move from pilot to production.",
-      likelyConstraint:
-        "The infrastructure may not support repeatable access to large datasets across teams and pipelines.",
-      businessImpact: "AI investment remains trapped in experimentation instead of business outcomes.",
-      bestNextQuestion: "What is preventing the pilot from becoming a repeatable production workflow?",
-      ddnHypothesis:
-        "Validate whether a production-grade data foundation is needed to support repeatable AI workloads.",
-    },
-  },
-};
+const DEEP_DIVE_FIELDS: Array<{ label: string; key: keyof Workflow }> = [
+  { label: "Why this workflow matters", key: "whyItMatters" },
+  { label: "Customer signal", key: "customerSignal" },
+  { label: "Translation question", key: "translationQuestion" },
+  { label: "Evidence I would request", key: "evidenceRequest" },
+  { label: "DDN hypothesis", key: "ddnHypothesis" },
+  { label: "Next sales action", key: "nextSalesAction" },
+  { label: "Stakeholders to involve", key: "stakeholders" },
+];
 
 export default function DdnFsiWhiteboardPage() {
-  const [selectedSymptom, setSelectedSymptom] = useState<SymptomKey>("gpuUnderutilized");
-  const selectedFlow = useMemo(() => SYMPTOM_FLOWS[selectedSymptom], [selectedSymptom]);
+  const [selectedWorkflow, setSelectedWorkflow] = useState<WorkflowKey>("aiInfrastructure");
+  const selected = useMemo(() => WORKFLOWS[selectedWorkflow], [selectedWorkflow]);
 
   return (
     <main className={styles.page}>
       <header className={styles.header}>
-        <h1 className={styles.title}>DDN FSI Discovery Talk Track</h1>
-        <p className={styles.subtitle}>
-          Start with the customer outcome, then validate whether data is the constraint.
-        </p>
-        <p className={styles.anchorQuestion}>
-          What outcome needs to happen faster — and what happens when it doesn’t?
+        <h1 className={styles.title}>My DDN FSI Translation Map</h1>
+        <p className={styles.subtitle}>Turning infrastructure experience into HPC / AI / FSI workflow discovery</p>
+        <p className={styles.povStatement}>
+          I would not lead with storage. I would translate customer workflow delay into business urgency, evidence,
+          and a DDN validation path.
         </p>
       </header>
 
-      <section className={styles.workspace} aria-label="DDN guided discovery flow">
-        <aside className={styles.symptomRail}>
-          <h2 className={styles.railTitle}>Customer symptom</h2>
-          <div className={styles.symptomList} role="group" aria-label="Select a customer symptom">
-            {SYMPTOM_ORDER.map((symptomKey) => {
-              const symptom = SYMPTOM_FLOWS[symptomKey];
-              const isSelected = selectedSymptom === symptomKey;
+      <section className={styles.briefingGrid} aria-label="DDN FSI executive briefing">
+        <section className={styles.zoneOne}>
+          <h2>FSI workflow delays I would listen for</h2>
+          <div className={styles.workflowCards} role="group" aria-label="Select workflow delay">
+            {WORKFLOW_ORDER.map((workflowKey) => {
+              const workflow = WORKFLOWS[workflowKey];
+              const isSelected = workflowKey === selectedWorkflow;
 
               return (
                 <button
-                  key={symptomKey}
+                  key={workflowKey}
                   type="button"
                   aria-pressed={isSelected}
-                  className={`${styles.symptomButton} ${isSelected ? styles.symptomButtonActive : ""}`}
-                  onClick={() => setSelectedSymptom(symptomKey)}
+                  className={`${styles.workflowCard} ${isSelected ? styles.workflowCardActive : ""}`}
+                  onClick={() => setSelectedWorkflow(workflowKey)}
                 >
-                  {symptom.label}
+                  <div className={styles.workflowCardHeaderRow}>
+                    <h3>{workflow.category}</h3>
+                    {workflow.loomDeepDive ? <span className={styles.deepDiveBadge}>Loom deep dive</span> : null}
+                  </div>
+                  <p>
+                    <strong>Delay:</strong> {workflow.delay}
+                  </p>
+                  <p>
+                    <strong>Pressure:</strong> {workflow.pressure}
+                  </p>
                 </button>
               );
             })}
           </div>
-        </aside>
+        </section>
 
-        <section className={styles.flowArea} aria-live="polite">
-          <h2 className={styles.selectedSymptomHeading}>Selected symptom: “{selectedFlow.label}”</h2>
-
-          <div className={styles.flowAndValidation}>
-            <ol className={styles.timeline}>
-              {FLOW_STAGE_ORDER.map((stage, index) => {
-                const isBestQuestion = stage.key === "bestNextQuestion";
-                const isHypothesis = stage.key === "ddnHypothesis";
-
-                return (
-                  <li key={stage.key} className={styles.timelineItem}>
-                    <article
-                      className={`${styles.flowCard} ${isBestQuestion ? styles.bestNextQuestionCard : ""} ${isHypothesis ? styles.hypothesisCard : ""}`}
-                    >
-                      <div className={styles.cardHeader}>
-                        <span className={styles.stepNumber}>{index + 1}</span>
-                        <h3>{stage.label}</h3>
-                      </div>
-                      <p>{selectedFlow.stages[stage.key]}</p>
-                    </article>
-                  </li>
-                );
-              })}
-            </ol>
-
-            <aside className={styles.validationBox}>
-              <h2>Validate before positioning DDN</h2>
-              <ul>
-                <li>What metric proves or disproves the constraint?</li>
-                <li>Who owns the delayed workflow?</li>
-                <li>What changes if the delay is removed?</li>
-              </ul>
-            </aside>
+        <section className={styles.zoneTwo}>
+          <h2>The translation I’m sharpening</h2>
+          <div className={styles.bridgeTable} role="table" aria-label="Language translation bridge">
+            <div className={styles.bridgeHeader} role="row">
+              <span role="columnheader">Traditional infrastructure language</span>
+              <span role="columnheader">DDN / HPC / AI / FSI language</span>
+            </div>
+            {LANGUAGE_BRIDGE.map((row) => (
+              <div className={styles.bridgeRow} role="row" key={row.traditional}>
+                <span role="cell">{row.traditional}</span>
+                <span role="cell">{row.translated}</span>
+              </div>
+            ))}
           </div>
         </section>
-      </section>
 
-      <footer className={styles.footerNote}>
-        The goal is not to pitch storage first. The goal is to connect workflow delay to measurable business impact,
-        then test whether the data path is the constraint.
-      </footer>
+        <section className={styles.zoneThree} aria-live="polite">
+          <h2>Deep dive: {selected.delay}</h2>
+          <div className={styles.deepDiveGrid}>
+            {DEEP_DIVE_FIELDS.map((field) => {
+              const isNextAction = field.key === "nextSalesAction";
+              return (
+                <article key={field.key} className={`${styles.deepDiveCard} ${isNextAction ? styles.nextActionCard : ""}`}>
+                  <h3>{field.label}</h3>
+                  <p>{selected[field.key]}</p>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className={styles.zoneFour}>
+          <h2>Field motion</h2>
+          <p className={styles.motionFlow}>
+            <span>Business outcome</span>
+            <span aria-hidden="true">→</span>
+            <span>Workflow delay</span>
+            <span aria-hidden="true">→</span>
+            <span>Evidence</span>
+            <span aria-hidden="true">→</span>
+            <span>DDN hypothesis</span>
+            <span aria-hidden="true">→</span>
+            <span>Next sales action</span>
+          </p>
+          <p className={styles.motionNote}>
+            The goal is not to force product fit. The goal is to prove whether the data path is part of the business
+            delay.
+          </p>
+        </section>
+      </section>
     </main>
   );
 }

--- a/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/whiteboard.module.css
+++ b/ui/partner-hub/app/(routes)/ddn-fsi-whiteboard/whiteboard.module.css
@@ -1,253 +1,278 @@
 .page {
   min-height: 100vh;
-  padding: clamp(1rem, 1.9vw, 1.8rem);
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(247, 249, 252, 0.96)),
-    repeating-linear-gradient(0deg, rgba(15, 23, 42, 0.03), rgba(15, 23, 42, 0.03) 1px, transparent 1px, transparent 30px);
+  padding: clamp(1.1rem, 2.2vw, 2rem);
   color: #0f172a;
+  background:
+    radial-gradient(circle at 20% 0%, rgba(37, 99, 235, 0.1), transparent 42%),
+    radial-gradient(circle at 100% 0%, rgba(15, 23, 42, 0.08), transparent 36%),
+    linear-gradient(180deg, #f8fbff 0%, #f2f6fc 100%);
 }
 
 .header {
-  max-width: 980px;
+  max-width: 1150px;
+  margin: 0 auto;
 }
 
 .title {
   margin: 0;
-  font-size: clamp(1.72rem, 2.7vw, 2.3rem);
-  line-height: 1.15;
+  font-size: clamp(1.8rem, 3.2vw, 2.6rem);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
 }
 
 .subtitle {
-  margin: 0.4rem 0 0;
-  font-size: clamp(1rem, 1.4vw, 1.1rem);
+  margin: 0.5rem 0 0;
+  font-size: clamp(1rem, 1.45vw, 1.2rem);
   color: #334155;
 }
 
-.anchorQuestion {
-  margin: 0.8rem 0 0;
-  padding: 0.72rem 0.9rem;
+.povStatement {
+  margin: 0.85rem 0 0;
+  max-width: 980px;
   border-left: 4px solid #1d4ed8;
-  border-radius: 10px;
-  background: #eef4ff;
-  font-size: clamp(1rem, 1.4vw, 1.16rem);
+  background: #eff6ff;
+  border-radius: 12px;
+  padding: 0.75rem 0.95rem;
+  font-size: clamp(1rem, 1.5vw, 1.16rem);
   font-weight: 700;
+  line-height: 1.45;
   color: #1e3a8a;
 }
 
-.workspace {
-  margin-top: 1rem;
+.briefingGrid {
+  max-width: 1150px;
+  margin: 1rem auto 0;
   display: grid;
-  grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
-  gap: 1rem;
-  align-items: start;
+  gap: 0.85rem;
+  grid-template-columns: minmax(0, 1.02fr) minmax(0, 1.18fr);
+  grid-template-areas:
+    "zone1 zone3"
+    "zone2 zone4";
 }
 
-.symptomRail {
+.zoneOne,
+.zoneTwo,
+.zoneThree,
+.zoneFour {
   border: 1px solid #cbd5e1;
-  border-radius: 14px;
-  background: #ffffff;
-  padding: 0.85rem;
-  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.06);
+  border-radius: 16px;
+  padding: 0.92rem;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
 }
 
-.railTitle {
+.zoneOne {
+  grid-area: zone1;
+}
+
+.zoneTwo {
+  grid-area: zone2;
+}
+
+.zoneThree {
+  grid-area: zone3;
+  border-color: #bfdbfe;
+  box-shadow: 0 14px 34px rgba(29, 78, 216, 0.14);
+}
+
+.zoneFour {
+  grid-area: zone4;
+}
+
+.zoneOne h2,
+.zoneTwo h2,
+.zoneThree h2,
+.zoneFour h2 {
   margin: 0;
-  font-size: 0.96rem;
-  font-weight: 700;
-  color: #334155;
+  font-size: 1rem;
+  color: #0f172a;
 }
 
-.symptomList {
-  margin-top: 0.6rem;
+.workflowCards {
+  margin-top: 0.68rem;
   display: grid;
-  gap: 0.45rem;
+  gap: 0.55rem;
 }
 
-.symptomButton {
-  width: 100%;
+.workflowCard {
   border: 1px solid #cbd5e1;
-  border-radius: 10px;
+  border-radius: 12px;
+  padding: 0.72rem 0.78rem;
   background: #f8fafc;
-  padding: 0.62rem 0.7rem;
   text-align: left;
-  font-size: 0.95rem;
-  line-height: 1.35;
   cursor: pointer;
-  transition: border-color 120ms ease, background-color 120ms ease, box-shadow 120ms ease;
+  transition: all 140ms ease;
 }
 
-.symptomButton:hover {
+.workflowCard:hover {
   border-color: #94a3b8;
+  background: #f1f5f9;
 }
 
-.symptomButton:focus-visible {
+.workflowCard:focus-visible {
   outline: 3px solid #2563eb;
   outline-offset: 2px;
 }
 
-.symptomButtonActive {
+.workflowCardActive {
   border-color: #1d4ed8;
-  background: #eaf1ff;
-  box-shadow: inset 0 0 0 1px rgba(29, 78, 216, 0.15);
-  font-weight: 600;
+  background: linear-gradient(180deg, #eff6ff, #f8fbff);
+  box-shadow: 0 0 0 1px rgba(29, 78, 216, 0.2), 0 8px 20px rgba(29, 78, 216, 0.14);
 }
 
-.flowArea {
-  display: grid;
-  gap: 0.6rem;
-}
-
-.selectedSymptomHeading {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 700;
-  color: #1e3a8a;
-}
-
-.flowAndValidation {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(230px, 280px);
-  gap: 0.75rem;
-  align-items: start;
-}
-
-.timeline {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 0.45rem;
-}
-
-.timelineItem {
-  position: relative;
-  padding-bottom: 0.25rem;
-}
-
-.timelineItem::after {
-  content: "";
-  position: absolute;
-  left: 1rem;
-  top: 100%;
-  width: 2px;
-  height: 0.42rem;
-  background: linear-gradient(to bottom, #94a3b8, #cbd5e1);
-}
-
-.timelineItem:last-child {
-  padding-bottom: 0;
-}
-
-.timelineItem:last-child::after {
-  display: none;
-}
-
-.flowCard {
-  border: 1px solid #cbd5e1;
-  border-radius: 12px;
-  background: #ffffff;
-  padding: 0.7rem 0.85rem;
-  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.05);
-}
-
-.cardHeader {
+.workflowCardHeaderRow {
   display: flex;
+  justify-content: space-between;
   align-items: center;
-  gap: 0.52rem;
+  gap: 0.4rem;
 }
 
-.stepNumber {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.45rem;
-  height: 1.45rem;
-  border-radius: 999px;
-  background: #e2e8f0;
-  color: #334155;
-  font-size: 0.8rem;
-  font-weight: 700;
-  flex-shrink: 0;
-}
-
-.flowCard h3 {
+.workflowCard h3 {
   margin: 0;
-  font-size: 0.95rem;
-  color: #1e3a8a;
+  font-size: 0.98rem;
+  color: #0f172a;
 }
 
-.flowCard p {
-  margin: 0.38rem 0 0;
-  font-size: 0.96rem;
-  line-height: 1.4;
-  color: #1e293b;
-}
-
-.bestNextQuestionCard {
-  border-color: #93c5fd;
-  background: linear-gradient(180deg, #ffffff, #f8fbff);
-  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.18), 0 6px 20px rgba(37, 99, 235, 0.08);
-}
-
-.bestNextQuestionCard .stepNumber {
-  background: #dbeafe;
-  color: #1d4ed8;
-}
-
-.hypothesisCard {
-  border-color: #c7d2fe;
-  background: linear-gradient(180deg, #eef2ff, #ffffff 40%);
-}
-
-.hypothesisCard .stepNumber {
-  background: #c7d2fe;
-  color: #3730a3;
-}
-
-.validationBox {
-  border: 1px solid #dbeafe;
-  border-radius: 12px;
-  background: #f8fbff;
-  padding: 0.72rem 0.82rem;
-  box-shadow: inset 0 0 0 1px rgba(147, 197, 253, 0.2);
-}
-
-.validationBox h2 {
-  margin: 0;
-  font-size: 0.93rem;
-  color: #1e3a8a;
-}
-
-.validationBox ul {
-  margin: 0.45rem 0 0;
-  padding-left: 1.1rem;
-  display: grid;
-  gap: 0.3rem;
-}
-
-.validationBox li {
+.workflowCard p {
+  margin: 0.25rem 0 0;
   font-size: 0.9rem;
   line-height: 1.35;
   color: #334155;
 }
 
-.footerNote {
-  margin-top: 0.9rem;
-  border-top: 1px solid #cbd5e1;
-  padding-top: 0.68rem;
-  font-size: 0.88rem;
-  line-height: 1.42;
+.deepDiveBadge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid #93c5fd;
+  background: #eff6ff;
+  padding: 0.16rem 0.45rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #1d4ed8;
+  white-space: nowrap;
+}
+
+.bridgeTable {
+  margin-top: 0.65rem;
+  display: grid;
+  border: 1px solid #dbeafe;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.bridgeHeader,
+.bridgeRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.bridgeHeader {
+  background: #eff6ff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #1e3a8a;
+}
+
+.bridgeHeader span,
+.bridgeRow span {
+  padding: 0.44rem 0.55rem;
+}
+
+.bridgeRow {
+  border-top: 1px solid #e2e8f0;
+}
+
+.bridgeRow span {
+  font-size: 0.8rem;
+  line-height: 1.28;
   color: #334155;
 }
 
-@media (max-width: 1100px) {
-  .flowAndValidation {
-    grid-template-columns: 1fr;
-  }
+.deepDiveGrid {
+  margin-top: 0.65rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.deepDiveCard {
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
+  background: #ffffff;
+  padding: 0.62rem 0.7rem;
+}
+
+.deepDiveCard h3 {
+  margin: 0;
+  font-size: 0.84rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: #1e3a8a;
+}
+
+.deepDiveCard p {
+  margin: 0.33rem 0 0;
+  font-size: 0.9rem;
+  line-height: 1.37;
+  color: #1e293b;
+}
+
+.nextActionCard {
+  border-color: #93c5fd;
+  background: linear-gradient(180deg, #f8fbff 0%, #eff6ff 100%);
+  box-shadow: inset 0 0 0 1px rgba(147, 197, 253, 0.25);
+}
+
+.motionFlow {
+  margin: 0.65rem 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.motionFlow span {
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  background: #f8fafc;
+  padding: 0.26rem 0.58rem;
+  font-size: 0.84rem;
+  color: #334155;
+}
+
+.motionFlow span[aria-hidden="true"] {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: #64748b;
+}
+
+.motionNote {
+  margin: 0.68rem 0 0;
+  border-left: 3px solid #1d4ed8;
+  padding-left: 0.64rem;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  color: #334155;
 }
 
 @media (max-width: 980px) {
-  .workspace {
+  .briefingGrid {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "zone1"
+      "zone3"
+      "zone2"
+      "zone4";
+  }
+
+  .deepDiveGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .bridgeHeader,
+  .bridgeRow {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
### Motivation
- Convert the existing DDN FSI whiteboard into a single-screen, Loom-friendly executive briefing that highlights multiple FSI workflows and intentionally deep-dives on GPUs underutilization as the default selection. 
- Keep the page static, dependency-free, accessible, and visually polished so it can be used for recorded Loom briefings without introducing backend or new library requirements.

### Description
- Replace the prior linear talk-track timeline with a workflow-driven card model and local `WORKFLOWS` data containing five FSI scenarios and full deep-dive copy, defaulting to `AI Infrastructure / GPUs are underutilized` (includes a `Loom deep dive` badge). 
- Add a compact two-column `LANGUAGE_BRIDGE` and `DEEP_DIVE_FIELDS` to translate infrastructure language into DDN/HPC/AI/FSI language and surface the requested discovery artifacts. 
- Implement accessible card selection using semantic `<button>` controls with `aria-pressed`, visible focus states, keyboard support, and responsive CSS delivered via an updated `whiteboard.module.css`. 
- Preserve the original route (`/partner-hub/ddn-fsi-whiteboard`), keep all content local/static, and avoid adding any new package dependencies.

### Testing
- Ran `npm run lint` in `ui/partner-hub`, which failed because the environment is missing the `next` binary and returned `sh: 1: next: not found`. 
- Ran `npm run typecheck` (`tsc --noEmit`), which failed with multiple TypeScript resolution errors such as missing `next/*`, `react`, and other type declarations in the container environment. 
- Ran `npm run build`, which invoked `prisma generate` during `prebuild` and failed with `sh: 1: prisma: not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11ff5cbe083308ccecb261eed63e2)