### PR TITLE
Add AI Workload Discovery Mapper tool and navigation entry

### DIFF
--- a/ui/partner-hub/app/(routes)/tools/workload-mapper/page.tsx
+++ b/ui/partner-hub/app/(routes)/tools/workload-mapper/page.tsx
@@ -1,0 +1,5 @@
+import { WorkloadMapper } from "@/components/workload-mapper/workload-mapper";
+
+export default function WorkloadMapperPage() {
+  return <WorkloadMapper />;
+}

--- a/ui/partner-hub/components/left-nav.tsx
+++ b/ui/partner-hub/components/left-nav.tsx
@@ -13,6 +13,7 @@ export function LeftNav() {
   const hpcLabEnabled = process.env.NEXT_PUBLIC_ENABLE_HPC_LAB === "true";
   const toolLinks = [
     { name: "Energy Tool", href: "/tools/energy" },
+    { name: "AI Workload Mapper", href: "/tools/workload-mapper" },
     ...(aiInterviewEnabled ? [{ name: "AI Interview", href: "/tools/interview" }] : []),
   ];
   const links = [

--- a/ui/partner-hub/components/workload-mapper/workload-mapper-data.ts
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper-data.ts
@@ -1,0 +1,37 @@
+import { SizingField, WorkloadTemplate } from "./workload-mapper-types";
+
+export const workloadLibrary: WorkloadTemplate[] = [
+  { id: "fraud", name: "Fraud Detection & Investigation", category: "FSI", description: "Detect anomalies quickly, investigate patterns, and improve fraud response confidence.", defaultPattern: "RAG", defaultPressurePoints: ["data ingestion velocity", "retrieval freshness", "governance and auditability"], assumptions: ["Near real-time event feeds", "Mixed structured and unstructured investigation artifacts"] },
+  { id: "risk", name: "Risk Modeling / Stress Testing", category: "FSI", description: "Run frequent portfolio stress analysis under evolving market conditions.", defaultPattern: "Analytics / ML pipeline", defaultPressurePoints: ["parallel data access", "scenario orchestration", "retention and lineage"], assumptions: ["Large historical data windows", "Compute spikes during quarterly stress cycles"] },
+  { id: "trading", name: "Trading / Quant Research", category: "FSI", description: "Accelerate alpha research and intraday strategy iteration.", defaultPattern: "Analytics / ML pipeline", defaultPressurePoints: ["low latency data access", "high query concurrency", "checkpointing"], assumptions: ["Time-series heavy", "High-frequency model refresh"] },
+  { id: "compliance", name: "Compliance / Document Intelligence", category: "FSI", description: "Extract obligations and evidence from policy and regulatory content.", defaultPattern: "RAG", defaultPressurePoints: ["embedding pipeline throughput", "explainability", "access controls"], assumptions: ["High-sensitivity documents", "Audit traceability is mandatory"] },
+  { id: "fsi-rag", name: "RAG Knowledge Assistant", category: "FSI", description: "Enable secure knowledge retrieval for relationship managers and operations teams.", defaultPattern: "RAG", defaultPressurePoints: ["retrieval freshness", "vector search consistency", "data residency"], assumptions: ["Many small documents", "Strict role-based access"] },
+  { id: "fsi-ft", name: "Model Training / Fine-tuning", category: "FSI", description: "Adapt domain models for financial language, risk, and client workflows.", defaultPattern: "Fine-tuning", defaultPressurePoints: ["GPU utilization", "checkpointing", "secure data staging"], assumptions: ["Controlled training datasets", "Periodic retraining cycles"] },
+  { id: "ai-training", name: "Large-scale AI Training", category: "HPC / AI", description: "Train foundation or domain models with distributed training at scale.", defaultPattern: "Training from scratch", defaultPressurePoints: ["GPU utilization", "checkpointing", "parallel data access"], assumptions: ["Large batch windows", "Sustained high throughput storage"] },
+  { id: "inference", name: "Inference Platform", category: "HPC / AI", description: "Serve interactive and API inference workloads with predictable latency.", defaultPattern: "Inference only", defaultPressurePoints: ["request concurrency", "model cache locality", "latency SLO adherence"], assumptions: ["Multi-tenant demand variability", "Autoscaling serving tiers"] },
+  { id: "simulation", name: "Scientific Simulation", category: "HPC / AI", description: "Execute numerically intense simulation runs and iterative experiments.", defaultPattern: "HPC simulation", defaultPressurePoints: ["parallel file access", "interconnect bandwidth", "job scheduling efficiency"], assumptions: ["Large temporary datasets", "Burst-like compute scheduling"] },
+  { id: "genomics", name: "Genomics / Life Sciences", category: "HPC / AI", description: "Process sequencing pipelines and AI-assisted analysis under compliance controls.", defaultPattern: "Analytics / ML pipeline", defaultPressurePoints: ["file/object explosion", "pipeline throughput", "data governance"], assumptions: ["Many small files", "Long retention for reproducibility"] },
+  { id: "media", name: "Media / Rendering Pipeline", category: "HPC / AI", description: "Run rendering and media enhancement pipelines with tight delivery timelines.", defaultPattern: "Inference only", defaultPressurePoints: ["throughput orchestration", "storage bandwidth", "deadline-driven scaling"], assumptions: ["Mixed file sizes", "High sustained ingest during production windows"] },
+];
+
+export const sizingFields: SizingField[] = [
+  { key: "exactDataVolume", label: "Exact data volume", whyItMatters: "Determines storage capacity, tiering strategy, and expected recovery windows." },
+  { key: "dailyIngestRate", label: "Daily ingest rate", whyItMatters: "Shapes ingestion architecture and write throughput requirements." },
+  { key: "fileObjectCount", label: "File/object count", whyItMatters: "Impacts metadata scaling, namespace performance, and indexing approach." },
+  { key: "queryConcurrency", label: "Query concurrency", whyItMatters: "Guides compute sizing and caching strategy for peak user demand." },
+  { key: "modelSize", label: "Model size", whyItMatters: "Influences memory footprint, model distribution, and serving pattern decisions." },
+  { key: "gpuRequirement", label: "GPU requirement", whyItMatters: "Defines accelerator class, scheduling policy, and power/cooling footprint." },
+  { key: "retentionPeriod", label: "Retention period", whyItMatters: "Establishes lifecycle policy, archival strategy, and compliance posture." },
+  { key: "haDrRequirements", label: "HA/DR requirements", whyItMatters: "Sets availability targets and cross-site architecture expectations." },
+  { key: "preferredVendors", label: "Preferred vendors", whyItMatters: "Highlights integration constraints and procurement dependencies early." },
+  { key: "budgetTimeline", label: "Budget/timeline", whyItMatters: "Aligns solution shape with delivery phases and implementation risk." },
+];
+
+export const architecturePatterns: Record<string, string[]> = {
+  RAG: ["Data Sources", "Ingestion / Normalization", "Feature + Embedding Pipeline", "High-Performance Data Platform", "Vector DB / Analytics Engine", "LLM / Model Serving", "Business Application"],
+  "Training from scratch": ["Data Lake + Curation", "Distributed Preprocessing", "High-Throughput Training Storage", "GPU Training Cluster", "Checkpoint & Artifact Registry", "Model Validation", "Model Registry"],
+  "Fine-tuning": ["Domain Dataset", "Data Quality + Labeling", "Fine-tuning Pipeline", "Accelerated Training", "Evaluation Harness", "Model Registry", "Deployment Targets"],
+  "Inference only": ["Application/API Gateway", "Request Orchestration", "Feature/Prompt Processing", "Model Serving Tier", "Caching + Session State", "Observability + Guardrails"],
+  "Analytics / ML pipeline": ["Data Sources", "Ingestion", "ETL/ELT + Feature Engineering", "Unified Data Platform", "ML/Analytics Execution", "BI / Decision Apps"],
+  "HPC simulation": ["Scientific Inputs", "Job Scheduler", "Parallel File/Data Platform", "HPC Compute Fabric", "Simulation Output Store", "Post-processing + Visualization"],
+};

--- a/ui/partner-hub/components/workload-mapper/workload-mapper-types.ts
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper-types.ts
@@ -1,0 +1,76 @@
+export type WorkloadCategory = "FSI" | "HPC / AI" | "Custom";
+
+export type AiPattern =
+  | "RAG"
+  | "Fine-tuning"
+  | "Training from scratch"
+  | "Inference only"
+  | "Analytics / ML pipeline"
+  | "HPC simulation"
+  | "Not sure yet";
+
+export type PerformanceTier = "real-time" | "near real-time" | "intraday" | "batch/end-of-day";
+
+export type SizingInputKey =
+  | "exactDataVolume"
+  | "dailyIngestRate"
+  | "fileObjectCount"
+  | "queryConcurrency"
+  | "modelSize"
+  | "gpuRequirement"
+  | "retentionPeriod"
+  | "haDrRequirements"
+  | "preferredVendors"
+  | "budgetTimeline";
+
+export interface WorkloadTemplate {
+  id: string;
+  name: string;
+  category: WorkloadCategory;
+  description: string;
+  defaultPattern: AiPattern;
+  defaultPressurePoints: string[];
+  assumptions: string[];
+}
+
+export interface WorkloadFormState {
+  workloadName: string;
+  selectedWorkloadId: string;
+  processImproved: string;
+  successCriteria: string;
+  aiPattern: AiPattern;
+  dataTypes: string[];
+  dataSizeRange: string;
+  dailyIngestRange: string;
+  filePattern: string;
+  freshnessRequirement: string;
+  performanceTier: PerformanceTier;
+  queryConcurrency: string;
+  gpuDependency: string;
+  latencyRequirement: string;
+  dataSensitivity: string;
+  auditTrail: string;
+  encryption: string;
+  dataResidency: string;
+  retention: string;
+  explainability: string;
+  accessControls: string;
+  sizingInputs: Record<SizingInputKey, string>;
+}
+
+export interface SizingField {
+  key: SizingInputKey;
+  label: string;
+  whyItMatters: string;
+}
+
+export interface WorkloadProfile {
+  classification: string;
+  pressurePoints: string[];
+  architectureSteps: string[];
+  buildingBlocks: Record<string, string[]>;
+  readinessPercent: number;
+  knownInputs: Array<{ label: string; value: string }>;
+  missingInputs: Array<{ label: string; whyItMatters: string }>;
+  talkTrack: string[];
+}

--- a/ui/partner-hub/components/workload-mapper/workload-mapper-utils.ts
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper-utils.ts
@@ -1,0 +1,65 @@
+import { architecturePatterns, sizingFields, workloadLibrary } from "./workload-mapper-data";
+import { WorkloadFormState, WorkloadProfile } from "./workload-mapper-types";
+
+const hasValue = (value: string) => value.trim().length > 0;
+
+export function getSelectedWorkload(selectedWorkloadId: string) {
+  return workloadLibrary.find((workload) => workload.id === selectedWorkloadId);
+}
+
+export function buildWorkloadProfile(state: WorkloadFormState): WorkloadProfile {
+  const selectedWorkload = getSelectedWorkload(state.selectedWorkloadId);
+  const sensitivity = state.dataSensitivity || "moderate-sensitivity";
+  const performance = state.performanceTier || "batch/end-of-day";
+  const pattern = state.aiPattern === "Not sure yet" ? selectedWorkload?.defaultPattern ?? "Analytics / ML pipeline" : state.aiPattern;
+
+  const classification = `${sensitivity}, ${performance} ${pattern} workload`;
+  const inferredPressurePoints = [
+    ...(selectedWorkload?.defaultPressurePoints ?? []),
+    ...(hasValue(state.dailyIngestRange) ? ["data ingestion velocity"] : []),
+    ...(hasValue(state.freshnessRequirement) ? ["retrieval freshness"] : []),
+    ...(hasValue(state.queryConcurrency) ? ["parallel data access"] : []),
+    ...(state.gpuDependency.toLowerCase().includes("high") ? ["GPU utilization"] : []),
+    ...(state.auditTrail.toLowerCase().includes("strict") ? ["governance and auditability"] : []),
+  ];
+
+  const pressurePoints = [...new Set(inferredPressurePoints)].slice(0, 7);
+  const architectureSteps = architecturePatterns[pattern] ?? architecturePatterns["Analytics / ML pipeline"];
+
+  const buildingBlocks: Record<string, string[]> = {
+    Compute: ["General compute cluster for orchestration", "Accelerated compute pool sized during design", "Autoscaling policy for peaks"],
+    "Storage / Data Platform": ["High-throughput primary data platform", "Object + file data tiering", "Snapshot and lifecycle management"],
+    Network: ["Low-latency east-west fabric", "Segmentation for sensitive data zones", "Performance telemetry for bottleneck isolation"],
+    "AI Software": ["Model lifecycle tooling", "Prompt/feature pipeline services", "Evaluation and observability controls"],
+    "Security / Governance": ["Encryption at rest and in transit", "Centralized audit logging", "Policy-based access controls and explainability workflow"],
+    Services: ["Architecture workshops", "Sizing and benchmark plan", "Operational readiness and runbook design"],
+  };
+
+  const knownInputs = sizingFields
+    .filter((field) => hasValue(state.sizingInputs[field.key]))
+    .map((field) => ({ label: field.label, value: state.sizingInputs[field.key] }));
+
+  const missingInputs = sizingFields
+    .filter((field) => !hasValue(state.sizingInputs[field.key]))
+    .map((field) => ({ label: field.label, whyItMatters: field.whyItMatters }));
+
+  const readinessPercent = Math.round((knownInputs.length / sizingFields.length) * 100);
+
+  const talkTrack = [
+    `We are mapping ${state.workloadName || selectedWorkload?.name || "this workload"} as a ${classification}.`,
+    `The main pressure points are ${pressurePoints.join(", ") || "to be validated during discovery"}, which shapes architecture priorities.`,
+    `Before any BOM proposal, we should close ${missingInputs.length} sizing gaps to reduce risk in performance, cost, and governance assumptions.`,
+    "This output is a discovery accelerant: it highlights likely building blocks and decision checkpoints, not an automatic BOM generator.",
+  ];
+
+  return {
+    classification,
+    pressurePoints,
+    architectureSteps,
+    buildingBlocks,
+    readinessPercent,
+    knownInputs,
+    missingInputs,
+    talkTrack,
+  };
+}

--- a/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { ReactNode, useMemo, useState } from "react";
+import { buildWorkloadProfile, getSelectedWorkload } from "./workload-mapper-utils";
+import { sizingFields, workloadLibrary } from "./workload-mapper-data";
+import { AiPattern, WorkloadFormState } from "./workload-mapper-types";
+
+const aiPatterns: AiPattern[] = ["RAG", "Fine-tuning", "Training from scratch", "Inference only", "Analytics / ML pipeline", "HPC simulation", "Not sure yet"];
+const dataTypeOptions = ["structured", "unstructured", "semi-structured", "streaming", "batch"];
+
+const initialState: WorkloadFormState = {
+  workloadName: "",
+  selectedWorkloadId: workloadLibrary[0]?.id ?? "",
+  processImproved: "",
+  successCriteria: "",
+  aiPattern: "Not sure yet",
+  dataTypes: [],
+  dataSizeRange: "",
+  dailyIngestRange: "",
+  filePattern: "",
+  freshnessRequirement: "",
+  performanceTier: "near real-time",
+  queryConcurrency: "",
+  gpuDependency: "Medium",
+  latencyRequirement: "",
+  dataSensitivity: "High-sensitivity",
+  auditTrail: "Strict",
+  encryption: "Required",
+  dataResidency: "Regional",
+  retention: "",
+  explainability: "Required",
+  accessControls: "RBAC + ABAC",
+  sizingInputs: {
+    exactDataVolume: "",
+    dailyIngestRate: "",
+    fileObjectCount: "",
+    queryConcurrency: "",
+    modelSize: "",
+    gpuRequirement: "",
+    retentionPeriod: "",
+    haDrRequirements: "",
+    preferredVendors: "",
+    budgetTimeline: "",
+  },
+};
+
+export function WorkloadMapper() {
+  const [state, setState] = useState<WorkloadFormState>(initialState);
+  const selected = getSelectedWorkload(state.selectedWorkloadId);
+
+  const profile = useMemo(() => buildWorkloadProfile(state), [state]);
+
+  return (
+    <div className="space-y-6 pb-10">
+      <section className="rounded-2xl border border-border/60 bg-gradient-to-r from-slate-50 to-white p-6 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground/50">AI Workload Discovery Mapper</p>
+        <h1 className="mt-2 text-3xl font-semibold">Story-first discovery from use case to BOM readiness</h1>
+        <p className="mt-3 max-w-4xl text-sm text-foreground/70">Use this framework to move from unfamiliar workload language into a repeatable architecture discovery motion: use case → pattern → data → pressure points → reference building blocks → BOM readiness gaps.</p>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-2">
+        <div className="space-y-6">
+          <Card title="Preloaded workload library + custom option">
+            <select className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm" value={state.selectedWorkloadId} onChange={(event) => setState((prev) => ({ ...prev, selectedWorkloadId: event.target.value, aiPattern: "Not sure yet" }))}>
+              {workloadLibrary.map((workload) => <option key={workload.id} value={workload.id}>{workload.category} — {workload.name}</option>)}
+              <option value="custom">Custom Workload</option>
+            </select>
+            <input className="mt-3 w-full rounded-md border border-border/70 px-3 py-2 text-sm" placeholder="Custom workload name (optional)" value={state.workloadName} onChange={(event) => setState((prev) => ({ ...prev, workloadName: event.target.value }))} />
+            {selected && <div className="mt-3 rounded-lg bg-muted/50 p-3 text-sm"><p className="font-semibold">{selected.description}</p><ul className="mt-2 list-disc space-y-1 pl-5 text-foreground/70">{selected.assumptions.map((a) => <li key={a}>{a}</li>)}</ul></div>}
+          </Card>
+
+          <Card title="Guided discovery questionnaire">
+            <div className="grid gap-3 md:grid-cols-2">
+              <Input label="Process/decision being improved" value={state.processImproved} onChange={(value) => setState((prev) => ({ ...prev, processImproved: value }))} />
+              <Input label="Success criteria" value={state.successCriteria} onChange={(value) => setState((prev) => ({ ...prev, successCriteria: value }))} />
+              <Select label="AI pattern" value={state.aiPattern} options={aiPatterns} onChange={(value) => setState((prev) => ({ ...prev, aiPattern: value as AiPattern }))} />
+              <Select label="Performance window" value={state.performanceTier} options={["real-time", "near real-time", "intraday", "batch/end-of-day"]} onChange={(value) => setState((prev) => ({ ...prev, performanceTier: value as WorkloadFormState["performanceTier"] }))} />
+              <Input label="Data size range" value={state.dataSizeRange} onChange={(value) => setState((prev) => ({ ...prev, dataSizeRange: value }))} />
+              <Input label="Daily ingest range" value={state.dailyIngestRange} onChange={(value) => setState((prev) => ({ ...prev, dailyIngestRange: value }))} />
+              <Input label="File/object pattern" value={state.filePattern} onChange={(value) => setState((prev) => ({ ...prev, filePattern: value }))} />
+              <Input label="Data freshness requirement" value={state.freshnessRequirement} onChange={(value) => setState((prev) => ({ ...prev, freshnessRequirement: value }))} />
+              <Input label="Query concurrency" value={state.queryConcurrency} onChange={(value) => setState((prev) => ({ ...prev, queryConcurrency: value, sizingInputs: { ...prev.sizingInputs, queryConcurrency: value } }))} />
+              <Input label="Latency requirement" value={state.latencyRequirement} onChange={(value) => setState((prev) => ({ ...prev, latencyRequirement: value }))} />
+            </div>
+            <div className="mt-3">
+              <p className="text-xs font-medium uppercase tracking-wide text-foreground/60">Data types</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {dataTypeOptions.map((option) => {
+                  const active = state.dataTypes.includes(option);
+                  return <button key={option} type="button" className={`rounded-full border px-3 py-1 text-xs ${active ? "border-primary bg-primary/10" : "border-border/60"}`} onClick={() => setState((prev) => ({ ...prev, dataTypes: active ? prev.dataTypes.filter((item) => item !== option) : [...prev.dataTypes, option] }))}>{option}</button>;
+                })}
+              </div>
+            </div>
+          </Card>
+
+          <Card title="BOM input capture">
+            <div className="grid gap-3 md:grid-cols-2">
+              {sizingFields.map((field) => <Input key={field.key} label={field.label} value={state.sizingInputs[field.key]} onChange={(value) => setState((prev) => ({ ...prev, sizingInputs: { ...prev.sizingInputs, [field.key]: value } }))} />)}
+            </div>
+          </Card>
+        </div>
+
+        <div className="space-y-6">
+          <Card title="Dynamic workload profile">
+            <p className="text-sm font-semibold text-foreground">{profile.classification}</p>
+            <p className="mt-2 text-sm text-foreground/70">Flow: Customer use case → Workload pattern → Data requirements → AI/model approach → Infrastructure pressure points → Reference architecture building blocks → BOM readiness gaps → Talk track.</p>
+          </Card>
+
+          <Card title="Architecture pattern output">
+            <div className="flex flex-wrap items-center gap-2">
+              {profile.architectureSteps.map((step, index) => (
+                <div key={step} className="flex items-center gap-2 text-xs">
+                  <span className="rounded-md border border-border/60 bg-muted/30 px-2 py-1">{step}</span>
+                  {index < profile.architectureSteps.length - 1 && <span className="text-foreground/40">→</span>}
+                </div>
+              ))}
+            </div>
+          </Card>
+
+          <Card title="Bottleneck / constraint mapping">
+            <ul className="space-y-2 text-sm">
+              {profile.pressurePoints.map((point) => <li key={point} className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2">{point}</li>)}
+            </ul>
+          </Card>
+
+          <Card title="Reference architecture building blocks">
+            <div className="grid gap-3 md:grid-cols-2">
+              {Object.entries(profile.buildingBlocks).map(([category, items]) => <div key={category} className="rounded-lg border border-border/60 p-3"><p className="text-sm font-semibold">{category}</p><ul className="mt-2 list-disc space-y-1 pl-5 text-xs text-foreground/70">{items.map((item) => <li key={item}>{item}</li>)}</ul></div>)}
+            </div>
+          </Card>
+
+          <Card title="BOM readiness & missing sizing inputs">
+            <div className="h-3 overflow-hidden rounded-full bg-muted"><div className="h-full bg-emerald-500" style={{ width: `${profile.readinessPercent}%` }} /></div>
+            <p className="mt-2 text-sm font-semibold">Readiness: {profile.readinessPercent}%</p>
+            <div className="mt-3 grid gap-4 md:grid-cols-2">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">Known inputs</p>
+                <ul className="mt-2 space-y-1 text-xs">{profile.knownInputs.map((input) => <li key={input.label}><span className="font-medium">{input.label}:</span> {input.value}</li>)}</ul>
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">Missing inputs + why they matter</p>
+                <ul className="mt-2 space-y-2 text-xs">{profile.missingInputs.map((input) => <li key={input.label} className="rounded-md border border-border/60 p-2"><p className="font-medium">{input.label}</p><p className="text-foreground/70">{input.whyItMatters}</p></li>)}</ul>
+              </div>
+            </div>
+          </Card>
+
+          <Card title="Executive / SE talk track + walkthrough mode">
+            <ol className="list-decimal space-y-2 pl-5 text-sm text-foreground/80">{profile.talkTrack.map((line) => <li key={line}>{line}</li>)}</ol>
+          </Card>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function Card({ title, children }: { title: string; children: ReactNode }) {
+  return <section className="rounded-2xl border border-border/60 bg-card p-4 shadow-sm"><h2 className="text-sm font-semibold uppercase tracking-wide text-foreground/60">{title}</h2><div className="mt-3">{children}</div></section>;
+}
+
+function Input({ label, value, onChange }: { label: string; value: string; onChange: (value: string) => void }) {
+  return <label className="text-xs font-medium text-foreground/70">{label}<input className="mt-1 w-full rounded-md border border-border/70 px-2 py-2 text-sm" value={value} onChange={(event) => onChange(event.target.value)} /></label>;
+}
+
+function Select({ label, value, options, onChange }: { label: string; value: string; options: string[]; onChange: (value: string) => void }) {
+  return <label className="text-xs font-medium text-foreground/70">{label}<select className="mt-1 w-full rounded-md border border-border/70 bg-background px-2 py-2 text-sm" value={value} onChange={(event) => onChange(event.target.value)}>{options.map((option) => <option key={option} value={option}>{option}</option>)}</select></label>;
+}


### PR DESCRIPTION
### Motivation
- Provide a repeatable, consultant-grade discovery tool to map unfamiliar workloads from use case through BOM readiness for AI, HPC, and FSI scenarios. 
- Surface architecture patterns, pressure points, building blocks and missing sizing inputs so teams can run structured discovery without producing an automatic/false BOM.

### Description
- Add a new App Router page at `/tools/workload-mapper` that renders a client-side `WorkloadMapper` experience. 
- Add a maintainable workload feature set implemented as typed modules: `workload-mapper.tsx` (UI), `workload-mapper-data.ts` (preloaded FSI and HPC/AI templates + sizing fields + architecture patterns), `workload-mapper-types.ts` (TypeScript types), and `workload-mapper-utils.ts` (pure profile derivation logic). 
- Update left navigation (`LeftNav`) to include the `AI Workload Mapper` entry pointing to `/tools/workload-mapper`. 
- The tool is deliberately purely client-side, avoids external API calls, avoids claiming exact vendor SKUs / GPU counts, and presents readiness as guidance, not an automatic BOM.

### Testing
- In `ui/partner-hub` ran `npm run lint` which failed in the environment with `next: not found` (tooling not installed in this run). 
- Ran `npm run typecheck` which surfaced pre-existing type/dependency resolution errors in the repository (missing type packages and environment assumptions). 
- Ran `npm test -- --runInBand` which failed due to the same pre-existing dependency/type resolution issues. 
- Ran `npm run build` which failed in `prebuild` because `prisma: not found` in the environment; these failures are environment/tooling related and not caused by the new workload-mapper code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3437ef540833090519b1446d37266)