### PR TITLE
Refactor daily conversation action builder to reuse derived action buckets

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx
@@ -23,7 +23,7 @@ export default function ConversationsClient() {
   const actions = useMemo(() => getTodaysConversationActions({ today: now, sequences: store.outreachSequences ?? [], targets: store.conversationTargets ?? [], jobs: store.jobs ?? [] }), [now, store]);
   const drafted = useMemo(() => getDraftedOutreach(store.outreachSequences ?? []), [store.outreachSequences]);
   const followUpsDue = useMemo(() => getFollowUpsDue(store.outreachSequences ?? [], now), [now, store.outreachSequences]);
-  const dailyActions = useMemo(() => buildDailyConversationActions({ today: now, sequences: store.outreachSequences ?? [], targets: store.conversationTargets ?? [], jobs: store.jobs ?? [] }), [now, store]);
+  const dailyActions = useMemo(() => buildDailyConversationActions({ jobsById: store.jobsById, targetsById: store.conversationTargetsById, actions, maxActions: 10 }), [actions, store.conversationTargetsById, store.jobsById]);
 
   const persist = (nextStore: ReturnType<typeof loadJobHunterStore>) => {
     setStore(nextStore);

--- a/ui/partner-hub/lib/job-hunter/conversationActions.test.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationActions.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { buildDailyConversationActions } from "./conversationActions";
+import { getTodaysConversationActions } from "./conversations";
 import type { ConversationTarget, JobPosting, OutreachSequence } from "./types";
 
 const today = new Date("2026-04-29T12:00:00.000Z");
@@ -11,16 +12,18 @@ const target: ConversationTarget = { id: "target-1", company: "Acme", name: "Tay
 const seq = (overrides: Partial<OutreachSequence>): OutreachSequence => ({ id: "job-1:target-1:intro:linkedin", jobId: job.id, contactId: target.id, stage: "intro", channel: "linkedin", generatedMessage: "hello", status: "draft", createdAt: today.toISOString(), updatedAt: today.toISOString(), ...overrides });
 
 test("prioritizes action types in required order", () => {
-  const actions = buildDailyConversationActions({
-    today,
-    jobs: [job, { ...job, id: "job-2", company: "Beta", title: "Manager" }],
-    targets: [target],
-    sequences: [
+  const jobs = [job, { ...job, id: "job-2", company: "Beta", title: "Manager" }];
+  const targets = [target];
+  const sequences = [
       seq({ id: "follow", stage: "follow_up_1", dueAt: "2026-04-29T00:00:00.000Z" }),
       seq({ id: "reply", status: "replied" }),
       seq({ id: "draft", stage: "intro", status: "draft" }),
       seq({ id: "stale", status: "sent", sentAt: "2026-04-20T00:00:00.000Z" }),
-    ],
+    ];
+  const actions = buildDailyConversationActions({
+    jobsById: Object.fromEntries(jobs.map((j) => [j.id, j])),
+    targetsById: Object.fromEntries(targets.map((t) => [t.id, t])),
+    actions: getTodaysConversationActions({ today, jobs, targets, sequences }),
   });
 
   assert.deepEqual(actions.map((a) => a.type), ["send_follow_up", "review_reply", "send_draft", "add_target", "review_stale_sent"]);
@@ -29,13 +32,26 @@ test("prioritizes action types in required order", () => {
 
 test("limits to top 10 actions by default", () => {
   const sequences = Array.from({ length: 20 }, (_, index) => seq({ id: `f-${index}`, stage: "follow_up_1", dueAt: "2026-04-29T00:00:00.000Z" }));
-  const actions = buildDailyConversationActions({ today, jobs: [job], targets: [target], sequences });
+  const jobs = [job];
+  const targets = [target];
+  const actions = buildDailyConversationActions({
+    jobsById: Object.fromEntries(jobs.map((j) => [j.id, j])),
+    targetsById: Object.fromEntries(targets.map((t) => [t.id, t])),
+    actions: getTodaysConversationActions({ today, jobs, targets, sequences }),
+  });
   assert.equal(actions.length, 10);
   assert.ok(actions.every((a) => a.type === "send_follow_up"));
 });
 
 test("includes context and guidance fields", () => {
-  const actions = buildDailyConversationActions({ today, jobs: [job, { ...job, id: "job-2", company: "NoTarget", title: "Dev" }], targets: [target], sequences: [seq({ id: "draft", generatedMessage: "message preview" })] });
+  const jobs = [job, { ...job, id: "job-2", company: "NoTarget", title: "Dev" }];
+  const targets = [target];
+  const sequences = [seq({ id: "draft", generatedMessage: "message preview" })];
+  const actions = buildDailyConversationActions({
+    jobsById: Object.fromEntries(jobs.map((j) => [j.id, j])),
+    targetsById: Object.fromEntries(targets.map((t) => [t.id, t])),
+    actions: getTodaysConversationActions({ today, jobs, targets, sequences }),
+  });
   const draftAction = actions.find((action) => action.type === "send_draft");
   const addTargetAction = actions.find((action) => action.type === "add_target");
   assert.equal(draftAction?.company, "Acme");

--- a/ui/partner-hub/lib/job-hunter/conversationActions.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationActions.ts
@@ -1,4 +1,3 @@
-import { getTodaysConversationActions } from "./conversations";
 import { getOutreachPreview } from "./conversationUi";
 import type { ConversationDailyAction, ConversationTarget, JobPosting, OutreachSequence } from "./types";
 
@@ -21,17 +20,13 @@ const getSequenceContext = (sequence: OutreachSequence, jobsById: Record<string,
 });
 
 export const buildDailyConversationActions = (params: {
-  today: Date;
-  limit?: number;
-  sequences: OutreachSequence[];
-  targets: ConversationTarget[];
-  jobs: JobPosting[];
+  jobsById: Record<string, JobPosting>;
+  targetsById: Record<string, ConversationTarget>;
+  actions: ReturnType<typeof import("./conversations").getTodaysConversationActions>;
+  maxActions?: number;
 }): BuilderAction[] => {
-  const { sequences, targets, jobs, today } = params;
-  const limit = params.limit ?? 10;
-  const jobsById = Object.fromEntries(jobs.map((job) => [job.id, job]));
-  const targetsById = Object.fromEntries(targets.map((target) => [target.id, target]));
-  const todays = getTodaysConversationActions({ today, sequences, targets, jobs });
+  const { jobsById, targetsById, actions: todays } = params;
+  const limit = params.maxActions ?? 10;
 
   const actions: BuilderAction[] = [];
 


### PR DESCRIPTION
### Motivation
- Finish Phase 4.2 cleanup by avoiding recomputation of today's conversation buckets inside the action builder and instead use the already-derived action buckets. 
- Reduce duplication and make `buildDailyConversationActions` accept lookup maps and the precomputed action buckets for clearer responsibilities.

### Description
- Updated `buildDailyConversationActions` signature to accept `jobsById`, `targetsById`, `actions`, and `maxActions` and removed its internal call to `getTodaysConversationActions`. 
- Updated `ConversationsClient` to pass the derived `actions` (from `getTodaysConversationActions`) and the `jobsById`/`conversationTargetsById` maps into `buildDailyConversationActions`. 
- Adjusted `conversationActions` tests to derive `actions` via `getTodaysConversationActions` and pass maps into the builder while preserving behavior and assertions. 
- Preserved canonical action fields (`type`, `priority`, `label`, `description`, `jobId`, `sequenceId`, `contactId`, `company`, `roleTitle`, `contactName`, `messagePreview`, `dueAt`), supported UI `supportedActions`/`guide`, ordering, and no auto-send/external API behavior.

### Testing
- Ran `npm test` from `ui/partner-hub`, which failed in this environment due to pre-existing missing dependencies/type errors (for example `Cannot find module 'node:test'`, `Cannot find module 'zod'`, and other unrelated Node/React/Next type issues). 
- Ran `npm run typecheck` from `ui/partner-hub`, which also failed due to existing repository-wide type/dependency issues (for example missing `react`, `next/*`, and Node type declarations). 
- Unit test source `ui/partner-hub/lib/job-hunter/conversationActions.test.ts` was updated to exercise the new builder shape, but full test/typecheck runs could not complete here because of the environment/dependency problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2637cf9bc83308920aa4b598871d1)