### PR TITLE
Fix workload summarizer API URL for Next.js basePath

### DIFF
--- a/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
@@ -166,14 +166,25 @@ export function WorkloadMapper() {
         buildingBlocks: profile.buildingBlocks,
       };
 
-      const response = await fetch("/api/workload-mapper/summarize", {
+      const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+      const response = await fetch(`${basePath}/api/workload-mapper/summarize`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
       });
-      const data = (await response.json()) as { summary?: string; error?: string };
-      if (!response.ok || !data.summary) {
-        throw new Error(data.error || "Could not generate summary.");
+      const responseText = await response.text();
+      let data: { summary?: string; error?: string } | null = null;
+
+      try {
+        data = JSON.parse(responseText) as { summary?: string; error?: string };
+      } catch {
+        throw new Error(
+          "Summarizer endpoint returned a non-JSON response. Check the API route/basePath configuration.",
+        );
+      }
+
+      if (!response.ok || !data?.summary) {
+        throw new Error(data?.error || "Could not generate summary.");
       }
       setSummary(data.summary);
     } catch (error) {


### PR DESCRIPTION
### Motivation
- The workload summarizer was calling a root-relative API (`/api/workload-mapper/summarize`) which breaks when the app is served under a Next.js `basePath` (e.g. `/partner-hub`), causing HTML responses and the `Unexpected token '<'` JSON parse error. 
- Improve client-side diagnostics when the summarizer endpoint returns non-JSON (HTML) so the UI surface provides a clear hint about `basePath`/API misconfiguration.

### Description
- Use the configured base path by prepending `process.env.NEXT_PUBLIC_BASE_PATH || ""` to the fetch URL so requests go to ``${basePath}/api/workload-mapper/summarize`` instead of a hardcoded `/api/...`.
- Read the response with `response.text()` first and attempt `JSON.parse(...)` inside a `try/catch`, throwing a clear error message when parsing fails to surface non-JSON responses.
- Preserve existing behavior for success/error flows and only change client-side request construction and error handling.
- Changed file: `ui/partner-hub/components/workload-mapper/workload-mapper.tsx`.

### Testing
- Ran `npm run lint` in the partner-hub workspace, which failed in this environment due to the missing `next` binary (pre-existing environment limitation).
- Ran `npm run typecheck`, which failed with many pre-existing missing dependency/type errors (missing `next`, `react`, node typings, etc.).
- Ran `npm test -- --runInBand`, which failed in this environment due to missing test/typing dependencies; unit test run could not complete here.
- Ran `npm run build`, which failed in this environment because the `prisma` binary is not available.
- Searched for test token strings with `rg -i "chip-?8|steam[- ]?trains" .` which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f391b006e08330b8f04d558b525b13)