### PR TITLE
Refine BOM summary prompt into narrative DDN-informed architecture format

### DIFF
--- a/ui/partner-hub/lib/workload-mapper/bom-summary-prompt.ts
+++ b/ui/partner-hub/lib/workload-mapper/bom-summary-prompt.ts
@@ -1,29 +1,33 @@
 import type { BomSummaryRequest } from "./summarize-types";
 
 export function buildBomSummaryPrompt(input: BomSummaryRequest): string {
+  const bomSummaryContext = {
+    workload: input.workload,
+    customWorkload: input.customWorkload,
+    questionnaire: input.questionnaire,
+    knownInputs: input.knownInputs,
+    missingInputs: input.missingInputs,
+    ddnReferencePattern: input.ddnReferencePattern,
+  };
+
   return [
     "You are generating a BOM-readiness architecture summary for an AI workload discovery workflow.",
     "Use only the provided structured input and write in plain English.",
     "Opening disclaimer must be exactly:",
     "This is not a final BOM. It is a DDN-informed architecture mapping based on the current workload inputs.",
-    "Treat ddnReferencePattern.buildingBlocks as the PRIMARY building block list whenever it is present.",
-    "If DDN-informed building blocks are available, do NOT default to generic profile-category headings.",
-    "Do NOT use generic headings like Compute, Storage / Data Platform, Network, AI Software, Security / Governance, Services as the main building blocks when more specific DDN-informed building blocks exist.",
-    "Start with a short 'closest pattern' paragraph that uses captured values directly and explicitly includes exact values when available (data volume, daily ingest rate, file/object count, query concurrency, model size, GPU requirement, retention period, HA/DR requirements, latency requirement, performance tier, governance/security fields).",
-    "Then provide building blocks in the same order as ddnReferencePattern.buildingBlocks (or a clear DDN-informed equivalent only if a block name needs minor wording normalization).",
-    "For EACH building block, include all four items:",
-    "1) what it does",
-    "2) why this workload needs it",
-    "3) which captured input values point to it (cite concrete captured values directly)",
-    "4) what should be validated before an actual BOM",
-    "Write this like a detailed architecture/BOM-readiness explanation, not a generic report.",
-    "If the workload resembles Fraud Detection & Investigation, prefer concrete blocks such as unified fraud ingestion, high-throughput low-latency active data platform, metadata/indexing, anomaly detection and scoring, real-time inference, investigator context/retrieval, governance/security/compliance, HA/DR replication, and performance validation/benchmark planning when those blocks are present in ddnReferencePattern.buildingBlocks.",
-    "After the building-block explanations, include a concise 'Validation before BOM' section that consolidates key validation checks across latency, ingest burst behavior, active footprint, metadata/index profile, concurrency, model serving, and HA/DR continuity targets using captured values.",
     "End with this exact closing note:",
     "This is an example starting point based on current DDN public reference architecture and platform themes. Actual sizing and final BOM require DDN/customer-specific validation, benchmark expectations, and constraints.",
+    "Treat ddnReferencePattern.buildingBlocks as the primary source for solution-shape building blocks whenever present.",
+    "Synthesize those building blocks into cohesive architecture paragraphs, and combine closely related blocks when it reads naturally.",
+    "Do NOT render the response as a field-by-field dump, checklist, or reference-map object.",
+    "Do NOT use repeated labels/headings like 'What it does', 'Why it fits', 'Captured input signals', or 'Validation questions'.",
+    "Do NOT expose internal field names from the payload. Use captured values naturally in sentences (for example, describe ingest rates, concurrency, model ranges, retention, latency, governance, and HA/DR expectations in plain language).",
+    "Start with a concise closest-pattern paragraph that explicitly uses concrete captured values when available.",
+    "Then explain the DDN-informed architecture building blocks as narrative paragraphs in the same overall sequence as ddnReferencePattern.buildingBlocks.",
+    "Include validation needs naturally in the narrative and finish with a concise final validation paragraph before the closing note.",
     "Guardrails: Do NOT output an actual BOM, exact SKU recommendations, node counts, GPU counts, pricing, quotes, or final sizing.",
     "Do not claim official one-to-one DDN BOM mapping certainty.",
     "Structured context:",
-    JSON.stringify(input, null, 2),
+    JSON.stringify(bomSummaryContext, null, 2),
   ].join("\n");
 }


### PR DESCRIPTION
### Motivation
- The BOM summary output currently reads like a raw dump of prompt fields and reference-map objects instead of a synthesized DDN-informed solution architecture narrative. 
- The goal is to force the summarizer to produce cohesive architecture paragraphs, use captured values naturally in sentences, and avoid exposing internal payload field names or repeated mechanical labels. 
- The change preserves the required opening disclaimer and closing note while tightening the prompt to reduce noisy profile/object dumps.

### Description
- Rewrote the BOM prompt in `ui/partner-hub/lib/workload-mapper/bom-summary-prompt.ts` to synthesize DDN-informed building blocks into narrative paragraphs rather than field-by-field lists. 
- Limited the serialized structured context sent to the LLM to a `bomSummaryContext` object containing only `workload`, `customWorkload`, `questionnaire`, `knownInputs`, `missingInputs`, and `ddnReferencePattern` to avoid leaking generic profile blocks. 
- Added explicit instructions that prohibit repeated labels such as "What it does", "Why it fits", "Captured input signals", and "Validation questions", and forbid exposing internal field names while requiring captured values to be used naturally. 
- Kept guardrails intact to prevent generation of any final BOM/sku/node/GPU/pricing/quoting/sizing content and required the exact opening disclaimer and closing note.

### Testing
- Ran `npm run lint` (in `ui/partner-hub`) which failed in this environment because `next` is not available (`sh: 1: next: not found`).
- Ran `npm run typecheck` (in `ui/partner-hub`) which failed due to missing project dependencies and type declarations (e.g., `next`, `react`, Node typings). 
- Ran `npm test -- --runInBand` (in `ui/partner-hub`) which failed due to missing test/Node typings and other environment dependencies. 
- Ran `npm run build` (in `ui/partner-hub`) which failed during prebuild because `prisma` is not available in this environment. 
- Searched for stale references with `rg -i "chip-?8|steam[- ]?trains" . || true` which passed with no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3af2e22308330bf4e1b08f813613e)