### PR TITLE
Fix skipped conversation metric windowing and add tests

### DIFF
--- a/ui/partner-hub/lib/job-hunter/conversationMetrics.test.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationMetrics.test.ts
@@ -31,7 +31,7 @@ test("calculates execution metrics for today window", () => {
       seq("intro-sent", { status: "sent", sentAt: "2026-04-29T05:00:00.000Z" }),
       seq("follow-sent", { stage: "follow_up_1", status: "sent", sentAt: "2026-04-29T06:00:00.000Z" }),
       seq("reply-today", { status: "replied", repliedAt: "2026-04-29T07:00:00.000Z" }),
-      seq("skipped", { status: "skipped" }),
+      seq("skipped", { status: "skipped", updatedAt: "2026-04-29T02:00:00.000Z" }),
       seq("stale", { status: "sent", sentAt: "2026-04-20T00:00:00.000Z" }),
     ],
   });
@@ -54,12 +54,14 @@ test("calculates execution metrics for last7Days window", () => {
       seq("follow-in-window", { stage: "follow_up_2", status: "sent", sentAt: "2026-04-28T06:00:00.000Z" }),
       seq("reply-in-window", { status: "replied", repliedAt: "2026-04-24T06:00:00.000Z" }),
       seq("reply-out-window", { status: "replied", repliedAt: "2026-04-20T06:00:00.000Z" }),
+      seq("skipped-in-window", { status: "skipped", updatedAt: "2026-04-24T06:00:00.000Z" }),
     ],
   });
 
   assert.equal(metrics.newOutreachSent, 1);
   assert.equal(metrics.followUpsSent, 1);
   assert.equal(metrics.replies, 1);
+  assert.equal(metrics.skipped, 1);
 });
 
 test("calculates execution metrics for allTime window", () => {
@@ -70,12 +72,39 @@ test("calculates execution metrics for allTime window", () => {
       seq("intro", { status: "sent", sentAt: "2026-04-01T05:00:00.000Z" }),
       seq("follow", { stage: "follow_up_1", status: "sent", sentAt: "2026-04-02T06:00:00.000Z" }),
       seq("reply", { status: "replied", repliedAt: "2026-04-03T07:00:00.000Z" }),
+      seq("skipped-valid-updated", { status: "skipped", updatedAt: "2026-03-01T00:00:00.000Z" }),
+      seq("skipped-missing-updated", { status: "skipped", updatedAt: undefined }),
+      seq("skipped-invalid-updated", { status: "skipped", updatedAt: "not-a-date" }),
     ],
   });
 
   assert.equal(metrics.newOutreachSent, 1);
   assert.equal(metrics.followUpsSent, 1);
   assert.equal(metrics.replies, 1);
+  assert.equal(metrics.skipped, 3);
+});
+
+test("today excludes skipped records updated yesterday", () => {
+  const metrics = calculateConversationExecutionMetrics({
+    today,
+    window: "today",
+    sequences: [seq("skipped-yesterday", { status: "skipped", updatedAt: "2026-04-28T23:00:00.000Z" })],
+  });
+
+  assert.equal(metrics.skipped, 0);
+});
+
+test("last7Days excludes skipped records older than 7 days", () => {
+  const metrics = calculateConversationExecutionMetrics({
+    today,
+    window: "last7Days",
+    sequences: [
+      seq("skipped-8-days-ago", { status: "skipped", updatedAt: "2026-04-21T11:59:59.000Z" }),
+      seq("skipped-in-window", { status: "skipped", updatedAt: "2026-04-23T12:00:00.000Z" }),
+    ],
+  });
+
+  assert.equal(metrics.skipped, 1);
 });
 
 test("handles invalid or missing dates safely", () => {
@@ -86,12 +115,14 @@ test("handles invalid or missing dates safely", () => {
       seq("missing", { status: "sent" }),
       seq("invalid", { status: "sent", sentAt: "not-a-date" }),
       seq("invalid-reply", { status: "replied", repliedAt: "not-a-date" }),
+      seq("invalid-skipped-updatedAt", { status: "skipped", updatedAt: "not-a-date" }),
     ],
   });
 
   assert.equal(metrics.newOutreachSent, 0);
   assert.equal(metrics.followUpsSent, 0);
   assert.equal(metrics.replies, 0);
+  assert.equal(metrics.skipped, 0);
 });
 
 test("returns structured daily progress with clamping and remaining counts", () => {

--- a/ui/partner-hub/lib/job-hunter/conversationMetrics.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationMetrics.ts
@@ -79,7 +79,14 @@ export const calculateConversationExecutionMetrics = (params: {
 
     if (repliedAt && isWithinWindow(repliedAt, today, window)) metrics.replies += 1;
 
-    if (sequence.status === "skipped") metrics.skipped += 1;
+    if (sequence.status === "skipped") {
+      if (window === "allTime") {
+        metrics.skipped += 1;
+      } else {
+        const updatedAt = parseDate(sequence.updatedAt);
+        if (updatedAt && isWithinWindow(updatedAt, today, window)) metrics.skipped += 1;
+      }
+    }
     if (sequence.status === "replied") metrics.activeConversations += 1;
 
     if (sequence.status === "sent" && !sequence.repliedAt) {


### PR DESCRIPTION
### Motivation
- Ensure `skipped` metric only counts sequences with `status === "skipped"` whose `updatedAt` falls inside the requested metrics window for `today` and `last7Days`, while `allTime` includes all skipped records and handles missing/invalid `updatedAt` safely.

### Description
- Updated `calculateConversationExecutionMetrics` in `ui/partner-hub/lib/job-hunter/conversationMetrics.ts` to check `updatedAt` (via `parseDate`) for `skipped` sequences when `window` is `today` or `last7Days`, and to count all skipped records for `allTime`.
- Expanded `ui/partner-hub/lib/job-hunter/conversationMetrics.test.ts` with tests that cover: `today` excludes skipped updated yesterday, `last7Days` excludes skipped older than 7 days, `allTime` counts skipped (including missing/invalid `updatedAt`), and invalid `updatedAt` does not crash or count in windowed modes.

### Testing
- Ran `npm test` in `ui/partner-hub`, which invoked `tsc` and the test runner but failed in this environment due to missing/unavailable project dependencies and global type declarations (errors such as missing `node:test`, `react`, `next`, `zod`), so the full test suite could not complete.
- Ran `npm run typecheck`, which also failed for unrelated global type/dependency issues (missing Next/React/Node typings), so repository-wide typecheck did not succeed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26a298a8083309bafc2013fa7440f)