### PR TITLE
Replace CHIP-8 and Steam Trains with AI Workload Mapper

### DIFF
--- a/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
@@ -44,11 +44,11 @@ interface InputProps {
   onChange: (value: string) => void;
 }
 
-interface SelectProps {
+interface SelectProps<T extends string> {
   label: string;
-  value: string;
-  options: string[];
-  onChange: (value: string) => void;
+  value: T;
+  options: readonly T[];
+  onChange: (value: T) => void;
 }
 
 interface MultiSelectChipsProps {
@@ -264,7 +264,7 @@ function CustomWorkloadFields({
   };
 
   const handlePatternChange = (value: string) => {
-    onStateChange((previousState) => ({ ...previousState, aiPattern: value as AiPattern }));
+    onStateChange((previousState) => ({ ...previousState, aiPattern: value }));
   };
 
   return (
@@ -294,7 +294,7 @@ function CustomWorkloadFields({
 
 function DiscoveryQuestionnaire({ state, onStateChange }: WorkloadStateProps) {
   const handlePatternChange = (value: string) => {
-    onStateChange((previousState) => ({ ...previousState, aiPattern: value as AiPattern }));
+    onStateChange((previousState) => ({ ...previousState, aiPattern: value }));
   };
 
   return (
@@ -322,7 +322,7 @@ function DiscoveryQuestionnaire({ state, onStateChange }: WorkloadStateProps) {
             value={state.performanceTier}
             options={["real-time", "near real-time", "intraday", "batch/end-of-day"]}
             onChange={(value) =>
-              onStateChange((p) => ({ ...p, performanceTier: value as WorkloadFormState["performanceTier"] }))
+              onStateChange((p) => ({ ...p, performanceTier: value }))
             }
           />
           <Input
@@ -600,7 +600,7 @@ function Input({ label, value, onChange }: InputProps) {
   );
 }
 
-function Select({ label, value, options, onChange }: SelectProps) {
+function Select<T extends string>({ label, value, options, onChange }: SelectProps<T>) {
   return (
     <label className="text-xs font-medium text-foreground/70">
       {label}


### PR DESCRIPTION
### Motivation
- Remove legacy CHIP-8 and Steam Trains artifacts and ensure the AI Workload Discovery Mapper is the canonical tool under `/tools/workload-mapper` with correct routing and navigation.
- Verify there are no stale working-tree references to CHIP-8 or Steam Trains after the merge and that no accidental routes/pages remain.
- Apply minimal TypeScript hygiene to eliminate avoidable `any`/casts in the workload mapper component without adding features.

### Description
- Performed a repository-wide stale-reference scan with `rg -i "chip-?8|steam[- ]?trains" . || true` and found no working-tree matches, confirming CHIP-8 and Steam Trains code was removed.
- Verified route and page: `/tools/workload-mapper` is present at `ui/partner-hub/app/(routes)/tools/workload-mapper/page.tsx` and there are no active `/tools/chip8` or `/tools/steam-trains` routes/pages.
- Left navigation now includes `AI Workload Mapper` and does not include `CHIP-8` or `Steam Trains` (see `ui/partner-hub/components/left-nav.tsx`).
- Made a small TypeScript improvement in `ui/partner-hub/components/workload-mapper/workload-mapper.tsx` to tighten `Select` typing (`SelectProps<T extends string>`) and removed avoidable `as` assertions in handlers; no behavioral changes or feature additions.

### Testing
- Ran the stale-reference scan `rg -i "chip-?8|steam[- ]?trains" . || true` which returned no matches, confirming no stale references remain.
- Executed validation commands in `ui/partner-hub`: `npm run lint` failed with `next: not found`, `npm run typecheck` failed with pre-existing missing module/type errors (e.g., `next/*`, `react`, `node:*`), `npm test -- --runInBand` failed due to the same environment/dependency/type-resolution issues, and `npm run build` failed in prebuild because `prisma` was not found; these failures appear environment/dependency-related and not caused by this change.
- Cleaned transient test artifacts created during local typecheck (`.tmp-tests`/`tsconfig.tsbuildinfo`) and committed the TypeScript cleanup with commit message `Tighten workload mapper select typing` affecting `workload-mapper.tsx`.
- No automated test suite changes were made and no tests were added; the attempted `typecheck`/`test` runs surfaced existing project-wide environment/type issues rather than regressions introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34ca2c23c8330b17f83d53e6abbd2)