### PR TITLE
Clean up Phase 4 Daily Action Plan model and component boundaries

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx
@@ -11,6 +11,7 @@ import { loadJobHunterStore, saveJobHunterStore } from "@/lib/job-hunter/storage
 
 import { ActiveConversationsSection, DraftedOutreachSection, FollowUpsDueSection } from "./components/ConversationSections";
 import { TargetDraftCard } from "./components/TargetDraftCard";
+import { DailyActionPlan } from "./components/DailyActionPlan";
 
 export default function ConversationsClient() {
   const [store, setStore] = useState(() => loadJobHunterStore());
@@ -67,26 +68,7 @@ export default function ConversationsClient() {
   return <main className="mx-auto max-w-5xl space-y-6 p-6">
     <header className="space-y-2"><h1 className="text-2xl font-semibold">Conversations</h1><p className="text-sm text-foreground/70">Review drafts, follow-ups, and active replies without auto-sending.</p></header>
 
-    <section className="space-y-3 rounded-lg border border-border/60 p-4 text-sm">
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold">Today's Action Plan</h2>
-        <p className="text-xs text-foreground/70">Top {dailyActions.length} prioritized actions</p>
-      </div>
-      {dailyActions.length === 0 ? <p className="text-sm text-foreground/70">No immediate actions today.</p> : <div className="space-y-2">{dailyActions.map((action) => <article key={action.id} className="rounded border border-border/40 p-3">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <p className="text-sm font-medium">P{action.priority} · {action.actionType.replaceAll("_", " ")}</p>
-          <div className="flex flex-wrap gap-2 text-xs">
-            {action.supportedActions.includes("edit") && action.sequenceId ? <button type="button" onClick={() => setDraftEdits((prev) => ({ ...prev, [action.sequenceId as string]: draftEdits[action.sequenceId as string] ?? (store.outreachSequencesById[action.sequenceId as string]?.editedMessage ?? store.outreachSequencesById[action.sequenceId as string]?.generatedMessage ?? "") }))} className="rounded border border-border px-2 py-1">edit</button> : null}
-            {action.supportedActions.includes("copy") ? <button type="button" onClick={() => void navigator.clipboard?.writeText(action.messagePreview ?? "")} className="rounded border border-border px-2 py-1">copy</button> : null}
-            {action.supportedActions.includes("mark_sent") ? <button type="button" onClick={() => onActionMarkSent(action.sequenceId)} className="rounded border border-border px-2 py-1">mark sent</button> : null}
-            {action.supportedActions.includes("skip") ? <button type="button" onClick={() => onActionSkip(action.sequenceId)} className="rounded border border-border px-2 py-1">skip</button> : null}
-          </div>
-        </div>
-        <p className="text-xs text-foreground/70">{[action.company, action.role, action.contact].filter(Boolean).join(" · ") || "General"}</p>
-        {action.messagePreview ? <p className="mt-1 line-clamp-2 text-xs">{action.messagePreview}</p> : null}
-        {action.guide === "roles_needing_targets" ? <a href="#roles-needing-targets" className="mt-1 inline-block text-xs underline">Go to Roles Needing Targets</a> : null}
-      </article>)}</div>}
-    </section>
+    <DailyActionPlan dailyActions={dailyActions} draftEdits={draftEdits} setDraftEdits={setDraftEdits} store={store} onActionMarkSent={onActionMarkSent} onActionSkip={onActionSkip} />
 
     <section className="space-y-3 rounded-lg border border-border/60 p-4 text-sm"><div className="flex flex-wrap items-center justify-between gap-3"><p className="text-foreground/80">Generate conversation briefs and drafts from top-scoring roles.</p><button type="button" onClick={onGenerateDrafts} className="rounded border border-border px-3 py-1.5 font-medium hover:bg-accent">Generate conversation drafts</button></div>{generationSummary ? <p className="text-xs text-foreground/70">Processed {generationSummary.consideredJobs} jobs with {generationSummary.eligibleJobs} eligible top matches; generated {generationSummary.generatedBriefs} briefs, {generationSummary.generatedTargets} targets, and {generationSummary.generatedOutreachDrafts} outreach drafts; skipped {generationSummary.skippedDuplicates} duplicates.</p> : null}<div className="grid gap-3 md:grid-cols-5">{[["Drafts to review", actions.draftsToReview.length], ["Follow-ups due", actions.followUpsDue.length], ["Stale sent no reply", actions.staleSentNoReply.length], ["Active replies", actions.activeReplies.length], ["Roles needing targets", actions.rolesNeedingTargets.length]].map(([label, count]) => <article key={String(label)} className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">{label}</p><p className="text-2xl font-semibold">{count}</p></article>)}</div></section>
 

--- a/ui/partner-hub/app/(routes)/job-hunter/conversations/components/DailyActionPlan.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/conversations/components/DailyActionPlan.tsx
@@ -1,0 +1,36 @@
+import type { Dispatch, SetStateAction } from "react";
+import type { JobHunterStore } from "@/lib/job-hunter/types";
+import type { buildDailyConversationActions } from "@/lib/job-hunter/conversationActions";
+
+type DailyAction = ReturnType<typeof buildDailyConversationActions>[number];
+
+export function DailyActionPlan({ dailyActions, draftEdits, setDraftEdits, store, onActionMarkSent, onActionSkip }: {
+  dailyActions: DailyAction[];
+  draftEdits: Record<string, string>;
+  setDraftEdits: Dispatch<SetStateAction<Record<string, string>>>;
+  store: JobHunterStore;
+  onActionMarkSent: (sequenceId?: string) => void;
+  onActionSkip: (sequenceId?: string) => void;
+}) {
+  return <section className="space-y-3 rounded-lg border border-border/60 p-4 text-sm">
+    <div className="flex items-center justify-between">
+      <h2 className="text-lg font-semibold">Today's Action Plan</h2>
+      <p className="text-xs text-foreground/70">Top {dailyActions.length} prioritized actions</p>
+    </div>
+    {dailyActions.length === 0 ? <p className="text-sm text-foreground/70">No immediate actions today.</p> : <div className="space-y-2">{dailyActions.map((action) => <article key={action.id} className="rounded border border-border/40 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-sm font-medium">{action.priority} · {action.label}</p>
+        <div className="flex flex-wrap gap-2 text-xs">
+          {action.supportedActions.includes("edit") && action.sequenceId ? <button type="button" onClick={() => setDraftEdits((prev) => ({ ...prev, [action.sequenceId as string]: draftEdits[action.sequenceId as string] ?? (store.outreachSequencesById[action.sequenceId as string]?.editedMessage ?? store.outreachSequencesById[action.sequenceId as string]?.generatedMessage ?? "") }))} className="rounded border border-border px-2 py-1">edit</button> : null}
+          {action.supportedActions.includes("copy") ? <button type="button" onClick={() => void navigator.clipboard?.writeText(action.messagePreview ?? "")} className="rounded border border-border px-2 py-1">copy</button> : null}
+          {action.supportedActions.includes("mark_sent") ? <button type="button" onClick={() => onActionMarkSent(action.sequenceId)} className="rounded border border-border px-2 py-1">mark sent</button> : null}
+          {action.supportedActions.includes("skip") ? <button type="button" onClick={() => onActionSkip(action.sequenceId)} className="rounded border border-border px-2 py-1">skip</button> : null}
+        </div>
+      </div>
+      <p className="text-xs text-foreground/70">{[action.company, action.roleTitle, action.contactName].filter(Boolean).join(" · ") || "General"}</p>
+      <p className="mt-1 text-xs text-foreground/70">{action.description}{action.dueAt ? ` Due ${new Date(action.dueAt).toISOString().slice(0, 10)}.` : ""}</p>
+      {action.messagePreview ? <p className="mt-1 line-clamp-2 text-xs">{action.messagePreview}</p> : null}
+      {action.guide === "roles_needing_targets" ? <a href="#roles-needing-targets" className="mt-1 inline-block text-xs underline">Go to Roles Needing Targets</a> : null}
+    </article>)}</div>}
+  </section>;
+}

--- a/ui/partner-hub/lib/job-hunter/conversationActions.test.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationActions.test.ts
@@ -23,23 +23,24 @@ test("prioritizes action types in required order", () => {
     ],
   });
 
-  assert.deepEqual(actions.map((a) => a.actionType), ["send_follow_up", "review_reply", "send_draft", "add_target", "review_stale_sent"]);
+  assert.deepEqual(actions.map((a) => a.type), ["send_follow_up", "review_reply", "send_draft", "add_target", "review_stale_sent"]);
+  assert.equal(actions[0]?.priority, "high");
 });
 
 test("limits to top 10 actions by default", () => {
   const sequences = Array.from({ length: 20 }, (_, index) => seq({ id: `f-${index}`, stage: "follow_up_1", dueAt: "2026-04-29T00:00:00.000Z" }));
   const actions = buildDailyConversationActions({ today, jobs: [job], targets: [target], sequences });
   assert.equal(actions.length, 10);
-  assert.ok(actions.every((a) => a.actionType === "send_follow_up"));
+  assert.ok(actions.every((a) => a.type === "send_follow_up"));
 });
 
 test("includes context and guidance fields", () => {
   const actions = buildDailyConversationActions({ today, jobs: [job, { ...job, id: "job-2", company: "NoTarget", title: "Dev" }], targets: [target], sequences: [seq({ id: "draft", generatedMessage: "message preview" })] });
-  const draftAction = actions.find((action) => action.actionType === "send_draft");
-  const addTargetAction = actions.find((action) => action.actionType === "add_target");
+  const draftAction = actions.find((action) => action.type === "send_draft");
+  const addTargetAction = actions.find((action) => action.type === "add_target");
   assert.equal(draftAction?.company, "Acme");
-  assert.equal(draftAction?.role, "Staff Engineer");
-  assert.equal(draftAction?.contact, "Taylor");
+  assert.equal(draftAction?.roleTitle, "Staff Engineer");
+  assert.equal(draftAction?.contactName, "Taylor");
   assert.equal(draftAction?.messagePreview, "message preview");
   assert.deepEqual(draftAction?.supportedActions, ["edit", "copy", "mark_sent", "skip"]);
   assert.equal(addTargetAction?.guide, "roles_needing_targets");

--- a/ui/partner-hub/lib/job-hunter/conversationActions.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationActions.ts
@@ -1,29 +1,23 @@
-import { normalizeCompanyKey } from "./conversations";
+import { getTodaysConversationActions } from "./conversations";
 import { getOutreachPreview } from "./conversationUi";
-import type { ConversationTarget, JobPosting, OutreachSequence } from "./types";
+import type { ConversationDailyAction, ConversationTarget, JobPosting, OutreachSequence } from "./types";
 
-export type ConversationActionType = "send_follow_up" | "review_reply" | "send_draft" | "add_target" | "review_stale_sent";
 export type SequenceAction = "edit" | "copy" | "mark_sent" | "skip";
-export type ConversationAction = {
-  id: string;
-  actionType: ConversationActionType;
-  priority: number;
-  company?: string;
-  role?: string;
-  contact?: string;
+
+type BuilderAction = ConversationDailyAction & {
+  supportedActions: SequenceAction[];
   messagePreview?: string;
   sequenceId?: string;
-  supportedActions: SequenceAction[];
   guide?: "roles_needing_targets";
 };
 
-const PRIORITY_ORDER: ConversationActionType[] = ["send_follow_up", "review_reply", "send_draft", "add_target", "review_stale_sent"];
+const PRIORITY_ORDER: ConversationDailyAction["type"][] = ["send_follow_up", "review_reply", "send_draft", "add_target", "review_stale_sent"];
 const PRIORITY_RANK = new Map(PRIORITY_ORDER.map((type, index) => [type, index + 1]));
 
 const getSequenceContext = (sequence: OutreachSequence, jobsById: Record<string, JobPosting>, targetsById: Record<string, ConversationTarget>) => ({
   company: jobsById[sequence.jobId]?.company ?? targetsById[sequence.contactId]?.company,
-  role: jobsById[sequence.jobId]?.title,
-  contact: targetsById[sequence.contactId]?.name,
+  roleTitle: jobsById[sequence.jobId]?.title,
+  contactName: targetsById[sequence.contactId]?.name,
 });
 
 export const buildDailyConversationActions = (params: {
@@ -32,48 +26,43 @@ export const buildDailyConversationActions = (params: {
   sequences: OutreachSequence[];
   targets: ConversationTarget[];
   jobs: JobPosting[];
-}): ConversationAction[] => {
+}): BuilderAction[] => {
   const { sequences, targets, jobs, today } = params;
   const limit = params.limit ?? 10;
-  const todayIso = today.toISOString().slice(0, 10);
   const jobsById = Object.fromEntries(jobs.map((job) => [job.id, job]));
   const targetsById = Object.fromEntries(targets.map((target) => [target.id, target]));
+  const todays = getTodaysConversationActions({ today, sequences, targets, jobs });
 
-  const companiesWithTargets = new Set(targets.map((target) => normalizeCompanyKey(target.company)));
+  const actions: BuilderAction[] = [];
 
-  const actions: ConversationAction[] = [];
-
-  for (const sequence of sequences) {
+  for (const sequence of todays.followUpsDue) {
     const context = getSequenceContext(sequence, jobsById, targetsById);
-    if ((sequence.stage === "follow_up_1" || sequence.stage === "follow_up_2") && (sequence.status === "draft" || sequence.status === "queued") && (sequence.dueAt?.slice(0, 10) ?? "") <= todayIso) {
-      actions.push({ id: `send_follow_up:${sequence.id}`, actionType: "send_follow_up", priority: 1, ...context, messagePreview: getOutreachPreview(sequence), sequenceId: sequence.id, supportedActions: ["edit", "copy", "mark_sent", "skip"] });
-      continue;
-    }
-    if (sequence.status === "replied") {
-      actions.push({ id: `review_reply:${sequence.id}`, actionType: "review_reply", priority: 2, ...context, messagePreview: getOutreachPreview(sequence), sequenceId: sequence.id, supportedActions: ["copy", "skip"] });
-      continue;
-    }
-    if ((sequence.status === "draft" || sequence.status === "queued") && sequence.stage === "intro") {
-      actions.push({ id: `send_draft:${sequence.id}`, actionType: "send_draft", priority: 3, ...context, messagePreview: getOutreachPreview(sequence), sequenceId: sequence.id, supportedActions: ["edit", "copy", "mark_sent", "skip"] });
-      continue;
-    }
-    if (sequence.status === "sent" && !sequence.repliedAt && (today.getTime() - new Date(sequence.sentAt ?? sequence.updatedAt).getTime()) / 86400000 > 5) {
-      actions.push({ id: `review_stale_sent:${sequence.id}`, actionType: "review_stale_sent", priority: 5, ...context, messagePreview: getOutreachPreview(sequence), sequenceId: sequence.id, supportedActions: ["copy", "skip"] });
-    }
+    actions.push({ id: `send_follow_up:${sequence.id}`, type: "send_follow_up", priority: "high", label: "Send follow-up", description: "Due follow-up ready to send.", dueAt: sequence.dueAt, ...context, messagePreview: getOutreachPreview(sequence), sequenceId: sequence.id, supportedActions: ["edit", "copy", "mark_sent", "skip"] });
   }
 
-  for (const job of jobs) {
-    if (!companiesWithTargets.has(normalizeCompanyKey(job.company))) {
-      actions.push({ id: `add_target:${job.id}`, actionType: "add_target", priority: 4, company: job.company, role: job.title, supportedActions: ["skip"], guide: "roles_needing_targets" });
-    }
+  for (const sequence of todays.activeReplies) {
+    const context = getSequenceContext(sequence, jobsById, targetsById);
+    actions.push({ id: `review_reply:${sequence.id}`, type: "review_reply", priority: "high", label: "Review reply", description: "A contact replied and needs review.", ...context, messagePreview: getOutreachPreview(sequence), sequenceId: sequence.id, supportedActions: ["copy", "skip"] });
   }
 
-  return actions
-    .sort((a, b) => {
-      const rankA = PRIORITY_RANK.get(a.actionType) ?? 999;
-      const rankB = PRIORITY_RANK.get(b.actionType) ?? 999;
-      if (rankA !== rankB) return rankA - rankB;
-      return a.id.localeCompare(b.id);
-    })
-    .slice(0, limit);
+  for (const sequence of todays.draftsToReview.filter((s) => s.stage === "intro")) {
+    const context = getSequenceContext(sequence, jobsById, targetsById);
+    actions.push({ id: `send_draft:${sequence.id}`, type: "send_draft", priority: "medium", label: "Send intro draft", description: "Intro outreach draft ready for polish and send.", dueAt: sequence.dueAt, ...context, messagePreview: getOutreachPreview(sequence), sequenceId: sequence.id, supportedActions: ["edit", "copy", "mark_sent", "skip"] });
+  }
+
+  for (const sequence of todays.staleSentNoReply) {
+    const context = getSequenceContext(sequence, jobsById, targetsById);
+    actions.push({ id: `review_stale_sent:${sequence.id}`, type: "review_stale_sent", priority: "low", label: "Review stale sent", description: "Sent outreach has gone stale without a reply.", ...context, messagePreview: getOutreachPreview(sequence), sequenceId: sequence.id, supportedActions: ["copy", "skip"] });
+  }
+
+  for (const job of todays.rolesNeedingTargets) {
+    actions.push({ id: `add_target:${job.id}`, type: "add_target", priority: "medium", label: "Add target", description: "Role needs at least one contact target.", company: job.company, roleTitle: job.title, supportedActions: ["skip"], guide: "roles_needing_targets" });
+  }
+
+  return actions.sort((a, b) => {
+    const rankA = PRIORITY_RANK.get(a.type) ?? 999;
+    const rankB = PRIORITY_RANK.get(b.type) ?? 999;
+    if (rankA !== rankB) return rankA - rankB;
+    return a.id.localeCompare(b.id);
+  }).slice(0, limit);
 };

--- a/ui/partner-hub/lib/job-hunter/types.ts
+++ b/ui/partner-hub/lib/job-hunter/types.ts
@@ -210,6 +210,22 @@ export type OutreachSequence = {
   updatedAt: string;
 };
 
+
+export type ConversationDailyActionType = "send_follow_up" | "review_reply" | "send_draft" | "add_target" | "review_stale_sent";
+export type ConversationDailyActionPriority = "high" | "medium" | "low";
+
+export type ConversationDailyAction = {
+  id: string;
+  type: ConversationDailyActionType;
+  priority: ConversationDailyActionPriority;
+  label: string;
+  description: string;
+  company?: string;
+  roleTitle?: string;
+  contactName?: string;
+  dueAt?: string;
+};
+
 export type JobHunterConversationType = "initial_outreach" | "follow_up" | "post_interview_thanks";
 export type JobHunterConversationMessageRole = "user" | "assistant" | "contact";
 export type JobHunterConversationMessage = { id: string; role: JobHunterConversationMessageRole; body: string; createdAt: string };


### PR DESCRIPTION
### Motivation
- Align the daily action plan data shape to a canonical `ConversationDailyAction` model to make UI & orchestration consistent.
- Move the Today’s Action Plan rendering out of the large client component so `ConversationsClient` remains orchestration-only.
- Surface richer action metadata (`label`, `description`, `roleTitle`, `contactName`, `dueAt`) and use human-friendly `priority` strings to simplify rendering and sorting.

### Description
- Introduced `ConversationDailyAction` types in `lib/job-hunter/types.ts` and switched to `type` (replacing `actionType`) with `priority` values of `high|medium|low` and added `label`, `description`, `roleTitle`, `contactName`, and `dueAt`.
- Refactored `lib/job-hunter/conversationActions.ts` so `buildDailyConversationActions` consumes `getTodaysConversationActions(...)` and produces the new `ConversationDailyAction`-shaped objects (preserving previous sort/prioritization semantics).
- Added a new UI component `app/(routes)/job-hunter/conversations/components/DailyActionPlan.tsx` and wired `ConversationsClient.tsx` to render it so the client file only handles store wiring and actions.
- Updated unit test expectations in `lib/job-hunter/conversationActions.test.ts` to assert the renamed fields and the new priority string values.

### Testing
- Ran `cd ui/partner-hub && npm test` and the run failed during TypeScript compile due to existing repository-wide dependency/type issues (missing `node:*` typings and missing framework typings such as `react`, `next`, `zod`, `jszip`), so test execution did not complete. 
- Ran `cd ui/partner-hub && npm run typecheck` and the command failed with many pre-existing type errors across routes and components unrelated to this change (missing external typings and unrelated route/component type issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f261c3f79083309a9f6b902cb89ccf)