### PR TITLE
Reposition Job Hunter landing page around Conversation Pipeline messaging

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/page.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/page.tsx
@@ -4,33 +4,33 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 const sections = [
   {
+    title: "Conversations",
+    description: "Start here to draft outreach, manage manual follow-ups, and track replies through interview outcomes.",
+    href: "/job-hunter/conversations",
+  },
+  {
     title: "Find Jobs",
-    description: "Run discovery from your preferences and review top matches.",
+    description: "Find and score opportunities based on your target roles and company criteria.",
     href: "/job-hunter/jobs",
   },
   {
     title: "Preferences",
-    description: "Set targeting rules that drive discovery and ranking.",
+    description: "Define target roles, locations, and companies that shape conversation pipeline quality.",
     href: "/job-hunter/preferences",
   },
   {
     title: "Applications",
-    description: "Review application progress and next steps.",
+    description: "Use guided apply tracking as supporting context for ongoing hiring conversations.",
     href: "/job-hunter/applications",
   },
   {
-    title: "Conversations",
-    description: "Review outreach drafts, follow-ups, replies, and missing targets.",
-    href: "/job-hunter/conversations",
-  },
-  {
     title: "Resume",
-    description: "Edit resume profile data used for minimal-delta tailoring output.",
+    description: "Maintain resume profile inputs that support targeted outreach and tailored application assets.",
     href: "/job-hunter/resume",
   },
   {
     title: "Advanced Sources",
-    description: "Optional manual provider/token setup for power users.",
+    description: "Optional supporting workflow for manual provider/token configuration and source control.",
     href: "/job-hunter/settings",
   },
 ];
@@ -39,17 +39,17 @@ export default function JobHunterPage() {
   return (
     <main className="mx-auto max-w-5xl space-y-6 p-6">
       <header className="space-y-2">
-        <h1 className="text-2xl font-semibold">Job Hunter</h1>
-        <p className="text-sm text-foreground/70">Use preferences-first discovery to find jobs, then choose, tailor, and apply.</p>
+        <h1 className="text-2xl font-semibold">Conversation Pipeline</h1>
+        <p className="text-sm text-foreground/70">Generate targeted outreach, manage follow-ups, and turn job opportunities into hiring conversations.</p>
       </header>
 
       <section className="rounded-lg border border-border/60 bg-muted/20 p-4 text-sm">
         <ol className="list-decimal space-y-1 pl-5 text-foreground/80">
-          <li>Set preferences</li>
-          <li>Find jobs from preferences</li>
-          <li>Select jobs to pursue</li>
-          <li>Tailor resume variants minimally</li>
-          <li>Complete guided apply workflow</li>
+          <li>Set target roles and companies</li>
+          <li>Find and score opportunities</li>
+          <li>Generate conversation drafts</li>
+          <li>Send and track follow-ups manually</li>
+          <li>Measure replies, conversations, and interviews</li>
         </ol>
       </section>
 


### PR DESCRIPTION
### Motivation
- Reframe the Job Hunter landing page to present the app as a hiring conversation engine rather than a traditional job application tracker. 
- Surface Conversations as the primary workflow while keeping existing routes and features intact. 
- Implement copy/order changes only (no new functionality, external APIs, or auto-send behavior). 

### Description
- Updated the landing page title from `Job Hunter` to `Conversation Pipeline` in `ui/partner-hub/app/(routes)/job-hunter/page.tsx`. 
- Replaced the landing-page subtitle with: `Generate targeted outreach, manage follow-ups, and turn job opportunities into hiring conversations.` in `ui/partner-hub/app/(routes)/job-hunter/page.tsx`. 
- Replaced the numbered workflow with the five-step conversation-pipeline list: `Set target roles and companies`, `Find and score opportunities`, `Generate conversation drafts`, `Send and track follow-ups manually`, and `Measure replies, conversations, and interviews`. 
- Moved the `Conversations` card to the first position and updated card descriptions so Conversations is the primary workflow while keeping `Find Jobs`, `Preferences`, `Applications`, `Resume`, and `Advanced Sources` as supporting workflows in `ui/partner-hub/app/(routes)/job-hunter/page.tsx`. 

### Testing
- Ran `npm test` from `ui/partner-hub`, which failed in this environment due to missing test/runtime type modules (for example `Cannot find module 'node:test'` and missing `zod` types), indicating pre-existing dependency/type setup issues unrelated to the landing-page text change. 
- Ran `npm run typecheck` from `ui/partner-hub`, which failed due to missing framework/dependency type declarations (for example `Cannot find module 'next/link'` and `Cannot find module 'react'`) and broader project-wide type errors not caused by this copy/order update. 
- Limitation: the validation commands do not pass in the current environment because of missing dependencies and project-wide type issues, and this PR intentionally limits changes to landing-page copy/order only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26c990d3c8330adcd9d7bc6c8d630)