### PR TITLE
Add conversation draft generation (Phase 3)

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 import { getTodaysConversationActions } from "@/lib/job-hunter/conversations";
 import { buildConversationTarget, createTargetDraft, isTargetDraftValid, type TargetDraft } from "@/lib/job-hunter/conversationTargets";
 import { applySequenceMessageEdit, getDraftedOutreach, getFollowUpsDue, markSequenceSent, skipSequence, snoozeSequence } from "@/lib/job-hunter/conversationUi";
+import { generateConversationDraftsFromTopJobs, type ConversationAutomationSummary } from "@/lib/job-hunter/conversationAutomation";
 import { loadJobHunterStore, saveJobHunterStore } from "@/lib/job-hunter/storage";
 
 import { ActiveConversationsSection, DraftedOutreachSection, FollowUpsDueSection } from "./components/ConversationSections";
@@ -15,6 +16,7 @@ export default function ConversationsClient() {
   const [draftEdits, setDraftEdits] = useState<Record<string, string>>({});
   const [targetDrafts, setTargetDrafts] = useState<Record<string, TargetDraft>>({});
   const [now] = useState(() => new Date());
+  const [generationSummary, setGenerationSummary] = useState<ConversationAutomationSummary | null>(null);
 
   const actions = useMemo(() => getTodaysConversationActions({ today: now, sequences: store.outreachSequences ?? [], targets: store.conversationTargets ?? [], jobs: store.jobs ?? [] }), [now, store]);
   const drafted = useMemo(() => getDraftedOutreach(store.outreachSequences ?? []), [store.outreachSequences]);
@@ -31,6 +33,13 @@ export default function ConversationsClient() {
     persist(applySequenceMessageEdit(store, sequenceId, nextText, new Date()));
   };
 
+
+  const onGenerateDrafts = () => {
+    const result = generateConversationDraftsFromTopJobs({ store, now: new Date() });
+    persist(result.store);
+    setGenerationSummary(result.summary);
+  };
+
   const onAddTarget = (jobId: string) => {
     const draft = targetDrafts[jobId] ?? createTargetDraft();
     const job = store.jobsById[jobId];
@@ -43,7 +52,7 @@ export default function ConversationsClient() {
 
   return <main className="mx-auto max-w-5xl space-y-6 p-6">
     <header className="space-y-2"><h1 className="text-2xl font-semibold">Conversations</h1><p className="text-sm text-foreground/70">Review drafts, follow-ups, and active replies without auto-sending.</p></header>
-    <section className="grid gap-3 rounded-lg border border-border/60 p-4 md:grid-cols-5 text-sm">{[["Drafts to review", actions.draftsToReview.length], ["Follow-ups due", actions.followUpsDue.length], ["Stale sent no reply", actions.staleSentNoReply.length], ["Active replies", actions.activeReplies.length], ["Roles needing targets", actions.rolesNeedingTargets.length]].map(([label, count]) => <article key={String(label)} className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">{label}</p><p className="text-2xl font-semibold">{count}</p></article>)}</section>
+    <section className="space-y-3 rounded-lg border border-border/60 p-4 text-sm"><div className="flex flex-wrap items-center justify-between gap-3"><p className="text-foreground/80">Generate conversation briefs and drafts from top-scoring roles.</p><button type="button" onClick={onGenerateDrafts} className="rounded border border-border px-3 py-1.5 font-medium hover:bg-accent">Generate conversation drafts</button></div>{generationSummary ? <p className="text-xs text-foreground/70">Generated {generationSummary.generatedBriefs} briefs, {generationSummary.generatedTargets} targets, and {generationSummary.generatedOutreachDrafts} outreach drafts across {generationSummary.eligibleJobs} eligible jobs ({generationSummary.consideredJobs} considered).</p> : null}<div className="grid gap-3 md:grid-cols-5">{[["Drafts to review", actions.draftsToReview.length], ["Follow-ups due", actions.followUpsDue.length], ["Stale sent no reply", actions.staleSentNoReply.length], ["Active replies", actions.activeReplies.length], ["Roles needing targets", actions.rolesNeedingTargets.length]].map(([label, count]) => <article key={String(label)} className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">{label}</p><p className="text-2xl font-semibold">{count}</p></article>)}</div></section>
 
     <DraftedOutreachSection drafted={drafted} jobsById={store.jobsById} targetsById={store.conversationTargetsById} draftEdits={draftEdits} setDraftEdit={(id, value) => setDraftEdits((prev) => ({ ...prev, [id]: value }))} onEditSave={onEditSave} onCopy={(value) => void navigator.clipboard?.writeText(value)} onMarkSent={(id) => persist(markSequenceSent(store, id, new Date()))} onSkip={(id) => persist(skipSequence(store, id, new Date()))} />
 

--- a/ui/partner-hub/lib/job-hunter/conversationAutomation.test.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationAutomation.test.ts
@@ -1,0 +1,71 @@
+import * as assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { generateConversationDraftsFromTopJobs } from "./conversationAutomation";
+import { getDefaultPreferences } from "./preferences";
+import type { JobHunterStore, JobPosting } from "./types";
+
+const makeJob = (id: string, title: string, notes = ""): JobPosting => ({
+  id,
+  title,
+  company: `Company ${id}`,
+  source: "manual",
+  notes,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+});
+
+const baseStore = (jobs: JobPosting[]): JobHunterStore => ({
+  jobs,
+  jobsById: jobs.reduce<Record<string, JobPosting>>((acc, job) => ({ ...acc, [job.id]: job }), {}),
+  selectedJobIds: [],
+  sources: [],
+  applications: [],
+  applicationsById: {},
+  preferences: getDefaultPreferences(),
+  automation: { autoSyncOnJobsOpen: true, autoSyncIfOlderThanHours: 24, topMatchesLimit: 10 },
+  conversations: [],
+  conversationsById: {},
+  conversationTargets: [],
+  conversationTargetsById: {},
+  conversationBriefs: [],
+  conversationBriefsById: {},
+  outreachSequences: [],
+  outreachSequencesById: {},
+});
+
+describe("conversation automation", () => {
+  it("generates briefs, targets, and drafts for high-scoring jobs only", () => {
+    const strong = makeJob("job-1", "Solutions Architect", "cloud architecture kubernetes distributed systems");
+    const weak = makeJob("job-2", "Office Coordinator", "office admin");
+    const { store, summary } = generateConversationDraftsFromTopJobs({
+      store: baseStore([strong, weak]),
+      now: new Date("2026-01-02T00:00:00.000Z"),
+      minimumScore: 60,
+    });
+
+    assert.equal(summary.eligibleJobs, 1);
+    assert.equal(summary.generatedBriefs, 1);
+    assert.equal(summary.generatedTargets, 2);
+    assert.equal(summary.generatedOutreachDrafts >= 1, true);
+    assert.equal(store.conversationBriefs.length, 1);
+  });
+
+  it("does not duplicate previously generated records", () => {
+    const strong = makeJob("job-1", "Solutions Architect", "cloud architecture kubernetes distributed systems");
+    const first = generateConversationDraftsFromTopJobs({
+      store: baseStore([strong]),
+      now: new Date("2026-01-02T00:00:00.000Z"),
+      minimumScore: 60,
+    });
+    const second = generateConversationDraftsFromTopJobs({
+      store: first.store,
+      now: new Date("2026-01-03T00:00:00.000Z"),
+      minimumScore: 60,
+    });
+
+    assert.equal(second.summary.generatedBriefs, 0);
+    assert.equal(second.summary.generatedTargets, 0);
+    assert.equal(second.summary.generatedOutreachDrafts, 0);
+  });
+});

--- a/ui/partner-hub/lib/job-hunter/conversationAutomation.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationAutomation.ts
@@ -1,0 +1,103 @@
+import { buildConversationBriefForJob, buildInitialOutreachQueueForJob } from "./conversations";
+import { scoreJobFit } from "./scoring";
+import type { ConversationBrief, ConversationTarget, JobHunterPreferences, JobHunterStore, OutreachSequence } from "./types";
+
+export type ConversationAutomationSummary = {
+  consideredJobs: number;
+  eligibleJobs: number;
+  generatedBriefs: number;
+  generatedTargets: number;
+  generatedOutreachDrafts: number;
+};
+
+export const DEFAULT_CONVERSATION_MINIMUM_SCORE = 70;
+
+export const generateConversationDraftsFromTopJobs = (params: {
+  store: JobHunterStore;
+  now: Date;
+  minimumScore?: number;
+  limit?: number;
+  preferences?: JobHunterPreferences;
+}): { store: JobHunterStore; summary: ConversationAutomationSummary } => {
+  const minimumScore = Math.max(0, Math.min(100, params.minimumScore ?? params.store.preferences?.minimumScore ?? DEFAULT_CONVERSATION_MINIMUM_SCORE));
+  const limit = Math.max(1, params.limit ?? params.store.automation?.topMatchesLimit ?? 10);
+  const preferences = params.preferences ?? params.store.preferences;
+
+  const ranked = [...params.store.jobs]
+    .map((job) => ({ job, fit: scoreJobFit(job, preferences) }))
+    .sort((a, b) => (b.fit.score !== a.fit.score ? b.fit.score - a.fit.score : b.job.updatedAt.localeCompare(a.job.updatedAt)));
+
+  const eligible = ranked.filter((row) => row.fit.score >= minimumScore).slice(0, limit);
+
+  const nextBriefsById: Record<string, ConversationBrief> = { ...params.store.conversationBriefsById };
+  const nextTargetsById: Record<string, ConversationTarget> = { ...params.store.conversationTargetsById };
+  const nextSequencesById: Record<string, OutreachSequence> = { ...params.store.outreachSequencesById };
+
+  let generatedBriefs = 0;
+  let generatedTargets = 0;
+  let generatedOutreachDrafts = 0;
+
+  for (const row of eligible) {
+    const existingBrief = Object.values(nextBriefsById).find((brief) => brief.jobId === row.job.id);
+    const companyTargets = Object.values(nextTargetsById).filter((target) => target.company === row.job.company);
+    const existingOutreach = Object.values(nextSequencesById).filter((sequence) => sequence.jobId === row.job.id);
+
+    let brief = existingBrief;
+    let targets = companyTargets;
+
+    if (!brief) {
+      const generated = buildConversationBriefForJob(row.job, {
+        matched: row.fit.matched.map((item) => item.keyword),
+        missing: row.fit.missing.map((item) => item.keyword),
+        preferenceSignals: row.fit.preferenceSignals,
+      }, params.store.resumeProfile, params.now);
+      brief = generated.brief;
+      targets = generated.targets;
+      nextBriefsById[brief.id] = brief;
+      generatedBriefs += 1;
+
+      for (const target of targets) {
+        if (!nextTargetsById[target.id]) {
+          nextTargetsById[target.id] = target;
+          generatedTargets += 1;
+        }
+      }
+    }
+
+    if (!brief) continue;
+
+    const queue = buildInitialOutreachQueueForJob({
+      job: row.job,
+      brief,
+      targets,
+      existing: existingOutreach,
+      now: params.now,
+    });
+
+    for (const draft of queue) {
+      if (!nextSequencesById[draft.id]) {
+        nextSequencesById[draft.id] = draft;
+        generatedOutreachDrafts += 1;
+      }
+    }
+  }
+
+  return {
+    store: {
+      ...params.store,
+      conversationBriefsById: nextBriefsById,
+      conversationBriefs: Object.values(nextBriefsById),
+      conversationTargetsById: nextTargetsById,
+      conversationTargets: Object.values(nextTargetsById),
+      outreachSequencesById: nextSequencesById,
+      outreachSequences: Object.values(nextSequencesById),
+    },
+    summary: {
+      consideredJobs: ranked.length,
+      eligibleJobs: eligible.length,
+      generatedBriefs,
+      generatedTargets,
+      generatedOutreachDrafts,
+    },
+  };
+};


### PR DESCRIPTION
### Motivation
- Provide an explicit, review-controlled way to generate conversation briefs, recommended targets, and outreach drafts from high-scoring job postings so the Conversations page can be populated with actionable daily items. 
- Keep generation manual and gated (no page-load generation, no auto-send, and no external APIs) while leveraging existing scoring and brief/draft builders.

### Description
- Added `ui/partner-hub/lib/job-hunter/conversationAutomation.ts` implementing `generateConversationDraftsFromTopJobs`, which ranks jobs by fit, filters by a configurable minimum score, caps by a top-limit, and idempotently merges generated briefs, targets, and outreach drafts into the store.
- Added `ui/partner-hub/lib/job-hunter/conversationAutomation.test.ts` with coverage that asserts generation only for qualifying/high-scoring jobs and that repeated runs do not duplicate previously-generated records.
- Updated the Conversations UI at `ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx` to expose a manual `Generate conversation drafts` button and to display a post-run `generationSummary` with counts of generated briefs, targets, and drafts.
- Implementation reuses existing helpers (`scoreJobFit`, `buildConversationBriefForJob`, `buildInitialOutreachQueueForJob`) and preserves review flow (drafts are created but not sent).

### Testing
- Ran `npm test` from `ui/partner-hub`, which exercised the repo test harness but failed in this environment due to missing runtime/type dependencies (test harness reported missing `node:test`/`node:assert`, `@types/node`, and other repo-wide deps); the new tests were added but could not be executed to completion here.
- Ran `npm run typecheck` from `ui/partner-hub`, which failed in this environment because of missing framework/type dependencies (e.g., `next`, `react`, UI libs) and pre-existing repository type errors unrelated to the changes.
- Summary: new automation logic and tests are present and unit-tested in-source, but the CI-local test/typecheck steps could not be validated to green due to the environment lacking repository-wide dependencies and type setup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25af6fc8c8330a8314bbc2031f077)