### PR TITLE
Improve Workload Mapper summary prompt for business-first, known-vs-missing output

### DIFF
--- a/ui/partner-hub/lib/workload-mapper/summarize-prompt.ts
+++ b/ui/partner-hub/lib/workload-mapper/summarize-prompt.ts
@@ -19,21 +19,40 @@ export function buildSummarizePrompt(input: WorkloadSummaryRequest): string {
     ? "Infer business context from custom workload name, description, process improved, and success criteria."
     : workloadBusinessHints[input.workload.id] ?? "Use the workload details to infer the likely business driver.";
 
+  const knownFields = input.knownInputs
+    .filter((item) => item.value && item.value.trim().length > 0)
+    .map((item) => `${item.label}: ${item.value.trim()}`);
+
+  const missingFields = input.missingInputs.map((item) => `${item.label}: ${item.whyItMatters.trim()}`);
+
   return [
     "You are a solutions engineer writing to a sales counterpart.",
     "Write a plain-English workload summary using only the provided data.",
+    "Write natural paragraphs, not a rigid report format unless the user data is extremely sparse.",
     "Start with the business reason this workload exists.",
     "Then explain what the customer is trying to accomplish.",
     "Then explain what the environment needs to support technically.",
     "Then explain what information is missing and why it matters.",
+    "Tie business intent to technical requirements with clear cause/effect statements (example: because the team needs faster fraud decisions, the platform needs near-real-time ingest and fast retrieval of case context).",
     "Do not use vendor pitch language.",
     "Do not sound like an interview answer.",
+    "Use a helpful, plain-English tone for a sales counterpart.",
     "Keep jargon light; if jargon is needed, explain it simply.",
     "Do not invent facts beyond the provided fields.",
-    "Call out missing fields clearly.",
+    "Use populated fields directly and specifically.",
+    "Avoid generic filler phrases like 'scalable environment' unless you explain what must scale and why.",
+    "Only list a field as missing when it is truly blank, empty, unknown, TBD, or absent.",
+    "If a field has a value in the structured context or known fields, treat it as known and use it.",
+    "Do not claim category, governance, AI pattern, performance, or data details are missing when values are present.",
+    "Do not output lines like: 'The category seems to be Custom but is not clearly explained' unless custom was selected and the relevant custom fields are actually blank.",
+    "Call out missing fields clearly when they are truly missing.",
     `Workload business framing hint: ${hint}`,
     "Use the workload business framing hint as context, but prioritize the actual field values provided by the user.",
     "Respond in 3-5 short paragraphs.",
+    "\nKnown fields (treat as populated facts):\n",
+    knownFields.length > 0 ? knownFields.join("\n") : "None provided.",
+    "\nMissing fields (only these are currently known gaps):\n",
+    missingFields.length > 0 ? missingFields.join("\n") : "None currently flagged.",
     "\nStructured workload context:\n",
     JSON.stringify(input, null, 2),
   ].join("\n");


### PR DESCRIPTION
### Motivation
- Make the Ollama-generated plain-English workload summary read like a helpful SE note for a sales counterpart by prioritizing business intent and natural paragraph flow.
- Reduce robotic or incorrect "missing information" claims by ensuring the model treats populated structured fields as known facts and only flags truly absent/empty/TBD values.
- Strengthen the business-to-technical connection so summaries state clear cause/effect (e.g., business need -> specific technical requirement).

### Description
- Updated the prompt in `ui/partner-hub/lib/workload-mapper/summarize-prompt.ts` to instruct the model to use natural paragraphs and start with the business reason, then customer objective, technical needs, and only then missing info.
- Added `knownFields` and `missingFields` derived from `input.knownInputs` and `input.missingInputs` and included compact `Known fields` and `Missing fields` sections in the prompt so the model can reliably differentiate populated vs missing values.
- Added explicit rules to use populated fields directly, avoid generic filler language, and only list a field as missing when it is truly blank/empty/unknown/TBD/absent, with anti-pattern guidance to prevent fabricated missing statements (e.g., category/governance/AI pattern claims).
- Added guidance to tie business intent to technical requirements with concrete cause/effect phrasing and to favor the structured context over the hint when conflicts arise.

### Testing
- Ran `rg -i "chip-?8|steam[- ]?trains" . || true` which passed and returned no matches for stale references.
- Attempted `npm run lint` at repo root which failed because no root `package.json` exists in this environment.
- Ran `npm run lint`, `npm run typecheck`, and `npm test -- --runInBand` in `ui/partner-hub` which all failed in this environment due to missing dev tooling/dependencies (e.g., `next`, `react`, `node:test` types) and thus could not complete here.
- Attempted `npm run build` in `ui/partner-hub` which failed due to missing `prisma` binary in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3980d2d1083308e8001595b904388)