### PR TITLE
Guided approval-gated outreach launch for Phase 7 (Conversations UI + placeholder targets)

### DIFF
--- a/ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx
+++ b/ui/partner-hub/app/(routes)/job-hunter/conversations/ConversationsClient.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { Button } from "@/components/ui/button";
 import { getTodaysConversationActions } from "@/lib/job-hunter/conversations";
 import { buildConversationTarget, createTargetDraft, isTargetDraftValid, type TargetDraft } from "@/lib/job-hunter/conversationTargets";
 import { applySequenceMessageEdit, getDraftedOutreach, getFollowUpsDue, markSequenceSent, skipSequence, snoozeSequence } from "@/lib/job-hunter/conversationUi";
@@ -15,6 +16,17 @@ import { ActiveConversationsSection, DraftedOutreachSection, FollowUpsDueSection
 import { TargetDraftCard } from "./components/TargetDraftCard";
 import { DailyActionPlan } from "./components/DailyActionPlan";
 import { ConversationMetricsPanel } from "./components/ConversationMetricsPanel";
+
+const LAUNCH_STEPS = [
+  "1. Start outreach pipeline",
+  "2. Add/select opportunity",
+  "3. Add/approve outreach candidates",
+  "4. Generate drafts",
+  "5. Review/edit drafts",
+  "6. Copy/send manually",
+  "7. Mark sent",
+  "8. Track follow-up/outcome",
+] as const;
 
 export default function ConversationsClient() {
   const [store, setStore] = useState(() => loadJobHunterStore());
@@ -34,6 +46,7 @@ export default function ConversationsClient() {
     acc[outcome.type] = (acc[outcome.type] ?? 0) + 1;
     return acc;
   }, {}), [store.conversationOutcomes]);
