### PR TITLE
Align conversation metrics with Phase 5.1 contract

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx
@@ -27,8 +27,8 @@ export default function ConversationsClient() {
   const followUpsDue = useMemo(() => getFollowUpsDue(store.outreachSequences ?? [], now), [now, store.outreachSequences]);
   const dailyActions = useMemo(() => buildDailyConversationActions({ jobsById: store.jobsById, targetsById: store.conversationTargetsById, actions, maxActions: 10 }), [actions, store.conversationTargetsById, store.jobsById]);
   const dailyQuota = useMemo(() => getDefaultConversationDailyQuota(), []);
-  const executionMetrics = useMemo(() => calculateConversationExecutionMetrics({ now, sequences: store.outreachSequences ?? [] }), [now, store.outreachSequences]);
-  const progressPercent = useMemo(() => calculateConversationDailyProgress({ metrics: executionMetrics, quota: dailyQuota }), [dailyQuota, executionMetrics]);
+  const executionMetrics = useMemo(() => calculateConversationExecutionMetrics({ today: now, window: "today", sequences: store.outreachSequences ?? [] }), [now, store.outreachSequences]);
+  const dailyProgress = useMemo(() => calculateConversationDailyProgress({ metrics: executionMetrics, quota: dailyQuota }), [dailyQuota, executionMetrics]);
 
   const persist = (nextStore: ReturnType<typeof loadJobHunterStore>) => {
     setStore(nextStore);
@@ -73,7 +73,7 @@ export default function ConversationsClient() {
   return <main className="mx-auto max-w-5xl space-y-6 p-6">
     <header className="space-y-2"><h1 className="text-2xl font-semibold">Conversations</h1><p className="text-sm text-foreground/70">Review drafts, follow-ups, and active replies without auto-sending.</p></header>
 
-    <ConversationMetricsPanel metrics={executionMetrics} quota={dailyQuota} progressPercent={progressPercent} />
+    <ConversationMetricsPanel metrics={executionMetrics} progress={dailyProgress} />
 
     <DailyActionPlan dailyActions={dailyActions} draftEdits={draftEdits} setDraftEdits={setDraftEdits} store={store} onActionMarkSent={onActionMarkSent} onActionSkip={onActionSkip} />
 

--- a/ui/partner-hub/app/(routes)/job-hunter/conversations/components/ConversationMetricsPanel.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/conversations/components/ConversationMetricsPanel.tsx
@@ -1,24 +1,23 @@
-import type { ConversationDailyQuota, ConversationExecutionMetrics } from "@/lib/job-hunter/conversationMetrics";
+import type { ConversationDailyProgress, ConversationExecutionMetrics } from "@/lib/job-hunter/conversationMetrics";
 
 type ConversationMetricsPanelProps = {
   metrics: ConversationExecutionMetrics;
-  quota: ConversationDailyQuota;
-  progressPercent: number;
+  progress: ConversationDailyProgress;
 };
 
-export function ConversationMetricsPanel({ metrics, quota, progressPercent }: ConversationMetricsPanelProps) {
+export function ConversationMetricsPanel({ metrics, progress }: ConversationMetricsPanelProps) {
   return <section className="space-y-3 rounded-lg border border-border/60 p-4 text-sm">
     <div className="flex flex-wrap items-center justify-between gap-3">
       <h2 className="text-lg font-semibold">Daily Execution Metrics</h2>
-      <p className="text-sm text-foreground/70">Daily progress: <span className="font-semibold text-foreground">{progressPercent}%</span></p>
+      <p className="text-sm text-foreground/70">Daily progress: <span className="font-semibold text-foreground">{progress.progressPct}%</span></p>
     </div>
     <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-      <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${Math.max(0, Math.min(progressPercent, 100))}%` }} />
+      <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${Math.max(0, Math.min(progress.progressPct, 100))}%` }} />
     </div>
     <div className="grid gap-3 md:grid-cols-3">
-      <article className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">New outreach sent today</p><p className="text-2xl font-semibold">{metrics.newOutreachSentToday} / {quota.newOutreach}</p></article>
-      <article className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">Follow-ups sent today</p><p className="text-2xl font-semibold">{metrics.followUpsSentToday} / {quota.followUps}</p></article>
-      <article className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">Replies today</p><p className="text-2xl font-semibold">{metrics.repliesToday}</p></article>
+      <article className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">New outreach sent today</p><p className="text-2xl font-semibold">{metrics.newOutreachSent} / {progress.quota.newOutreachTarget}</p></article>
+      <article className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">Follow-ups sent today</p><p className="text-2xl font-semibold">{metrics.followUpsSent} / {progress.quota.followUpTarget}</p></article>
+      <article className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">Replies today</p><p className="text-2xl font-semibold">{metrics.replies}</p></article>
       <article className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">Active conversations</p><p className="text-2xl font-semibold">{metrics.activeConversations}</p></article>
       <article className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">Stale sent / no reply</p><p className="text-2xl font-semibold">{metrics.staleSentNoReply}</p></article>
     </div>

--- a/ui/partner-hub/docs/issues/phase-5-1-conversation-metrics-cleanup.md
+++ b/ui/partner-hub/docs/issues/phase-5-1-conversation-metrics-cleanup.md
@@ -1,0 +1,45 @@
+# Phase 5.1 Cleanup: Conversation Engine Metrics Contract Alignment
+
+## Goal
+Align `lib/job-hunter/conversationMetrics.ts` and consuming UI types with the Phase 5 metrics contract before building additional workflow features.
+
+## Scope
+- Rename quota fields to `newOutreachTarget` and `followUpTarget`.
+- Introduce `ConversationMetricsWindow` with:
+  - `today`
+  - `last7Days`
+  - `allTime`
+- Update `ConversationExecutionMetrics` to include:
+  - `window`
+  - `newOutreachSent`
+  - `followUpsSent`
+  - `skipped`
+  - `replies`
+  - `activeConversations`
+  - `staleSentNoReply`
+- Update `calculateConversationExecutionMetrics` signature to:
+  - `calculateConversationExecutionMetrics({ sequences, today, window })`
+- Add `calculateConversationDailyProgress` return shape:
+  - `quota`
+  - `newOutreachSent`
+  - `followUpsSent`
+  - `totalCompleted`
+  - `totalTarget`
+  - `progressPct`
+  - `remainingNewOutreach`
+  - `remainingFollowUps`
+- Preserve current UI behavior while migrating `ConversationMetricsPanel` to consume the new object shape.
+- Add tests for:
+  - windows: `today`, `last7Days`, `allTime`
+  - `skipped`
+  - progress clamping
+  - remaining counts
+  - invalid/missing dates
+
+## Constraints
+- No auto-send behavior changes.
+- No API integration changes.
+
+## Validation
+- `npm test`
+- `npm run typecheck`

--- a/ui/partner-hub/lib/job-hunter/conversationMetrics.test.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationMetrics.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 import { calculateConversationDailyProgress, calculateConversationExecutionMetrics, getDefaultConversationDailyQuota } from "./conversationMetrics";
 import type { OutreachSequence } from "./types";
 
-const now = new Date("2026-04-29T12:00:00.000Z");
+const today = new Date("2026-04-29T12:00:00.000Z");
 
 const seq = (id: string, overrides: Partial<OutreachSequence>): OutreachSequence => ({
   id,
@@ -20,38 +20,97 @@ const seq = (id: string, overrides: Partial<OutreachSequence>): OutreachSequence
 });
 
 test("returns default daily quota", () => {
-  assert.deepEqual(getDefaultConversationDailyQuota(), { newOutreach: 8, followUps: 5 });
+  assert.deepEqual(getDefaultConversationDailyQuota(), { newOutreachTarget: 8, followUpTarget: 5 });
 });
 
-test("calculates execution metrics for today", () => {
+test("calculates execution metrics for today window", () => {
   const metrics = calculateConversationExecutionMetrics({
-    now,
+    today,
+    window: "today",
     sequences: [
       seq("intro-sent", { status: "sent", sentAt: "2026-04-29T05:00:00.000Z" }),
       seq("follow-sent", { stage: "follow_up_1", status: "sent", sentAt: "2026-04-29T06:00:00.000Z" }),
       seq("reply-today", { status: "replied", repliedAt: "2026-04-29T07:00:00.000Z" }),
-      seq("reply-old", { status: "replied", repliedAt: "2026-04-20T07:00:00.000Z" }),
+      seq("skipped", { status: "skipped" }),
       seq("stale", { status: "sent", sentAt: "2026-04-20T00:00:00.000Z" }),
-      seq("fresh-sent", { status: "sent", sentAt: "2026-04-27T00:00:00.000Z" }),
     ],
   });
 
-  assert.equal(metrics.newOutreachSentToday, 1);
-  assert.equal(metrics.followUpsSentToday, 1);
-  assert.equal(metrics.repliesToday, 1);
-  assert.equal(metrics.activeConversations, 2);
+  assert.equal(metrics.window, "today");
+  assert.equal(metrics.newOutreachSent, 1);
+  assert.equal(metrics.followUpsSent, 1);
+  assert.equal(metrics.skipped, 1);
+  assert.equal(metrics.replies, 1);
+  assert.equal(metrics.activeConversations, 1);
   assert.equal(metrics.staleSentNoReply, 1);
 });
 
-test("caps daily progress at 100 percent", () => {
+test("calculates execution metrics for last7Days window", () => {
+  const metrics = calculateConversationExecutionMetrics({
+    today,
+    window: "last7Days",
+    sequences: [
+      seq("intro-in-window", { status: "sent", sentAt: "2026-04-23T11:00:00.000Z" }),
+      seq("follow-in-window", { stage: "follow_up_2", status: "sent", sentAt: "2026-04-28T06:00:00.000Z" }),
+      seq("reply-in-window", { status: "replied", repliedAt: "2026-04-24T06:00:00.000Z" }),
+      seq("reply-out-window", { status: "replied", repliedAt: "2026-04-20T06:00:00.000Z" }),
+    ],
+  });
+
+  assert.equal(metrics.newOutreachSent, 1);
+  assert.equal(metrics.followUpsSent, 1);
+  assert.equal(metrics.replies, 1);
+});
+
+test("calculates execution metrics for allTime window", () => {
+  const metrics = calculateConversationExecutionMetrics({
+    today,
+    window: "allTime",
+    sequences: [
+      seq("intro", { status: "sent", sentAt: "2026-04-01T05:00:00.000Z" }),
+      seq("follow", { stage: "follow_up_1", status: "sent", sentAt: "2026-04-02T06:00:00.000Z" }),
+      seq("reply", { status: "replied", repliedAt: "2026-04-03T07:00:00.000Z" }),
+    ],
+  });
+
+  assert.equal(metrics.newOutreachSent, 1);
+  assert.equal(metrics.followUpsSent, 1);
+  assert.equal(metrics.replies, 1);
+});
+
+test("handles invalid or missing dates safely", () => {
+  const metrics = calculateConversationExecutionMetrics({
+    today,
+    window: "today",
+    sequences: [
+      seq("missing", { status: "sent" }),
+      seq("invalid", { status: "sent", sentAt: "not-a-date" }),
+      seq("invalid-reply", { status: "replied", repliedAt: "not-a-date" }),
+    ],
+  });
+
+  assert.equal(metrics.newOutreachSent, 0);
+  assert.equal(metrics.followUpsSent, 0);
+  assert.equal(metrics.replies, 0);
+});
+
+test("returns structured daily progress with clamping and remaining counts", () => {
   const progress = calculateConversationDailyProgress({
     metrics: {
-      newOutreachSentToday: 10,
-      followUpsSentToday: 8,
-      repliesToday: 0,
+      window: "today",
+      newOutreachSent: 10,
+      followUpsSent: 8,
+      skipped: 0,
+      replies: 0,
       activeConversations: 0,
       staleSentNoReply: 0,
     },
+    quota: { newOutreachTarget: 8, followUpTarget: 5 },
   });
-  assert.equal(progress, 100);
+
+  assert.equal(progress.totalCompleted, 18);
+  assert.equal(progress.totalTarget, 13);
+  assert.equal(progress.progressPct, 100);
+  assert.equal(progress.remainingNewOutreach, 0);
+  assert.equal(progress.remainingFollowUps, 0);
 });

--- a/ui/partner-hub/lib/job-hunter/conversationMetrics.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationMetrics.ts
@@ -1,62 +1,115 @@
 import type { OutreachSequence } from "./types";
 
 export type ConversationDailyQuota = {
-  newOutreach: number;
-  followUps: number;
+  newOutreachTarget: number;
+  followUpTarget: number;
 };
 
+export type ConversationMetricsWindow = "today" | "last7Days" | "allTime";
+
 export type ConversationExecutionMetrics = {
-  newOutreachSentToday: number;
-  followUpsSentToday: number;
-  repliesToday: number;
+  window: ConversationMetricsWindow;
+  newOutreachSent: number;
+  followUpsSent: number;
+  skipped: number;
+  replies: number;
   activeConversations: number;
   staleSentNoReply: number;
 };
 
+export type ConversationDailyProgress = {
+  quota: ConversationDailyQuota;
+  newOutreachSent: number;
+  followUpsSent: number;
+  totalCompleted: number;
+  totalTarget: number;
+  progressPct: number;
+  remainingNewOutreach: number;
+  remainingFollowUps: number;
+};
+
 const ONE_DAY_MS = 86_400_000;
+
+const isValidDate = (value: Date | null) => Boolean(value && !Number.isNaN(value.getTime()));
+
+const parseDate = (value?: string) => {
+  if (!value) return null;
+  const date = new Date(value);
+  return isValidDate(date) ? date : null;
+};
 
 const isSameUtcDay = (left: Date, right: Date) => left.toISOString().slice(0, 10) === right.toISOString().slice(0, 10);
 
+const isWithinWindow = (value: Date, today: Date, window: ConversationMetricsWindow) => {
+  if (window === "allTime") return true;
+  if (window === "today") return isSameUtcDay(value, today);
+  const deltaMs = today.getTime() - value.getTime();
+  return deltaMs >= 0 && deltaMs < ONE_DAY_MS * 7;
+};
+
 export const getDefaultConversationDailyQuota = (): ConversationDailyQuota => ({
-  newOutreach: 8,
-  followUps: 5,
+  newOutreachTarget: 8,
+  followUpTarget: 5,
 });
 
-export const calculateConversationExecutionMetrics = (params: { now: Date; sequences: OutreachSequence[] }): ConversationExecutionMetrics => {
-  const { now, sequences } = params;
+export const calculateConversationExecutionMetrics = (params: {
+  sequences: OutreachSequence[];
+  today: Date;
+  window: ConversationMetricsWindow;
+}): ConversationExecutionMetrics => {
+  const { sequences, today, window } = params;
   const metrics: ConversationExecutionMetrics = {
-    newOutreachSentToday: 0,
-    followUpsSentToday: 0,
-    repliesToday: 0,
+    window,
+    newOutreachSent: 0,
+    followUpsSent: 0,
+    skipped: 0,
+    replies: 0,
     activeConversations: 0,
     staleSentNoReply: 0,
   };
 
   for (const sequence of sequences) {
-    const sentAt = sequence.sentAt ? new Date(sequence.sentAt) : null;
-    const repliedAt = sequence.repliedAt ? new Date(sequence.repliedAt) : null;
+    const sentAt = parseDate(sequence.sentAt);
+    const repliedAt = parseDate(sequence.repliedAt);
 
-    if (sentAt && isSameUtcDay(sentAt, now)) {
-      if (sequence.stage === "intro") metrics.newOutreachSentToday += 1;
-      if (sequence.stage !== "intro") metrics.followUpsSentToday += 1;
+    if (sentAt && isWithinWindow(sentAt, today, window)) {
+      if (sequence.stage === "intro") metrics.newOutreachSent += 1;
+      if (sequence.stage !== "intro") metrics.followUpsSent += 1;
     }
 
-    if (repliedAt && isSameUtcDay(repliedAt, now)) metrics.repliesToday += 1;
+    if (repliedAt && isWithinWindow(repliedAt, today, window)) metrics.replies += 1;
+
+    if (sequence.status === "skipped") metrics.skipped += 1;
     if (sequence.status === "replied") metrics.activeConversations += 1;
 
     if (sequence.status === "sent" && !sequence.repliedAt) {
-      const referenceAt = sentAt ?? new Date(sequence.updatedAt);
-      if ((now.getTime() - referenceAt.getTime()) / ONE_DAY_MS > 5) metrics.staleSentNoReply += 1;
+      const referenceAt = sentAt ?? parseDate(sequence.updatedAt);
+      if (referenceAt && (today.getTime() - referenceAt.getTime()) / ONE_DAY_MS > 5) metrics.staleSentNoReply += 1;
     }
   }
 
   return metrics;
 };
 
-export const calculateConversationDailyProgress = (params: { metrics: ConversationExecutionMetrics; quota?: ConversationDailyQuota }): number => {
+export const calculateConversationDailyProgress = (params: {
+  metrics: ConversationExecutionMetrics;
+  quota?: ConversationDailyQuota;
+}): ConversationDailyProgress => {
   const quota = params.quota ?? getDefaultConversationDailyQuota();
-  const sentToday = params.metrics.newOutreachSentToday + params.metrics.followUpsSentToday;
-  const targetTotal = quota.newOutreach + quota.followUps;
-  if (targetTotal <= 0) return 100;
-  return Math.min(100, Math.round((sentToday / targetTotal) * 100));
+  const newOutreachSent = params.metrics.newOutreachSent;
+  const followUpsSent = params.metrics.followUpsSent;
+  const totalCompleted = newOutreachSent + followUpsSent;
+  const totalTarget = quota.newOutreachTarget + quota.followUpTarget;
+  const progressPct = totalTarget <= 0 ? 100 : Math.max(0, Math.min(100, Math.round((totalCompleted / totalTarget) * 100)));
+
+  return {
+    quota,
+    newOutreachSent,
+    followUpsSent,
+    totalCompleted,
+    totalTarget,
+    progressPct,
+    remainingNewOutreach: Math.max(0, quota.newOutreachTarget - newOutreachSent),
+    remainingFollowUps: Math.max(0, quota.followUpTarget - followUpsSent),
+  };
 };


### PR DESCRIPTION
### Motivation
- Standardize the Job Hunter conversation metrics shape to the Phase 5 contract so future workflow features can rely on a stable metrics API.
- Ensure the metrics support multiple time windows (`today`, `last7Days`, `allTime`) and richer execution counts (skipped, replies, active, stale) required by Phase 5 features.
- Preserve existing UI behavior while moving the panel to consume the new structured progress object instead of piecemeal values.

### Description
- Updated `ui/partner-hub/lib/job-hunter/conversationMetrics.ts` to rename quota fields to `newOutreachTarget` and `followUpTarget`, add `ConversationMetricsWindow`, reshape `ConversationExecutionMetrics` (adds `window`, `newOutreachSent`, `followUpsSent`, `skipped`, `replies`), and made `calculateConversationExecutionMetrics` accept `{ sequences, today, window }` with safe date parsing and window filtering.
- Replaced the simple numeric progress function with `calculateConversationDailyProgress` that returns a structured `ConversationDailyProgress` object containing `quota`, `newOutreachSent`, `followUpsSent`, `totalCompleted`, `totalTarget`, `progressPct`, `remainingNewOutreach`, and `remainingFollowUps`.
- Updated UI to consume the new shapes: `ConversationMetricsPanel` now accepts `metrics` + `progress` and `ConversationsClient` calls `calculateConversationExecutionMetrics({ today, window, sequences })` and passes `dailyProgress` to the panel.
- Added unit tests `ui/partner-hub/lib/job-hunter/conversationMetrics.test.ts` covering `today`, `last7Days`, `allTime`, `skipped`, invalid/missing dates, progress clamping, and remaining counts, and created a docs issue file `ui/partner-hub/docs/issues/phase-5-1-conversation-metrics-cleanup.md` describing the migration scope.

### Testing
- Ran `npm test` in the `ui/partner-hub` package and it failed in this environment due to pre-existing missing project dependencies/type declarations (repo-wide Node type/module resolution errors), so the added tests were not executed successfully here.
- Ran `npm run typecheck` and it failed in this environment due to the same missing dependency/type issues across the repo, so typechecking could not be validated here.
- The change includes unit tests for the new metrics behavior, which are added to the repo and should run in CI or a local environment with project dependencies installed and Node types available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f268f3054883309477e018630008e5)