### PR TITLE
Add Ollama-powered plain‑English workload summarization to Workload Mapper

### DIFF
--- a/ui/partner-hub/app/api/workload-mapper/summarize/route.ts
+++ b/ui/partner-hub/app/api/workload-mapper/summarize/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+
+import { buildSummarizePrompt } from "@/lib/workload-mapper/summarize-prompt";
+import type { WorkloadSummaryRequest, WorkloadSummaryResponse } from "@/lib/workload-mapper/summarize-types";
+
+const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL ?? "http://localhost:11434";
+const OLLAMA_MODEL = process.env.OLLAMA_MODEL ?? "llama3.1";
+const OLLAMA_ERROR = "Could not reach local Ollama. Make sure Ollama is running and the configured model is available.";
+
+interface OllamaChatResponse {
+  message?: { content?: string };
+}
+
+export async function POST(request: Request) {
+  let payload: WorkloadSummaryRequest;
+  try {
+    payload = (await request.json()) as WorkloadSummaryRequest;
+  } catch {
+    return NextResponse.json({ error: "Invalid request payload." }, { status: 400 });
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 30000);
+
+  try {
+    const response = await fetch(`${OLLAMA_BASE_URL}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      signal: controller.signal,
+      body: JSON.stringify({
+        model: OLLAMA_MODEL,
+        stream: false,
+        messages: [{ role: "user", content: buildSummarizePrompt(payload) }],
+      }),
+    });
+
+    if (!response.ok) {
+      return NextResponse.json({ error: OLLAMA_ERROR }, { status: 502 });
+    }
+
+    const data = (await response.json()) as OllamaChatResponse;
+    const summary = data.message?.content?.trim();
+    if (!summary) {
+      return NextResponse.json({ error: "Local Ollama returned an empty or malformed response." }, { status: 502 });
+    }
+
+    const result: WorkloadSummaryResponse = { summary };
+    return NextResponse.json(result);
+  } catch {
+    return NextResponse.json({ error: OLLAMA_ERROR }, { status: 502 });
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
@@ -2,6 +2,9 @@
 
 import { type Dispatch, type ReactNode, type SetStateAction, useMemo, useState } from "react";
 
+import type { WorkloadSummaryRequest } from "@/lib/workload-mapper/summarize-types";
+import { toSelectionContext } from "@/lib/workload-mapper/summarize-types";
+
 import { sizingFields, workloadExamplePresets, workloadLibrary } from "./workload-mapper-data";
 import { buildWorkloadProfile, getSelectedWorkload } from "./workload-mapper-utils";
 import { type AiPattern, type WorkloadFormState } from "./workload-mapper-types";
@@ -113,6 +116,9 @@ export function WorkloadMapper() {
   const [customDescription, setCustomDescription] = useState("");
   const [customAssumptions, setCustomAssumptions] = useState("");
   const [customPressurePoints, setCustomPressurePoints] = useState("");
+  const [summary, setSummary] = useState("");
+  const [summaryError, setSummaryError] = useState("");
+  const [isSummarizing, setIsSummarizing] = useState(false);
 
   const isCustom = state.selectedWorkloadId === "custom";
   const selected = getSelectedWorkload(state.selectedWorkloadId);
@@ -134,6 +140,49 @@ export function WorkloadMapper() {
       ),
     [state, isCustom, customCategory, customDescription, customAssumptions, customPressurePoints],
   );
+
+
+  const summarizeWorkload = async () => {
+    setIsSummarizing(true);
+    setSummaryError("");
+    try {
+      const payload: WorkloadSummaryRequest = {
+        workload: toSelectionContext(selected, state, {
+          category: customCategory,
+          description: customDescription,
+          assumptions: customAssumptions,
+          pressurePoints: customPressurePoints,
+        }),
+        customWorkload: {
+          category: customCategory,
+          description: customDescription,
+          assumptions: customAssumptions,
+          pressurePoints: customPressurePoints,
+        },
+        questionnaire: state,
+        knownInputs: profile.knownInputs,
+        missingInputs: profile.missingInputs,
+        architecturePipeline: profile.architectureSteps,
+        buildingBlocks: profile.buildingBlocks,
+      };
+
+      const response = await fetch("/api/workload-mapper/summarize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = (await response.json()) as { summary?: string; error?: string };
+      if (!response.ok || !data.summary) {
+        throw new Error(data.error || "Could not generate summary.");
+      }
+      setSummary(data.summary);
+    } catch (error) {
+      setSummary("");
+      setSummaryError(error instanceof Error ? error.message : "Could not generate summary.");
+    } finally {
+      setIsSummarizing(false);
+    }
+  };
 
   const applyWorkloadExamplePreset = () => {
     const preset = workloadExamplePresets[state.selectedWorkloadId] ?? (isCustom ? workloadExamplePresets.custom : undefined);
@@ -203,6 +252,7 @@ export function WorkloadMapper() {
             <BuildingBlocks blocks={profile.buildingBlocks} />
             <BomReadinessCard profile={profile} />
             <TalkTrackCard profile={profile} />
+            <SummarizeCard summary={summary} error={summaryError} loading={isSummarizing} onSummarize={summarizeWorkload} />
           </div>
         </section>
       )}
@@ -604,6 +654,51 @@ function TalkTrackCard({ profile }: { profile: ReturnType<typeof buildWorkloadPr
           <li key={line}>• {line}</li>
         ))}
       </ul>
+    </Card>
+  );
+}
+
+
+function SummarizeCard({
+  summary,
+  error,
+  loading,
+  onSummarize,
+}: {
+  summary: string;
+  error: string;
+  loading: boolean;
+  onSummarize: () => Promise<void>;
+}) {
+  const copySummary = async () => {
+    if (!summary) return;
+    await navigator.clipboard.writeText(summary);
+  };
+
+  return (
+    <Card title="Summarize">
+      <p className="mb-3 text-xs text-foreground/70">
+        Summary generation uses the local Ollama model configured for this app. Discovery inputs are sent only to the
+        local summarization endpoint.
+      </p>
+      <button type="button" className="rounded-md border px-3 py-2 text-sm font-medium" onClick={onSummarize} disabled={loading}>
+        {loading ? "Generating summary..." : "Summarize workload in plain English"}
+      </button>
+      {error ? (
+        <div className="mt-3 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+          <p>{error}</p>
+          <p className="mt-2 text-xs">Try: <code>ollama serve</code> and <code>ollama pull &lt;model&gt;</code></p>
+        </div>
+      ) : null}
+      {summary ? (
+        <div className="mt-3 rounded-md border border-border/70 bg-muted/20 p-3">
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <h3 className="text-sm font-semibold">Plain-English Workload Summary</h3>
+            <button type="button" className="rounded-md border px-2 py-1 text-xs" onClick={copySummary}>Copy Summary</button>
+          </div>
+          <p className="whitespace-pre-wrap text-sm text-foreground/90">{summary}</p>
+        </div>
+      ) : null}
     </Card>
   );
 }

--- a/ui/partner-hub/lib/workload-mapper/summarize-prompt.ts
+++ b/ui/partner-hub/lib/workload-mapper/summarize-prompt.ts
@@ -1,0 +1,39 @@
+import type { WorkloadSummaryRequest } from "./summarize-types";
+
+const workloadBusinessHints: Record<string, string> = {
+  fraud: "Focus on reducing fraud exposure, speeding investigations, and improving decision confidence.",
+  "risk-modeling": "Focus on understanding portfolio exposure, regulatory readiness, and scenario impact faster.",
+  trading: "Focus on finding and validating trading strategies faster.",
+  compliance: "Focus on reducing manual review effort and improving audit/regulatory response.",
+  rag: "Focus on helping employees find trusted answers faster.",
+  "model-finetune": "Focus on adapting models to domain language/processes and improving task quality under governance.",
+  "ai-training": "Focus on building differentiated AI capabilities or domain models.",
+  inference: "Focus on serving AI capabilities reliably to users/apps with predictable latency.",
+  simulation: "Focus on completing simulations faster and shortening time from run to insight.",
+  genomics: "Focus on improving sample/pipeline turnaround while preserving traceability.",
+  media: "Focus on delivering creative/rendering work faster under deadline pressure.",
+};
+
+export function buildSummarizePrompt(input: WorkloadSummaryRequest): string {
+  const hint = input.workload.isCustom
+    ? "Infer business context from custom workload name, description, process improved, and success criteria."
+    : workloadBusinessHints[input.workload.id] ?? "Use the workload details to infer the likely business driver.";
+
+  return [
+    "You are a solutions engineer writing to a sales counterpart.",
+    "Write a plain-English workload summary using only the provided data.",
+    "Start with the business reason this workload exists.",
+    "Then explain what the customer is trying to accomplish.",
+    "Then explain what the environment needs to support technically.",
+    "Then explain what information is missing and why it matters.",
+    "Do not use vendor pitch language.",
+    "Do not sound like an interview answer.",
+    "Keep jargon light; if jargon is needed, explain it simply.",
+    "Do not invent facts beyond the provided fields.",
+    "Call out missing fields clearly.",
+    `Workload business framing hint: ${hint}`,
+    "Respond in 3-5 short paragraphs.",
+    "\nStructured workload context:\n",
+    JSON.stringify(input, null, 2),
+  ].join("\n");
+}

--- a/ui/partner-hub/lib/workload-mapper/summarize-types.ts
+++ b/ui/partner-hub/lib/workload-mapper/summarize-types.ts
@@ -1,0 +1,43 @@
+import type { WorkloadFormState, WorkloadTemplate } from "@/components/workload-mapper/workload-mapper-types";
+
+export interface WorkloadSelectionContext {
+  id: string;
+  name: string;
+  category: string;
+  description: string;
+  assumptions?: string;
+  pressurePoints?: string;
+  isCustom: boolean;
+}
+
+export interface WorkloadSummaryRequest {
+  workload: WorkloadSelectionContext;
+  customWorkload: {
+    category: string;
+    description: string;
+    assumptions: string;
+    pressurePoints: string;
+  };
+  questionnaire: WorkloadFormState;
+  knownInputs: Array<{ label: string; value: string }>;
+  missingInputs: Array<{ label: string; whyItMatters: string }>;
+  architecturePipeline: string[];
+  buildingBlocks: Record<string, string[]>;
+}
+
+export interface WorkloadSummaryResponse {
+  summary: string;
+}
+
+export function toSelectionContext(selected: WorkloadTemplate | undefined, state: WorkloadFormState, custom: WorkloadSummaryRequest["customWorkload"]): WorkloadSelectionContext {
+  const isCustom = state.selectedWorkloadId === "custom";
+  return {
+    id: isCustom ? "custom" : state.selectedWorkloadId,
+    name: isCustom ? state.workloadName || "Custom workload" : selected?.name || "Unknown workload",
+    category: isCustom ? custom.category : selected?.category || "Unknown",
+    description: isCustom ? custom.description : selected?.description || "",
+    assumptions: isCustom ? custom.assumptions : selected?.assumptions.join(", "),
+    pressurePoints: isCustom ? custom.pressurePoints : selected?.defaultPressurePoints.join(", "),
+    isCustom,
+  };
+}


### PR DESCRIPTION
### Motivation
- Provide a local LLM–powered, sales-friendly plain‑English summary for completed discovery questionnaires using a local Ollama model while keeping model config and calls server‑side.
- Surface business-first framing, technical needs, and missing information clearly so an SE can share a concise workload synopsis with sales.

### Description
- Add a Next.js server API route at `POST /api/workload-mapper/summarize` that proxies summarization requests to the local Ollama `/api/chat` endpoint with `OLLAMA_BASE_URL` and `OLLAMA_MODEL` server‑side defaults, a 30s timeout, and robust non‑200/malformed response handling.
- Add strongly typed payload/response models and a `toSelectionContext` helper in `lib/workload-mapper/summarize-types.ts` to build a structured request that includes selected workload metadata, questionnaire state, known/missing BOM inputs, architecture pipeline, and building blocks.
- Add a prompt builder in `lib/workload-mapper/summarize-prompt.ts` that encodes workload-aware business framing hints and explicit instructions to produce a business‑first, plain‑English SE‑style summary that calls out missing fields and avoids vendor pitch or invented facts.
- Extend the Workload Mapper UI with a Summarize card and components in `components/workload-mapper/workload-mapper.tsx` that add a `Summarize workload in plain English` button, loading state, plain‑English summary output card titled `Plain-English Workload Summary`, a `Copy Summary` action, a local‑only privacy note, and a clear Ollama unreachable/error message with `ollama serve` / `ollama pull <model>` hints.

### Testing
- Ran `npm run lint` which failed because `next` is not available in this environment (`next: not found`).
- Attempted `npm ci` which failed due to npm registry access (`403 Forbidden`), so dependencies could not be installed and subsequent commands could not run fully.
- Ran `npm run typecheck` which reported many missing modules/types due to the absent dependency install, so typechecking could not be completed in this environment.
- Attempted `npm test -- --runInBand` and `npm run build` which could not complete for the same dependency/tooling limitations, and `rg -i "chip-?8|steam[- ]?trains" .` returned no matches added by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38df7e7cc83309d8fcaf517992db5)