+  const hasPipelineData = (store.outreachSequences?.length ?? 0) > 0 || (store.conversationTargets?.length ?? 0) > 0 || (store.conversationBriefs?.length ?? 0) > 0;
 
   const persist = (nextStore: ReturnType<typeof loadJobHunterStore>) => {
     setStore(nextStore);
@@ -45,9 +58,6 @@ export default function ConversationsClient() {
     if (typeof nextText !== "string") return;
     persist(applySequenceMessageEdit(store, sequenceId, nextText, new Date()));
   };
-
-
-
 
   const onActionSkip = (sequenceId?: string) => {
     if (!sequenceId) return;
@@ -81,11 +91,13 @@ export default function ConversationsClient() {
   return <main className="mx-auto max-w-5xl space-y-6 p-6">
     <header className="space-y-2"><h1 className="text-2xl font-semibold">Conversations</h1><p className="text-sm text-foreground/70">Review drafts, follow-ups, and active replies without auto-sending.</p></header>
 
+    {!hasPipelineData ? <section className="space-y-4 rounded-lg border border-border/60 bg-muted/20 p-4 text-sm"><h2 className="text-xl font-semibold">Guided outreach launch</h2><Button type="button" onClick={onGenerateDrafts}>Start outreach pipeline</Button><p className="text-foreground/80">Add a target company or role, approve the outreach candidates, then generate editable messages. Nothing is sent automatically.</p><ol className="list-decimal space-y-1 pl-5 text-foreground/80">{LAUNCH_STEPS.map((step) => <li key={step}>{step}</li>)}</ol></section> : null}
+
     <ConversationMetricsPanel metrics={executionMetrics} progress={dailyProgress} />
 
     <DailyActionPlan dailyActions={dailyActions} draftEdits={draftEdits} setDraftEdits={setDraftEdits} store={store} onActionMarkSent={onActionMarkSent} onActionSkip={onActionSkip} />
 
-    <section className="space-y-3 rounded-lg border border-border/60 p-4 text-sm"><div className="flex flex-wrap items-center justify-between gap-3"><p className="text-foreground/80">Generate conversation briefs and drafts from top-scoring roles.</p><button type="button" onClick={onGenerateDrafts} className="rounded border border-border px-3 py-1.5 font-medium hover:bg-accent">Generate conversation drafts</button></div>{generationSummary ? <p className="text-xs text-foreground/70">Processed {generationSummary.consideredJobs} jobs with {generationSummary.eligibleJobs} eligible top matches; generated {generationSummary.generatedBriefs} briefs, {generationSummary.generatedTargets} targets, and {generationSummary.generatedOutreachDrafts} outreach drafts; skipped {generationSummary.skippedDuplicates} duplicates.</p> : null}<div className="grid gap-3 md:grid-cols-5">{[["Drafts to review", actions.draftsToReview.length], ["Follow-ups due", actions.followUpsDue.length], ["Stale sent no reply", actions.staleSentNoReply.length], ["Active replies", actions.activeReplies.length], ["Roles needing targets", actions.rolesNeedingTargets.length]].map(([label, count]) => <article key={String(label)} className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">{label}</p><p className="text-2xl font-semibold">{count}</p></article>)}</div></section>
+    <section className="space-y-3 rounded-lg border border-border/60 p-4 text-sm"><div className="flex flex-wrap items-center justify-between gap-3"><p className="text-foreground/80">Phase 7 automation is approval-gated: candidate details, generated messages, copy/send, mark sent, and outcome tracking are always user-confirmed.</p><button type="button" onClick={onGenerateDrafts} className="rounded border border-border px-3 py-1.5 font-medium hover:bg-accent">Start outreach pipeline</button></div>{generationSummary ? <p className="text-xs text-foreground/70">Processed {generationSummary.consideredJobs} jobs with {generationSummary.eligibleJobs} eligible top matches; generated {generationSummary.generatedBriefs} briefs, {generationSummary.generatedTargets} targets, and {generationSummary.generatedOutreachDrafts} outreach drafts; skipped {generationSummary.skippedDuplicates} duplicates.</p> : null}<div className="grid gap-3 md:grid-cols-5">{[["Drafts to review", actions.draftsToReview.length], ["Follow-ups due", actions.followUpsDue.length], ["Stale sent no reply", actions.staleSentNoReply.length], ["Active replies", actions.activeReplies.length], ["Roles needing targets", actions.rolesNeedingTargets.length]].map(([label, count]) => <article key={String(label)} className="rounded border border-border/40 p-3"><p className="text-xs text-foreground/70">{label}</p><p className="text-2xl font-semibold">{count}</p></article>)}</div></section>
 
     <DraftedOutreachSection drafted={drafted} jobsById={store.jobsById} targetsById={store.conversationTargetsById} draftEdits={draftEdits} setDraftEdit={(id, value) => setDraftEdits((prev) => ({ ...prev, [id]: value }))} onEditSave={onEditSave} onCopy={(value) => void navigator.clipboard?.writeText(value)} onMarkSent={(id) => persist(markSequenceSent(store, id, new Date()))} onSkip={(id) => persist(skipSequence(store, id, new Date()))} />
 
@@ -94,6 +106,6 @@ export default function ConversationsClient() {
     <ActiveConversationsSection activeReplies={actions.activeReplies} jobsById={store.jobsById} targetsById={store.conversationTargetsById} onMarkOutcome={onMarkOutcome} />
     <PipelineOutcomesPanel outcomeCounts={outcomeCounts} />
 
-    <section id="roles-needing-targets" className="space-y-3"><h2 className="text-xl font-semibold">Roles Needing Targets</h2>{actions.rolesNeedingTargets.length === 0 ? <p className="text-sm text-foreground/70">Every company currently has at least one target.</p> : actions.rolesNeedingTargets.map((job) => { const draft = targetDrafts[job.id] ?? createTargetDraft(); return <TargetDraftCard key={job.id} job={job} draft={draft} onChange={(nextDraft) => setTargetDrafts((prev) => ({ ...prev, [job.id]: nextDraft }))} onAdd={() => onAddTarget(job.id)} />; })}</section>
+    <section id="roles-needing-targets" className="space-y-3"><h2 className="text-xl font-semibold">Roles Needing Targets</h2><p className="text-xs text-foreground/70">If exact people are unknown, use placeholders: Recruiter target needed, Hiring manager target needed, Employee/referral target needed. Then fill name, title, LinkedIn URL, email, and notes.</p>{actions.rolesNeedingTargets.length === 0 ? <p className="text-sm text-foreground/70">Every company currently has at least one target.</p> : actions.rolesNeedingTargets.map((job) => { const draft = targetDrafts[job.id] ?? createTargetDraft(); return <TargetDraftCard key={job.id} job={job} draft={draft} onChange={(nextDraft) => setTargetDrafts((prev) => ({ ...prev, [job.id]: nextDraft }))} onAdd={() => onAddTarget(job.id)} />; })}</section>
   </main>;
 }

--- a/ui/partner-hub/lib/job-hunter/conversationAutomation.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationAutomation.ts
@@ -24,8 +24,9 @@ const logicalOutreachKey = (sequence: OutreachSequence) => `${sequence.jobId}:${
 const buildPlaceholderTargets = (job: JobPosting, now: Date): ConversationTarget[] => {
   const createdAt = now.toISOString();
   return [
-    { id: `${job.id}:auto-recruiter`, company: job.company, name: `${job.company} Recruiter`, relationshipType: "recruiter", source: "manual", confidence: 60, createdAt, updatedAt: createdAt },
-    { id: `${job.id}:auto-hiring-manager`, company: job.company, name: `${job.company} Hiring Manager`, relationshipType: "hiring_manager", source: "manual", confidence: 55, createdAt, updatedAt: createdAt },
+    { id: `${job.id}:auto-recruiter-needed`, company: job.company, name: "Recruiter target needed", relationshipType: "recruiter", source: "manual", confidence: 60, notes: "Add name, title, LinkedIn URL, email, and notes before outreach.", createdAt, updatedAt: createdAt },
+    { id: `${job.id}:auto-hiring-manager-needed`, company: job.company, name: "Hiring manager target needed", relationshipType: "hiring_manager", source: "manual", confidence: 55, notes: "Add name, title, LinkedIn URL, email, and notes before outreach.", createdAt, updatedAt: createdAt },
+    { id: `${job.id}:auto-employee-referral-needed`, company: job.company, name: "Employee/referral target needed", relationshipType: "employee", source: "manual", confidence: 50, notes: "Add name, title, LinkedIn URL, email, and notes before outreach.", createdAt, updatedAt: createdAt },
   ];
 };
 


### PR DESCRIPTION
### Motivation
- Provide a clear, guided launch workflow for Phase 7 outreach that is visible in the Conversations empty state with a primary CTA `Start outreach pipeline`.
- Automate generation of conversation briefs, placeholder candidate slots, and editable outreach drafts while ensuring every send/mark/outcome action remains user-approved (no auto-send).
- Make it obvious how to proceed when exact people are unknown by creating placeholder candidate slots that prompt users to fill contact details before outreach.

### Description
- Added an empty-state guided launch panel to the Conversations UI with `LAUNCH_STEPS`, a prominent `Start outreach pipeline` CTA, and copy clarifying that nothing is sent automatically in `app/(routes)/job-hunter/conversations/ConversationsClient.tsx`.
- Added an approval-gated banner in the automation panel and a `hasPipelineData` check so the guided launch appears only when the pipeline is empty in `ConversationsClient.tsx`.
- Updated automated placeholder target creation to emit three "needed" placeholder target slots (`Recruiter target needed`, `Hiring manager target needed`, `Employee/referral target needed`) that include `notes` prompting users to add name, title, LinkedIn URL, email, and notes in `lib/job-hunter/conversationAutomation.ts`.
- Files changed: `app/(routes)/job-hunter/conversations/ConversationsClient.tsx` and `lib/job-hunter/conversationAutomation.ts`.

### Testing
- Ran `npm test`, which failed in this environment before app-level assertions due to missing test/runtime dependencies and typings such as `node:test`, `node:assert/strict`, `zod`, and `jszip`.
- Ran `npm run typecheck`, which failed in this environment due to missing framework/dependency typings (for example `next/*`, `react`, `lucide-react`) and pre-existing repo-wide type issues unrelated to these changes.
- Limitation: automated test/typecheck failures are environmental and dependency-related; the change is UI/text and placeholder-target logic only and does not introduce auto-send or external API calls.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26fa9882c8330807de8c46d6a6771)