### PR TITLE
Phase 7.1: Block placeholder-only draft generation and add guided-start issue doc

### DIFF
--- a/ui/partner-hub/docs/issues/phase-7-1-conversations-guided-start-cleanup.md
+++ b/ui/partner-hub/docs/issues/phase-7-1-conversations-guided-start-cleanup.md
@@ -1,0 +1,75 @@
+# Phase 7.1 Cleanup — Guided Start Outreach Pipeline from Zero Data
+
+## Repo
+`jwsiejk/accountlist`
+
+## Goal
+Make **Start Outreach Pipeline** actually usable when the user starts with no jobs/opportunities.
+
+## Problem
+Phase 7 added launch copy and placeholder targets, but the button currently only runs generation. With zero jobs/opportunities, it processes 0 jobs and the user is stuck.
+
+## Scope
+### 1) Guided start workflow on Conversations page
+- Replace one-click generation-only start with a simple guided workflow/wizard.
+- Triggered by **Start Outreach Pipeline**.
+
+### 2) Step 1 — Add target opportunity
+Form fields:
+- `company` (required)
+- `role/title` (required)
+- `location` (optional)
+- `notes` (optional)
+- `sourceUrl` (optional)
+
+On save:
+- Create `JobPosting` with `source: "manual"`
+- Add to both `jobs` and `jobsById`
+- Persist store
+
+### 3) Step 2 — Add or approve outreach candidates
+Candidate lanes:
+- recruiter
+- hiring manager
+- employee/referral
+
+Rules:
+- Placeholder slots are allowed
+- Real outreach generation requires approved/filled candidate details
+
+### 4) Step 3 — Generate editable drafts
+- Generate drafts only for selected opportunity + approved candidates
+- Do **not** generate drafts for placeholders like “Recruiter target needed” unless explicitly approved
+
+### 5) Empty states
+Show explicit guidance strings:
+- “Add a target company/opportunity to begin.”
+- “Add or approve at least one outreach candidate.”
+- “Generate drafts once an opportunity and candidate exist.”
+
+### 6) Manual-only sending stays intact
+Keep current manual controls only:
+- edit
+- copy
+- open profile/email if available
+- mark sent
+
+## Constraints
+- No external APIs
+- No scraping
+- No LinkedIn automation
+- No auto-send
+
+## Tests
+Add/adjust coverage for:
+- create manual opportunity from wizard data
+- add opportunity to `jobs`/`jobsById`
+- create candidate slots for a manual opportunity
+- block draft generation when only unapproved placeholders exist
+- generate drafts when at least one approved candidate exists
+- no auto-send
+- preserve existing sent/replied/skipped sequences
+
+## Run
+- `npm test`
+- `npm run typecheck`

--- a/ui/partner-hub/lib/job-hunter/conversationAutomation.test.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationAutomation.test.ts
@@ -43,7 +43,7 @@ describe("conversation automation", () => {
 
     assert.equal(summary.eligibleJobs, 1);
     assert.equal(summary.generatedBriefs, 1);
-    assert.equal(summary.generatedTargets, 2);
+    assert.equal(summary.generatedTargets, 3);
     assert.equal(summary.generatedOutreachDrafts >= 1, true);
     assert.equal(store.conversationBriefs.length, 1);
   });
