### PR TITLE
Job Hunter Phase 3 cleanup: normalize company matching for conversation automation

### DIFF
--- a/ui/partner-hub/lib/job-hunter/conversationAutomation.test.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationAutomation.test.ts
@@ -48,16 +48,17 @@ describe("conversation automation", () => {
     assert.equal(store.conversationBriefs.length, 1);
   });
 
-  it("uses existing company targets and avoids placeholder targets when available", () => {
+  it("uses existing company targets with case-insensitive trimmed company matching", () => {
     const job = makeJob("job-1", "Solutions Architect", "cloud distributed systems", "Acme");
     const existingTarget: ConversationTarget = {
-      id: "acme:employee-1", company: "Acme", name: "Pat Engineer", relationshipType: "employee", source: "manual", confidence: 95,
+      id: "acme:employee-1", company: " acme ", name: "Pat Engineer", relationshipType: "employee", source: "manual", confidence: 95,
       createdAt: "2026-01-01T00:00:00.000Z", updatedAt: "2026-01-01T00:00:00.000Z",
     };
     const { assets, summary } = generateConversationAssetsForJobs({ store: baseStore([job], [existingTarget]), now: new Date("2026-01-02T00:00:00.000Z"), minimumScore: 60, topMatchesLimit: 5 });
 
     assert.equal(summary.generatedTargets, 0);
     assert.equal(Object.values(assets.targetsById).length, 0);
+    assert.equal(Object.values(assets.targetsById).some((target) => target.id.includes("auto-")), false);
     assert.equal(Object.values(assets.sequencesById).every((s) => s.contactId === existingTarget.id), true);
   });
 

--- a/ui/partner-hub/lib/job-hunter/conversationAutomation.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationAutomation.ts
@@ -1,5 +1,5 @@
 import { deriveTopMatchesReviewQueue, rankJobsForReview } from "./discoveryAutomation";
-import { buildConversationBriefForJob, buildInitialOutreachQueueForJob } from "./conversations";
+import { buildConversationBriefForJob, buildInitialOutreachQueueForJob, normalizeCompanyKey } from "./conversations";
 import type { ConversationBrief, ConversationTarget, JobHunterPreferences, JobHunterStore, JobPosting, OutreachSequence } from "./types";
 
 export type ConversationAutomationSummary = {
@@ -56,7 +56,8 @@ export const generateConversationAssetsForJobs = (params: {
 
   for (const row of eligible) {
     const existingBrief = Object.values(params.store.conversationBriefsById).find((brief) => brief.jobId === row.job.id);
-    const companyTargets = Object.values(params.store.conversationTargetsById).filter((target) => target.company === row.job.company);
+    const jobCompanyKey = normalizeCompanyKey(row.job.company);
+    const companyTargets = Object.values(params.store.conversationTargetsById).filter((target) => normalizeCompanyKey(target.company) === jobCompanyKey);
     const existingOutreach = Object.values(params.store.outreachSequencesById).filter((sequence) => sequence.jobId === row.job.id);
 
     let brief = existingBrief;

--- a/ui/partner-hub/lib/job-hunter/conversations.test.ts
+++ b/ui/partner-hub/lib/job-hunter/conversations.test.ts
@@ -40,4 +40,16 @@ describe("conversations engine", () => {
     assert.equal(actions.staleSentNoReply.length, 1);
     assert.equal(actions.rolesNeedingTargets.length, 1);
   });
+
+  it("does not mark roles as needing targets when company differs only by case/whitespace", () => {
+    const now = new Date("2026-01-12T00:00:00.000Z");
+    const { targets } = buildConversationBriefForJob(job, undefined, undefined, now);
+    const actions = getTodaysConversationActions({
+      today: now,
+      sequences: [],
+      targets: [{ ...targets[0], company: " acme " }],
+      jobs: [job],
+    });
+    assert.equal(actions.rolesNeedingTargets.length, 0);
+  });
 });

--- a/ui/partner-hub/lib/job-hunter/conversations.ts
+++ b/ui/partner-hub/lib/job-hunter/conversations.ts
@@ -3,6 +3,7 @@ import type { ConversationBrief, ConversationTarget, JobPosting, OutreachChannel
 const BANLIST = ["i am extremely passionate", "synergize", "circle back", "rockstar", "guru"];
 const clean = (value: string) => value.replace(/\s+/g, " ").trim();
 const iso = (d: Date) => d.toISOString();
+export const normalizeCompanyKey = (company: string) => clean(company).toLowerCase();
 
 export const normalizeConversationTarget = (target: ConversationTarget): ConversationTarget => ({
   ...target,
@@ -70,7 +71,10 @@ export const buildOutreachDraft = (params: { job: JobPosting; brief: Conversatio
 
 export const buildInitialOutreachQueueForJob = (params: { job: JobPosting; brief: ConversationBrief; targets: ConversationTarget[]; existing: OutreachSequence[]; now: Date }): OutreachSequence[] => {
   const priority = { recruiter: 0, hiring_manager: 1, employee: 2, referral: 3, unknown: 4 };
-  const sorted = [...params.targets].filter((t) => t.company === params.job.company).sort((a, b) => priority[a.relationshipType] - priority[b.relationshipType]);
+  const jobCompanyKey = normalizeCompanyKey(params.job.company);
+  const sorted = [...params.targets]
+    .filter((t) => normalizeCompanyKey(t.company) === jobCompanyKey)
+    .sort((a, b) => priority[a.relationshipType] - priority[b.relationshipType]);
   const seen = new Set(params.existing.map((s) => `${s.jobId}:${s.contactId}:${s.stage}:${s.channel}`));
   const out: OutreachSequence[] = [];
   for (const target of sorted) {
@@ -97,7 +101,7 @@ export const getTodaysConversationActions = (params: { today: Date; sequences: O
   const followUpsDue = params.sequences.filter((s) => s.stage !== "intro" && (s.status === "draft" || s.status === "queued") && (s.dueAt?.slice(0, 10) ?? "") <= todayIso);
   const staleSentNoReply = params.sequences.filter((s) => s.status === "sent" && !s.repliedAt && (params.today.getTime() - new Date(s.sentAt ?? s.updatedAt).getTime()) / 86400000 > 5);
   const activeReplies = params.sequences.filter((s) => s.status === "replied");
-  const companiesWithTargets = new Set(params.targets.map((t) => t.company));
-  const rolesNeedingTargets = params.jobs.filter((j) => !companiesWithTargets.has(j.company));
+  const companiesWithTargets = new Set(params.targets.map((t) => normalizeCompanyKey(t.company)));
+  const rolesNeedingTargets = params.jobs.filter((j) => !companiesWithTargets.has(normalizeCompanyKey(j.company)));
   return { draftsToReview, followUpsDue, staleSentNoReply, activeReplies, rolesNeedingTargets };
 };


### PR DESCRIPTION
### Motivation
- Prevent creation of duplicate/placeholder targets and ensure outreach generation uses existing targets when company names differ only by casing or surrounding whitespace.
- Make company comparisons in the conversation engine robust (trim + case-insensitive) so roles-needing-targets and outreach behavior remain consistent across variations in company strings.

### Description
- Added `normalizeCompanyKey(company: string)` to the conversations module which trims and lowercases company strings for comparisons (`lib/job-hunter/conversations.ts`).
- Use `normalizeCompanyKey` when filtering targets for a job in `buildInitialOutreachQueueForJob` so outreach drafts match targets case-insensitively and ignoring whitespace (`lib/job-hunter/conversations.ts`).
- Use `normalizeCompanyKey` in conversation automation when checking existing company targets so placeholder targets are not created if a matching target exists with different casing/whitespace (`lib/job-hunter/conversationAutomation.ts`).
- Update roles-needing-targets calculation to use normalized keys and add/adjust tests that assert case-insensitive trimmed matching and that no placeholder targets/outreach duplicates are created (`lib/job-hunter/conversationAutomation.test.ts`, `lib/job-hunter/conversations.test.ts`).

### Testing
- Ran `npm test` in `ui/partner-hub`, which attempted to compile and run tests but failed in this environment due to missing project dependencies/type declarations (e.g. Node/Next/Zod typings); automated test run did not complete successfully.
- Ran `npm run typecheck` in `ui/partner-hub`, which failed for the same missing dependency/type declaration reasons; typecheck did not complete successfully.
- Added unit tests covering: matching `"Acme"` to existing target `" acme "`, ensuring no placeholder targets are created when a case-insensitive match exists, verifying outreach drafts use the existing target, and verifying roles-needing-targets behavior under case/whitespace differences (`lib/job-hunter/conversationAutomation.test.ts`, `lib/job-hunter/conversations.test.ts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25ddae8288330b88c3dcefe555680)