### PR TITLE
Build Phase 4 daily action command center for Job Hunter conversations

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx
@@ -6,6 +6,7 @@ import { getTodaysConversationActions } from "@/lib/job-hunter/conversations";
 import { buildConversationTarget, createTargetDraft, isTargetDraftValid, type TargetDraft } from "@/lib/job-hunter/conversationTargets";
 import { applySequenceMessageEdit, getDraftedOutreach, getFollowUpsDue, markSequenceSent, skipSequence, snoozeSequence } from "@/lib/job-hunter/conversationUi";
 import { generateConversationDraftsFromTopJobs, type ConversationAutomationSummary } from "@/lib/job-hunter/conversationAutomation";
+import { buildDailyConversationActions } from "@/lib/job-hunter/conversationActions";
 import { loadJobHunterStore, saveJobHunterStore } from "@/lib/job-hunter/storage";
 
 import { ActiveConversationsSection, DraftedOutreachSection, FollowUpsDueSection } from "./components/ConversationSections";
@@ -21,6 +22,7 @@ export default function ConversationsClient() {
   const actions = useMemo(() => getTodaysConversationActions({ today: now, sequences: store.outreachSequences ?? [], targets: store.conversationTargets ?? [], jobs: store.jobs ?? [] }), [now, store]);
   const drafted = useMemo(() => getDraftedOutreach(store.outreachSequences ?? []), [store.outreachSequences]);
   const followUpsDue = useMemo(() => getFollowUpsDue(store.outreachSequences ?? [], now), [now, store.outreachSequences]);
+  const dailyActions = useMemo(() => buildDailyConversationActions({ today: now, sequences: store.outreachSequences ?? [], targets: store.conversationTargets ?? [], jobs: store.jobs ?? [] }), [now, store]);
 
   const persist = (nextStore: ReturnType<typeof loadJobHunterStore>) => {
     setStore(nextStore);
@@ -33,6 +35,18 @@ export default function ConversationsClient() {
     persist(applySequenceMessageEdit(store, sequenceId, nextText, new Date()));
   };
 
+
+
+
+  const onActionSkip = (sequenceId?: string) => {
+    if (!sequenceId) return;
+    persist(skipSequence(store, sequenceId, new Date()));
+  };
+
+  const onActionMarkSent = (sequenceId?: string) => {
+    if (!sequenceId) return;
+    persist(markSequenceSent(store, sequenceId, new Date()));
+  };
 
   const onGenerateDrafts = () => {
     const result = generateConversationDraftsFromTopJobs({ store, now: new Date() });
@@ -52,6 +66,28 @@ export default function ConversationsClient() {
 
   return <main className="mx-auto max-w-5xl space-y-6 p-6">
     <header className="space-y-2"><h1 className="text-2xl font-semibold">Conversations</h1><p className="text-sm text-foreground/70">Review drafts, follow-ups, and active replies without auto-sending.</p></header>
+
+    <section className="space-y-3 rounded-lg border border-border/60 p-4 text-sm">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Today's Action Plan</h2>
+        <p className="text-xs text-foreground/70">Top {dailyActions.length} prioritized actions</p>
+      </div>
+      {dailyActions.length === 0 ? <p className="text-sm text-foreground/70">No immediate actions today.</p> : <div className="space-y-2">{dailyActions.map((action) => <article key={action.id} className="rounded border border-border/40 p-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="text-sm font-medium">P{action.priority} · {action.actionType.replaceAll("_", " ")}</p>
+          <div className="flex flex-wrap gap-2 text-xs">
+            {action.supportedActions.includes("edit") && action.sequenceId ? <button type="button" onClick={() => setDraftEdits((prev) => ({ ...prev, [action.sequenceId as string]: draftEdits[action.sequenceId as string] ?? (store.outreachSequencesById[action.sequenceId as string]?.editedMessage ?? store.outreachSequencesById[action.sequenceId as string]?.generatedMessage ?? "") }))} className="rounded border border-border px-2 py-1">edit</button> : null}
+            {action.supportedActions.includes("copy") ? <button type="button" onClick={() => void navigator.clipboard?.writeText(action.messagePreview ?? "")} className="rounded border border-border px-2 py-1">copy</button> : null}
+            {action.supportedActions.includes("mark_sent") ? <button type="button" onClick={() => onActionMarkSent(action.sequenceId)} className="rounded border border-border px-2 py-1">mark sent</button> : null}
+            {action.supportedActions.includes("skip") ? <button type="button" onClick={() => onActionSkip(action.sequenceId)} className="rounded border border-border px-2 py-1">skip</button> : null}
+          </div>
+        </div>
+        <p className="text-xs text-foreground/70">{[action.company, action.role, action.contact].filter(Boolean).join(" · ") || "General"}</p>
+        {action.messagePreview ? <p className="mt-1 line-clamp-2 text-xs">{action.messagePreview}</p> : null}
+        {action.guide === "roles_needing_targets" ? <a href="#roles-needing-targets" className="mt-1 inline-block text-xs underline">Go to Roles Needing Targets</a> : null}
+      </article>)}</div>}
+    </section>
+
     <section className="space-y-3 rounded-lg border border-border/60 p-4 text-sm"><div className="flex flex-wrap items-center justify-between gap-3"><p className="text-foreground/80">Generate conversation briefs and drafts from top-scoring roles.</p><button type="button" onClick={onGenerateDrafts} className="rounded border border-border px-3 py-1.5 font-medium hover:bg-accent">Generate conversation drafts</button></div>{generationSummary ? <p className="text-xs text-foreground/70">Processed {generationSummary.consideredJobs} jobs with {generationSummary.eligibleJobs} eligible top matches; generated {generationSummary.generatedBriefs} briefs, {generationSummary.generatedTargets} targets, and {generationSummary.generatedOutreachDrafts} outreach drafts; skipped {generationSummary.skippedDuplicates} duplicates.</p> : null}<div className="grid gap-3 md:grid-cols-5">{[["Drafts to review", actions.draftsToReview.length], ["Follow-ups due", actions.followUpsDue.length], ["Stale sent no reply", actions.staleSentNoReply.length], ["Active replies", actions.activeReplies.length], ["Roles needing targets", actions.rolesNeedingTargets.length]].map(([label, count]) => <article key={String(label)} className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">{label}</p><p className="text-2xl font-semibold">{count}</p></article>)}</div></section>
 
     <DraftedOutreachSection drafted={drafted} jobsById={store.jobsById} targetsById={store.conversationTargetsById} draftEdits={draftEdits} setDraftEdit={(id, value) => setDraftEdits((prev) => ({ ...prev, [id]: value }))} onEditSave={onEditSave} onCopy={(value) => void navigator.clipboard?.writeText(value)} onMarkSent={(id) => persist(markSequenceSent(store, id, new Date()))} onSkip={(id) => persist(skipSequence(store, id, new Date()))} />
@@ -60,6 +96,6 @@ export default function ConversationsClient() {
 
     <ActiveConversationsSection activeReplies={actions.activeReplies} jobsById={store.jobsById} targetsById={store.conversationTargetsById} />
 
-    <section className="space-y-3"><h2 className="text-xl font-semibold">Roles Needing Targets</h2>{actions.rolesNeedingTargets.length === 0 ? <p className="text-sm text-foreground/70">Every company currently has at least one target.</p> : actions.rolesNeedingTargets.map((job) => { const draft = targetDrafts[job.id] ?? createTargetDraft(); return <TargetDraftCard key={job.id} job={job} draft={draft} onChange={(nextDraft) => setTargetDrafts((prev) => ({ ...prev, [job.id]: nextDraft }))} onAdd={() => onAddTarget(job.id)} />; })}</section>
+    <section id="roles-needing-targets" className="space-y-3"><h2 className="text-xl font-semibold">Roles Needing Targets</h2>{actions.rolesNeedingTargets.length === 0 ? <p className="text-sm text-foreground/70">Every company currently has at least one target.</p> : actions.rolesNeedingTargets.map((job) => { const draft = targetDrafts[job.id] ?? createTargetDraft(); return <TargetDraftCard key={job.id} job={job} draft={draft} onChange={(nextDraft) => setTargetDrafts((prev) => ({ ...prev, [job.id]: nextDraft }))} onAdd={() => onAddTarget(job.id)} />; })}</section>
   </main>;
 }

--- a/ui/partner-hub/lib/job-hunter/conversationActions.test.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationActions.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildDailyConversationActions } from "./conversationActions";
+import type { ConversationTarget, JobPosting, OutreachSequence } from "./types";
+
+const today = new Date("2026-04-29T12:00:00.000Z");
+
+const job: JobPosting = { id: "job-1", title: "Staff Engineer", company: "Acme", source: "manual", createdAt: today.toISOString(), updatedAt: today.toISOString() };
+const target: ConversationTarget = { id: "target-1", company: "Acme", name: "Taylor", relationshipType: "recruiter", source: "manual", confidence: 80, createdAt: today.toISOString(), updatedAt: today.toISOString() };
+const seq = (overrides: Partial<OutreachSequence>): OutreachSequence => ({ id: "job-1:target-1:intro:linkedin", jobId: job.id, contactId: target.id, stage: "intro", channel: "linkedin", generatedMessage: "hello", status: "draft", createdAt: today.toISOString(), updatedAt: today.toISOString(), ...overrides });
+
+test("prioritizes action types in required order", () => {
+  const actions = buildDailyConversationActions({
+    today,
+    jobs: [job, { ...job, id: "job-2", company: "Beta", title: "Manager" }],
+    targets: [target],
+    sequences: [
+      seq({ id: "follow", stage: "follow_up_1", dueAt: "2026-04-29T00:00:00.000Z" }),
+      seq({ id: "reply", status: "replied" }),
+      seq({ id: "draft", stage: "intro", status: "draft" }),
+      seq({ id: "stale", status: "sent", sentAt: "2026-04-20T00:00:00.000Z" }),
+    ],
+  });
+
+  assert.deepEqual(actions.map((a) => a.actionType), ["send_follow_up", "review_reply", "send_draft", "add_target", "review_stale_sent"]);
+});
+
+test("limits to top 10 actions by default", () => {
+  const sequences = Array.from({ length: 20 }, (_, index) => seq({ id: `f-${index}`, stage: "follow_up_1", dueAt: "2026-04-29T00:00:00.000Z" }));
+  const actions = buildDailyConversationActions({ today, jobs: [job], targets: [target], sequences });
+  assert.equal(actions.length, 10);
+  assert.ok(actions.every((a) => a.actionType === "send_follow_up"));
+});
+
+test("includes context and guidance fields", () => {
+  const actions = buildDailyConversationActions({ today, jobs: [job, { ...job, id: "job-2", company: "NoTarget", title: "Dev" }], targets: [target], sequences: [seq({ id: "draft", generatedMessage: "message preview" })] });
+  const draftAction = actions.find((action) => action.actionType === "send_draft");
+  const addTargetAction = actions.find((action) => action.actionType === "add_target");
+  assert.equal(draftAction?.company, "Acme");
+  assert.equal(draftAction?.role, "Staff Engineer");
+  assert.equal(draftAction?.contact, "Taylor");
+  assert.equal(draftAction?.messagePreview, "message preview");
+  assert.deepEqual(draftAction?.supportedActions, ["edit", "copy", "mark_sent", "skip"]);
+  assert.equal(addTargetAction?.guide, "roles_needing_targets");
+});

--- a/ui/partner-hub/lib/job-hunter/conversationActions.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationActions.ts
@@ -1,0 +1,79 @@
+import { normalizeCompanyKey } from "./conversations";
+import { getOutreachPreview } from "./conversationUi";
+import type { ConversationTarget, JobPosting, OutreachSequence } from "./types";
+
+export type ConversationActionType = "send_follow_up" | "review_reply" | "send_draft" | "add_target" | "review_stale_sent";
+export type SequenceAction = "edit" | "copy" | "mark_sent" | "skip";
+export type ConversationAction = {
+  id: string;
+  actionType: ConversationActionType;
+  priority: number;
+  company?: string;
+  role?: string;
+  contact?: string;
+  messagePreview?: string;
+  sequenceId?: string;
+  supportedActions: SequenceAction[];
+  guide?: "roles_needing_targets";
+};
+
+const PRIORITY_ORDER: ConversationActionType[] = ["send_follow_up", "review_reply", "send_draft", "add_target", "review_stale_sent"];
+const PRIORITY_RANK = new Map(PRIORITY_ORDER.map((type, index) => [type, index + 1]));
+
+const getSequenceContext = (sequence: OutreachSequence, jobsById: Record<string, JobPosting>, targetsById: Record<string, ConversationTarget>) => ({
+  company: jobsById[sequence.jobId]?.company ?? targetsById[sequence.contactId]?.company,
+  role: jobsById[sequence.jobId]?.title,
+  contact: targetsById[sequence.contactId]?.name,
+});
+
+export const buildDailyConversationActions = (params: {
+  today: Date;
+  limit?: number;
+  sequences: OutreachSequence[];
+  targets: ConversationTarget[];
+  jobs: JobPosting[];
+}): ConversationAction[] => {
+  const { sequences, targets, jobs, today } = params;
+  const limit = params.limit ?? 10;
+  const todayIso = today.toISOString().slice(0, 10);
+  const jobsById = Object.fromEntries(jobs.map((job) => [job.id, job]));
+  const targetsById = Object.fromEntries(targets.map((target) => [target.id, target]));
+
+  const companiesWithTargets = new Set(targets.map((target) => normalizeCompanyKey(target.company)));
+
+  const actions: ConversationAction[] = [];
+
+  for (const sequence of sequences) {
+    const context = getSequenceContext(sequence, jobsById, targetsById);
+    if ((sequence.stage === "follow_up_1" || sequence.stage === "follow_up_2") && (sequence.status === "draft" || sequence.status === "queued") && (sequence.dueAt?.slice(0, 10) ?? "") <= todayIso) {
+      actions.push({ id: `send_follow_up:${sequence.id}`, actionType: "send_follow_up", priority: 1, ...context, messagePreview: getOutreachPreview(sequence), sequenceId: sequence.id, supportedActions: ["edit", "copy", "mark_sent", "skip"] });
+      continue;
+    }
+    if (sequence.status === "replied") {
+      actions.push({ id: `review_reply:${sequence.id}`, actionType: "review_reply", priority: 2, ...context, messagePreview: getOutreachPreview(sequence), sequenceId: sequence.id, supportedActions: ["copy", "skip"] });
+      continue;
+    }
+    if ((sequence.status === "draft" || sequence.status === "queued") && sequence.stage === "intro") {
+      actions.push({ id: `send_draft:${sequence.id}`, actionType: "send_draft", priority: 3, ...context, messagePreview: getOutreachPreview(sequence), sequenceId: sequence.id, supportedActions: ["edit", "copy", "mark_sent", "skip"] });
+      continue;
+    }
+    if (sequence.status === "sent" && !sequence.repliedAt && (today.getTime() - new Date(sequence.sentAt ?? sequence.updatedAt).getTime()) / 86400000 > 5) {
+      actions.push({ id: `review_stale_sent:${sequence.id}`, actionType: "review_stale_sent", priority: 5, ...context, messagePreview: getOutreachPreview(sequence), sequenceId: sequence.id, supportedActions: ["copy", "skip"] });
+    }
+  }
+
+  for (const job of jobs) {
+    if (!companiesWithTargets.has(normalizeCompanyKey(job.company))) {
+      actions.push({ id: `add_target:${job.id}`, actionType: "add_target", priority: 4, company: job.company, role: job.title, supportedActions: ["skip"], guide: "roles_needing_targets" });
+    }
+  }
+
+  return actions
+    .sort((a, b) => {
+      const rankA = PRIORITY_RANK.get(a.actionType) ?? 999;
+      const rankB = PRIORITY_RANK.get(b.actionType) ?? 999;
+      if (rankA !== rankB) return rankA - rankB;
+      return a.id.localeCompare(b.id);
+    })
+    .slice(0, limit);
+};


### PR DESCRIPTION
### Motivation
- Provide a clear, prioritized daily command center on the Conversations page so users know exactly what to do next when managing outreach.
- Surface the highest-impact conversation items (follow-ups, replies, drafts, missing targets, stale sent messages) with concise context and controls while preserving manual send behavior.

### Description
- Added a new action engine `lib/job-hunter/conversationActions.ts` that builds prioritized daily actions with the order `send_follow_up`, `review_reply`, `send_draft`, `add_target`, `review_stale_sent`, returns the top 10 actions by default, includes priority, action type, company/role/contact context, message preview when available, and exposes supported sequence actions (`edit`, `copy`, `mark_sent`, `skip`).
- Added unit tests for the action engine in `lib/job-hunter/conversationActions.test.ts` covering ordering, default top-10 limit, and context/guide fields.
- Updated the Conversations UI client `app/(routes)/job-hunter/conversations/ConversationsClient.tsx` to render a new "Today’s Action Plan" section above the generate/summary panel, wire action controls (edit, copy, mark sent, skip), and link add-target guidance to the existing Roles Needing Targets section.
- Files changed: `ui/partner-hub/lib/job-hunter/conversationActions.ts`, `ui/partner-hub/lib/job-hunter/conversationActions.test.ts`, and `ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx`.

### Testing
- Ran `npm test` from `ui/partner-hub`; the command executed but overall test run failed due to environment/dependency gaps unrelated to this change (missing runtime/type modules such as `node:test`, `node:assert/strict`, `react`, `next/*`, `zod`, `jszip`), so tests could not be exercised end-to-end.
- Ran `npm run typecheck` from `ui/partner-hub`; typecheck failed for the same pre-existing missing module/type declarations across the repo, not caused by the new action engine.
- The new unit tests were added and validate expected behavior in isolation, but a green CI/test run could not be produced in the provided environment due to the dependency/type issues noted above.
- No external APIs, scraping, LinkedIn automation, or auto-send behavior were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25f8027a483308afe15dbb54a806c)