@@ -68,8 +68,18 @@ describe("conversation automation", () => {
     store.conversationBriefsById["b1"] = { id: "b1", jobId: job.id, company: "Acme", roleTitle: job.title, reasonToPursue: "x", likelyHiringPriorities: ["a"], likelyPainPoints: ["b"], candidateFit: ["c"], riskAreas: ["d"], messageAngle: "e", proofPoints: [], recommendedTargets: [], createdAt: "2026-01-01T00:00:00.000Z", updatedAt: "2026-01-01T00:00:00.000Z" };
     const { store: out } = generateConversationDraftsFromTopJobs({ store, now: new Date("2026-01-02T00:00:00.000Z"), minimumScore: 60 });
 
-    assert.ok(out.conversationTargetsById["job-1:auto-recruiter"]);
-    assert.ok(out.conversationTargetsById["job-1:auto-hiring-manager"]);
+    assert.ok(out.conversationTargetsById["job-1:auto-recruiter-needed"]);
+    assert.ok(out.conversationTargetsById["job-1:auto-hiring-manager-needed"]);
+    assert.equal(out.outreachSequences.length, 0);
+  });
+
+  it("generates drafts when at least one approved candidate exists", () => {
+    const job = makeJob("job-1", "Solutions Architect", "cloud distributed systems", "Acme");
+    const approvedTarget: ConversationTarget = {
+      id: "acme:recruiter-1", company: "Acme", name: "Jamie Recruiter", relationshipType: "recruiter", source: "manual", confidence: 90,
+      createdAt: "2026-01-01T00:00:00.000Z", updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    const { store: out } = generateConversationDraftsFromTopJobs({ store: baseStore([job], [approvedTarget]), now: new Date("2026-01-02T00:00:00.000Z"), minimumScore: 60 });
     assert.equal(out.outreachSequences.length >= 1, true);
   });
 

--- a/ui/partner-hub/lib/job-hunter/conversationAutomation.ts
+++ b/ui/partner-hub/lib/job-hunter/conversationAutomation.ts
@@ -18,6 +18,8 @@ export type ConversationAssets = {
 };
 
 export const DEFAULT_CONVERSATION_MINIMUM_SCORE = 70;
+const PLACEHOLDER_TARGET_NAMES = new Set(["Recruiter target needed", "Hiring manager target needed", "Employee/referral target needed"]);
+const isApprovedTarget = (target: ConversationTarget) => !PLACEHOLDER_TARGET_NAMES.has(target.name.trim());
 
 const logicalOutreachKey = (sequence: OutreachSequence) => `${sequence.jobId}:${sequence.contactId}:${sequence.stage}:${sequence.channel}`;
 
@@ -81,7 +83,10 @@ export const generateConversationAssetsForJobs = (params: {
 
     if (!brief) continue;
 
-    const queue = buildInitialOutreachQueueForJob({ job: row.job, brief, targets, existing: existingOutreach, now: params.now });
+    const approvedTargets = targets.filter(isApprovedTarget);
+    const queue = approvedTargets.length > 0
+      ? buildInitialOutreachQueueForJob({ job: row.job, brief, targets: approvedTargets, existing: existingOutreach, now: params.now })
+      : [];
     const seenLogicalKeys = new Set(existingOutreach.map(logicalOutreachKey));
 
     for (const draft of queue) {


### PR DESCRIPTION
### Motivation
- Ensure the "Start Outreach Pipeline" flow is usable from zero data by preventing the system from generating outreach drafts against placeholder targets and by documenting a guided start workflow to add a manual opportunity and candidates.

### Description
- Added a guard in `generateConversationAssetsForJobs` to skip building outreach drafts when only placeholder targets (e.g., “Recruiter target needed”) exist, and only generate when at least one approved/non-placeholder target is present (`ui/partner-hub/lib/job-hunter/conversationAutomation.ts`).
- Introduced a small helper set and predicate to recognize placeholder target names so placeholders can still be created and persisted but will not produce drafts until approved.
- Updated automation tests to reflect placeholder naming and behavior and to add a test that verifies drafts are generated when an approved candidate exists (`ui/partner-hub/lib/job-hunter/conversationAutomation.test.ts`).
- Added a Phase 7.1 cleanup issue doc that defines the guided start workflow, required UX steps, constraints (no external APIs/scraping/automation), and test expectations (`ui/partner-hub/docs/issues/phase-7-1-conversations-guided-start-cleanup.md`).

### Testing
- Updated unit tests: adjusted expectations for generated placeholder target names and added a test to ensure no drafts are produced for placeholder-only targets and that drafts are produced when an approved candidate exists; these test changes are in `conversationAutomation.test.ts` and were included with the patch.
- Ran `npm test` in the `ui/partner-hub` package which failed in this environment due to missing Node/Next typings and repository-wide type errors unrelated to the functional changes in this patch.
- Ran `npm run typecheck` which likewise failed due to missing framework/module typings and pre-existing type errors in the environment rather than the new logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27910bec08330957e57ae4a98bf13)