### PR TITLE
Add conversation execution metrics, daily quota, and progress panel

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx
@@ -7,11 +7,13 @@ import { buildConversationTarget, createTargetDraft, isTargetDraftValid, type Ta
 import { applySequenceMessageEdit, getDraftedOutreach, getFollowUpsDue, markSequenceSent, skipSequence, snoozeSequence } from "@/lib/job-hunter/conversationUi";
 import { generateConversationDraftsFromTopJobs, type ConversationAutomationSummary } from "@/lib/job-hunter/conversationAutomation";
 import { buildDailyConversationActions } from "@/lib/job-hunter/conversationActions";
+import { calculateConversationDailyProgress, calculateConversationExecutionMetrics, getDefaultConversationDailyQuota } from "@/lib/job-hunter/conversationMetrics";
 import { loadJobHunterStore, saveJobHunterStore } from "@/lib/job-hunter/storage";
 
 import { ActiveConversationsSection, DraftedOutreachSection, FollowUpsDueSection } from "./components/ConversationSections";
 import { TargetDraftCard } from "./components/TargetDraftCard";
 import { DailyActionPlan } from "./components/DailyActionPlan";
+import { ConversationMetricsPanel } from "./components/ConversationMetricsPanel";
 
 export default function ConversationsClient() {
   const [store, setStore] = useState(() => loadJobHunterStore());
@@ -24,6 +26,9 @@ export default function ConversationsClient() {
   const drafted = useMemo(() => getDraftedOutreach(store.outreachSequences ?? []), [store.outreachSequences]);
   const followUpsDue = useMemo(() => getFollowUpsDue(store.outreachSequences ?? [], now), [now, store.outreachSequences]);
   const dailyActions = useMemo(() => buildDailyConversationActions({ jobsById: store.jobsById, targetsById: store.conversationTargetsById, actions, maxActions: 10 }), [actions, store.conversationTargetsById, store.jobsById]);
+  const dailyQuota = useMemo(() => getDefaultConversationDailyQuota(), []);
+  const executionMetrics = useMemo(() => calculateConversationExecutionMetrics({ now, sequences: store.outreachSequences ?? [] }), [now, store.outreachSequences]);
+  const progressPercent = useMemo(() => calculateConversationDailyProgress({ metrics: executionMetrics, quota: dailyQuota }), [dailyQuota, executionMetrics]);
 
   const persist = (nextStore: ReturnType<typeof loadJobHunterStore>) => {
     setStore(nextStore);
@@ -67,6 +72,8 @@ export default function ConversationsClient() {
 
   return <main className="mx-auto max-w-5xl space-y-6 p-6">
     <header className="space-y-2"><h1 className="text-2xl font-semibold">Conversations</h1><p className="text-sm text-foreground/70">Review drafts, follow-ups, and active replies without auto-sending.</p></header>
+
+    <ConversationMetricsPanel metrics={executionMetrics} quota={dailyQuota} progressPercent={progressPercent} />
 
     <DailyActionPlan dailyActions={dailyActions} draftEdits={draftEdits} setDraftEdits={setDraftEdits} store={store} onActionMarkSent={onActionMarkSent} onActionSkip={onActionSkip} />
 

--- a/ui/partner-hub/app/(routes)/job-hunter/conversations/components/ConversationMetricsPanel.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/conversations/components/ConversationMetricsPanel.tsx
@@ -1,0 +1,26 @@
+import type { ConversationDailyQuota, ConversationExecutionMetrics } from "@/lib/job-hunter/conversationMetrics";
+
+type ConversationMetricsPanelProps = {
+  metrics: ConversationExecutionMetrics;
+  quota: ConversationDailyQuota;
+  progressPercent: number;
+};
+
+export function ConversationMetricsPanel({ metrics, quota, progressPercent }: ConversationMetricsPanelProps) {
+  return <section className="space-y-3 rounded-lg border border-border/60 p-4 text-sm">
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <h2 className="text-lg font-semibold">Daily Execution Metrics</h2>
+      <p className="text-sm text-foreground/70">Daily progress: <span className="font-semibold text-foreground">{progressPercent}%</span></p>
+    </div>
+    <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+      <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${Math.max(0, Math.min(progressPercent, 100))}%` }} />
+    </div>
+    <div className="grid gap-3 md:grid-cols-3">
+      <article className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">New outreach sent today</p><p className="text-2xl font-semibold">{metrics.newOutreachSentToday} / {quota.newOutreach}</p></article>
+      <article className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">Follow-ups sent today</p><p className="text-2xl font-semibold">{metrics.followUpsSentToday} / {quota.followUps}</p></article>
+      <article className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">Replies today</p><p className="text-2xl font-semibold">{metrics.repliesToday}</p></article>
+      <article className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">Active conversations</p><p className="text-2xl font-semibold">{metrics.activeConversations}</p></article>
+      <article className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">Stale sent / no reply</p><p className="text-2xl font-semibold">{metrics.staleSentNoReply}</p></article>
+    </div>
+  </section>;
+}

--- a/ui/partner-hub/lib/job-hunter/conversationMetrics.test.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationMetrics.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { calculateConversationDailyProgress, calculateConversationExecutionMetrics, getDefaultConversationDailyQuota } from "./conversationMetrics";
+import type { OutreachSequence } from "./types";
+
+const now = new Date("2026-04-29T12:00:00.000Z");
+
+const seq = (id: string, overrides: Partial<OutreachSequence>): OutreachSequence => ({
+  id,
+  jobId: "job-1",
+  contactId: "target-1",
+  stage: "intro",
+  channel: "linkedin",
+  generatedMessage: "hello",
+  status: "draft",
+  createdAt: "2026-04-28T00:00:00.000Z",
+  updatedAt: "2026-04-28T00:00:00.000Z",
+  ...overrides,
+});
+
+test("returns default daily quota", () => {
+  assert.deepEqual(getDefaultConversationDailyQuota(), { newOutreach: 8, followUps: 5 });
+});
+
+test("calculates execution metrics for today", () => {
+  const metrics = calculateConversationExecutionMetrics({
+    now,
+    sequences: [
+      seq("intro-sent", { status: "sent", sentAt: "2026-04-29T05:00:00.000Z" }),
+      seq("follow-sent", { stage: "follow_up_1", status: "sent", sentAt: "2026-04-29T06:00:00.000Z" }),
+      seq("reply-today", { status: "replied", repliedAt: "2026-04-29T07:00:00.000Z" }),
+      seq("reply-old", { status: "replied", repliedAt: "2026-04-20T07:00:00.000Z" }),
+      seq("stale", { status: "sent", sentAt: "2026-04-20T00:00:00.000Z" }),
+      seq("fresh-sent", { status: "sent", sentAt: "2026-04-27T00:00:00.000Z" }),
+    ],
+  });
+
+  assert.equal(metrics.newOutreachSentToday, 1);
+  assert.equal(metrics.followUpsSentToday, 1);
+  assert.equal(metrics.repliesToday, 1);
+  assert.equal(metrics.activeConversations, 2);
+  assert.equal(metrics.staleSentNoReply, 1);
+});
+
+test("caps daily progress at 100 percent", () => {
+  const progress = calculateConversationDailyProgress({
+    metrics: {
+      newOutreachSentToday: 10,
+      followUpsSentToday: 8,
+      repliesToday: 0,
+      activeConversations: 0,
+      staleSentNoReply: 0,
+    },
+  });
+  assert.equal(progress, 100);
+});

--- a/ui/partner-hub/lib/job-hunter/conversationMetrics.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationMetrics.ts
@@ -1,0 +1,62 @@
+import type { OutreachSequence } from "./types";
+
+export type ConversationDailyQuota = {
+  newOutreach: number;
+  followUps: number;
+};
+
+export type ConversationExecutionMetrics = {
+  newOutreachSentToday: number;
+  followUpsSentToday: number;
+  repliesToday: number;
+  activeConversations: number;
+  staleSentNoReply: number;
+};
+
+const ONE_DAY_MS = 86_400_000;
+
+const isSameUtcDay = (left: Date, right: Date) => left.toISOString().slice(0, 10) === right.toISOString().slice(0, 10);
+
+export const getDefaultConversationDailyQuota = (): ConversationDailyQuota => ({
+  newOutreach: 8,
+  followUps: 5,
+});
+
+export const calculateConversationExecutionMetrics = (params: { now: Date; sequences: OutreachSequence[] }): ConversationExecutionMetrics => {
+  const { now, sequences } = params;
+  const metrics: ConversationExecutionMetrics = {
+    newOutreachSentToday: 0,
+    followUpsSentToday: 0,
+    repliesToday: 0,
+    activeConversations: 0,
+    staleSentNoReply: 0,
+  };
+
+  for (const sequence of sequences) {
+    const sentAt = sequence.sentAt ? new Date(sequence.sentAt) : null;
+    const repliedAt = sequence.repliedAt ? new Date(sequence.repliedAt) : null;
+
+    if (sentAt && isSameUtcDay(sentAt, now)) {
+      if (sequence.stage === "intro") metrics.newOutreachSentToday += 1;
+      if (sequence.stage !== "intro") metrics.followUpsSentToday += 1;
+    }
+
+    if (repliedAt && isSameUtcDay(repliedAt, now)) metrics.repliesToday += 1;
+    if (sequence.status === "replied") metrics.activeConversations += 1;
+
+    if (sequence.status === "sent" && !sequence.repliedAt) {
+      const referenceAt = sentAt ?? new Date(sequence.updatedAt);
+      if ((now.getTime() - referenceAt.getTime()) / ONE_DAY_MS > 5) metrics.staleSentNoReply += 1;
+    }
+  }
+
+  return metrics;
+};
+
+export const calculateConversationDailyProgress = (params: { metrics: ConversationExecutionMetrics; quota?: ConversationDailyQuota }): number => {
+  const quota = params.quota ?? getDefaultConversationDailyQuota();
+  const sentToday = params.metrics.newOutreachSentToday + params.metrics.followUpsSentToday;
+  const targetTotal = quota.newOutreach + quota.followUps;
+  if (targetTotal <= 0) return 100;
+  return Math.min(100, Math.round((sentToday / targetTotal) * 100));
+};


### PR DESCRIPTION
### Motivation
- Surface daily execution metrics on the Conversations page so users can see whether they are performing enough outbound activity each day (new outreach, follow-ups, replies, active conversations, stale sent/no-reply, and a daily progress percentage).
- Provide a small, local-store-only metrics layer and UI that can be used to track quota progress without adding any automation, network calls, or scraping.

### Description
- Added `ui/partner-hub/lib/job-hunter/conversationMetrics.ts` with helpers `getDefaultConversationDailyQuota`, `calculateConversationExecutionMetrics`, and `calculateConversationDailyProgress` which compute quotas, per-day metrics, stale detection, and progress percent.
- Added unit tests in `ui/partner-hub/lib/job-hunter/conversationMetrics.test.ts` covering default quota, execution metric calculations, stale detection, and progress capping behavior.
- Added a presentational component `ConversationMetricsPanel` at `ui/partner-hub/app/(routes)/job-hunter/conversations/components/ConversationMetricsPanel.tsx` that displays: new outreach sent today X / 8, follow-ups sent today X / 5, replies today, active conversations, stale sent/no reply, and a progress bar showing daily progress percent.
- Integrated the metrics computation into `ConversationsClient` (`ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx`) using the local `store.outreachSequences` and `store` data only, and rendered the `ConversationMetricsPanel` above the daily action plan.

### Testing
- Ran `npm test` from `ui/partner-hub` and the run failed due to repository/environment-level TypeScript errors and missing dependency/type packages (errors include missing `node:test`, `react`, `next/*`, `zod`, `jszip`, and missing Node/Next/React typings), so the new unit test could not be executed in this environment.
- Ran `npm run typecheck` from `ui/partner-hub` and it failed for the same reasons (extensive pre-existing type errors and missing dependency/type declarations unrelated to these changes).
- The new helper tests were added but their execution could not be verified in this environment because of the above missing dependencies and baseline type issues; no tests specific to networking or automation were added or run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2677465808330bef084ab81cf9932)