### PR TITLE
Add workload-aware Architecture Pipeline info popovers

### DIFF
--- a/ui/partner-hub/components/workload-mapper/workload-mapper-pipeline-help.ts
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper-pipeline-help.ts
@@ -1,0 +1,164 @@
+import type { AiPattern, WorkloadFormState } from "./workload-mapper-types";
+
+export interface PipelineStepHelp {
+  title: string;
+  plainEnglish: string;
+  whyItMatters: string;
+  example?: string;
+  questions: string[];
+  ddnAngle?: string;
+}
+
+interface PipelineStepHelpArgs {
+  step: string;
+  workloadId?: string;
+  workloadName?: string;
+  category?: string;
+  aiPattern: AiPattern;
+  state: WorkloadFormState;
+}
+
+const normalizeStep = (step: string): string => {
+  const lower = step.toLowerCase();
+  if (lower.includes("data source")) return "Data Sources";
+  if (lower.includes("ingestion")) return "Ingestion / Normalization";
+  if (lower.includes("chunk")) return "Chunking + Embedding";
+  if (lower.includes("unified data platform") || lower.includes("high-performance data platform")) return "High-Performance Data Platform";
+  if (lower.includes("vector") || lower.includes("retrieval")) return "Vector DB / Retrieval";
+  if (lower.includes("llm") || lower.includes("model serving") || lower.includes("ml/analytics")) return "LLM / Model Serving";
+  if (lower.includes("business app") || lower.includes("decision app") || lower.includes("application")) return "Business App";
+  return step;
+};
+
+const describeScale = (state: WorkloadFormState): string => {
+  const ingest = state.dailyIngestRange || state.sizingInputs.dailyIngestRate;
+  const concurrency = state.queryConcurrency || state.sizingInputs.queryConcurrency;
+  if (ingest && concurrency) {
+    return `Because this workload includes ${ingest} ingest and ${concurrency} concurrent analyst/system sessions, this layer needs to support both write pressure and fast retrieval.`;
+  }
+  if (ingest) return `Because this workload includes ${ingest} ingest, this layer should absorb sustained write pressure without slowing downstream users.`;
+  if (concurrency) return `Because this workload expects ${concurrency} concurrent analyst/system sessions, retrieval and scoring paths must stay responsive under load.`;
+  return "This layer has to balance ingest throughput and read responsiveness as workload demand grows.";
+};
+
+const fraudHelpByStep = (step: string, state: WorkloadFormState): PipelineStepHelp | null => {
+  switch (step) {
+    case "Data Sources":
+      return {
+        title: step,
+        plainEnglish:
+          "This is where the raw fraud evidence starts: transaction events, account activity, identity/device signals, historical fraud cases, investigation notes, and policy/rules data.",
+        whyItMatters:
+          "Fraud detection is only as good as the signals it can see. If transaction, identity, behavior, and case data are fragmented, the model or investigator may miss the full pattern.",
+        questions: [
+          "Which fraud data sources are in scope first?",
+          "How fresh does each source need to be for prevention vs post-event investigation?",
+          "Which teams/systems own transaction, identity, behavior, and case data?",
+        ],
+        ddnAngle: "DDN angle: This is where data movement, metadata quality, and freshness alignment become architecture constraints.",
+      };
+    case "Ingestion / Normalization":
+      return {
+        title: step,
+        plainEnglish:
+          "This step moves data from source systems into a common structure so scoring, analytics, and investigation tools can use it.",
+        whyItMatters:
+          "For fraud, this matters because new events need to become usable quickly enough to act before loss exposure grows.",
+        questions: [
+          "What is the target ingest-to-usable-data SLA for high-risk events?",
+          "What schema and entity standardization is required across channels?",
+          "Where do late-arriving events and corrections get handled?",
+        ],
+        ddnAngle: "DDN angle: Ingest burst handling, transformation throughput, and metadata consistency should be validated early.",
+      };
+    case "Chunking + Embedding":
+      return {
+        title: step,
+        plainEnglish:
+          "For fraud, this mostly applies to unstructured case notes, policies, investigation documents, and evidence artifacts. The system breaks that content into searchable pieces and creates embeddings so investigator context can be retrieved later.",
+        whyItMatters:
+          "Without high-quality chunking and embeddings, retrieval can miss key evidence context and reduce investigator trust.",
+        questions: [
+          "Which document types should be embedded first?",
+          "What redaction or masking is required before indexing sensitive artifacts?",
+          "How will relevance quality be measured for investigators?",
+        ],
+      };
+    case "High-Performance Data Platform":
+      return {
+        title: step,
+        plainEnglish:
+          "This is the active data foundation supporting fast ingest, fast reads, and many concurrent analyst/system requests.",
+        whyItMatters: describeScale(state),
+        questions: [
+          "What peak burst periods (for example, fraud campaigns or seasonal spikes) must be absorbed?",
+          "Which queries must remain interactive during peak write load?",
+          "What retention and tiering policy keeps investigations fast without runaway cost?",
+        ],
+      };
+    case "Vector DB / Retrieval":
+      return {
+        title: step,
+        plainEnglish:
+          "This is how the system finds the most relevant case notes, policy context, prior fraud patterns, or supporting evidence for the investigator or LLM.",
+        whyItMatters: "Retrieval quality and freshness directly impact triage speed and decision confidence.",
+        questions: [
+          "What evidence should always be in top results for priority alert types?",
+          "How quickly should new case notes become retrievable?",
+          "What access filters are required so analysts only see permitted case context?",
+        ],
+      };
+    case "LLM / Model Serving":
+      return {
+        title: step,
+        plainEnglish:
+          "This is where the fraud assistant, scoring model, anomaly model, or summarization model runs. It may use GPU-backed inference depending on latency, model size, and concurrency requirements.",
+        whyItMatters:
+          "Serving architecture determines whether fraud decisions and investigator copilots can respond within operational SLAs.",
+        questions: [
+          "Which model paths are blocking (must answer in-line) vs asynchronous?",
+          "What p95/p99 latency targets are required for alerts and analyst workflows?",
+          "How will model drift and false-positive rates be monitored in production?",
+        ],
+      };
+    case "Business App":
+      return {
+        title: step,
+        plainEnglish:
+          "This is what the fraud analyst or risk operations team actually uses: a case-management screen, investigation assistant, alerting workflow, dashboard, or API integrated into the fraud platform.",
+        whyItMatters:
+          "Business outcomes depend on whether insights are delivered inside analyst workflows with clear actions and evidence.",
+        questions: [
+          "Which decisions are made in this interface and who approves them?",
+          "What evidence must be visible before an analyst can close or escalate a case?",
+          "Which actions should be automated vs analyst-confirmed?",
+        ],
+      };
+    default:
+      return null;
+  }
+};
+
+export function getPipelineStepHelp(args: PipelineStepHelpArgs): PipelineStepHelp {
+  const normalizedStep = normalizeStep(args.step);
+  if (args.workloadId === "fraud" || args.workloadName?.toLowerCase().includes("fraud")) {
+    const fraudHelp = fraudHelpByStep(normalizedStep, args.state);
+    if (fraudHelp) return fraudHelp;
+  }
+
+  return {
+    title: normalizedStep,
+    plainEnglish: `${normalizedStep} is a core stage in the ${args.aiPattern} architecture flow for ${args.workloadName || "this workload"}.`,
+    whyItMatters:
+      "This step is where data quality, throughput, or response behavior can either preserve or degrade downstream AI outcomes.",
+    example: args.state.processImproved
+      ? `Example: for "${args.state.processImproved}", this stage should be designed to keep the decision path reliable under expected demand.`
+      : undefined,
+    questions: [
+      `What does success look like for ${normalizedStep.toLowerCase()} in this workload?`,
+      "Which current captured inputs change sizing or design decisions here?",
+      "What evidence would prove this step is ready for pilot-to-production scale?",
+    ],
+    ddnAngle: "DDN angle: This is where data movement, metadata, throughput, or retrieval freshness can become part of the architecture conversation.",
+  };
+}

--- a/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
@@ -8,7 +8,8 @@ import { toSelectionContext } from "@/lib/workload-mapper/summarize-types";
 import { sizingFields, workloadExamplePresets, workloadLibrary } from "./workload-mapper-data";
 import { buildWorkloadProfile, getSelectedWorkload } from "./workload-mapper-utils";
 import { getDdnReferencePattern } from "./workload-mapper-ddn-reference";
-import { type AiPattern, type WorkloadFormState } from "./workload-mapper-types";
+import { getPipelineStepHelp } from "./workload-mapper-pipeline-help";
+import { type AiPattern, type WorkloadFormState, type WorkloadTemplate } from "./workload-mapper-types";
 
 type StateSetter = Dispatch<SetStateAction<WorkloadFormState>>;
 
@@ -35,6 +36,9 @@ interface WalkthroughViewProps {
   workloadName: string;
   workloadDescription: string;
   assumptions: string;
+  state: WorkloadFormState;
+  selectedWorkload?: WorkloadTemplate;
+  customCategory: string;
 }
 
 interface CardProps {
@@ -293,6 +297,9 @@ export function WorkloadMapper() {
           workloadName={state.workloadName || selected?.name || "Custom workload"}
           workloadDescription={isCustom ? customDescription : selected?.description || ""}
           assumptions={isCustom ? customAssumptions : selected?.assumptions.join(", ") || ""}
+          state={state}
+          selectedWorkload={selected}
+          customCategory={customCategory}
         />
       ) : (
         <section className="grid gap-6 xl:grid-cols-2">
@@ -316,7 +323,12 @@ export function WorkloadMapper() {
           </div>
 
           <div className="space-y-6">
-            <ArchitecturePipeline steps={profile.architectureSteps} />
+            <ArchitecturePipeline
+              steps={profile.architectureSteps}
+              state={state}
+              selectedWorkload={selected}
+              customContext={isCustom ? { workloadName: state.workloadName, category: customCategory } : undefined}
+            />
             <PressurePointChips points={profile.pressurePoints} />
             <BuildingBlocks blocks={profile.buildingBlocks} />
             <BomReadinessCard profile={profile} />
@@ -642,14 +654,68 @@ function BomInputCapture({
   );
 }
 
-function ArchitecturePipeline({ steps }: { steps: string[] }) {
+function ArchitecturePipeline({
+  steps,
+  state,
+  selectedWorkload,
+  customContext,
+}: {
+  steps: string[];
+  state: WorkloadFormState;
+  selectedWorkload?: WorkloadTemplate;
+  customContext?: { workloadName?: string; category?: string };
+}) {
+  const [openStep, setOpenStep] = useState<string | null>(null);
+
   return (
     <Card title="Architecture pipeline">
       <ol className="space-y-2">
         {steps.map((step, index) => (
           <li key={step} className="rounded-md border bg-muted/20 px-3 py-2 text-sm">
-            <span className="mr-2 font-semibold text-foreground/60">{index + 1}.</span>
-            {step}
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <span className="mr-2 font-semibold text-foreground/60">{index + 1}.</span>
+                {step}
+              </div>
+              <button
+                type="button"
+                aria-label={`Explain ${step}`}
+                className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-blue-500 bg-blue-500 text-xs font-bold text-white hover:bg-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+                onClick={() => setOpenStep((current) => (current === step ? null : step))}
+              >
+                i
+              </button>
+            </div>
+            {openStep === step ? (
+              <div className="mt-3 rounded-md border border-blue-200 bg-blue-50/40 p-3 text-xs text-foreground/90">
+                {(() => {
+                  const help = getPipelineStepHelp({
+                    step,
+                    workloadId: selectedWorkload?.id,
+                    workloadName: customContext?.workloadName || selectedWorkload?.name,
+                    category: customContext?.category || selectedWorkload?.category,
+                    aiPattern: state.aiPattern,
+                    state,
+                  });
+                  return (
+                    <div className="space-y-2">
+                      <p><span className="font-semibold">Plain English:</span> {help.plainEnglish}</p>
+                      <p><span className="font-semibold">Why it matters:</span> {help.whyItMatters}</p>
+                      {help.example ? <p><span className="font-semibold">Example:</span> {help.example}</p> : null}
+                      <div>
+                        <p className="font-semibold">Discovery questions:</p>
+                        <ul className="mt-1 list-disc space-y-1 pl-4">
+                          {help.questions.map((question) => (
+                            <li key={question}>{question}</li>
+                          ))}
+                        </ul>
+                      </div>
+                      {help.ddnAngle ? <p>{help.ddnAngle}</p> : null}
+                    </div>
+                  );
+                })()}
+              </div>
+            ) : null}
           </li>
         ))}
       </ol>
@@ -819,7 +885,7 @@ function BomSummaryCard({
   );
 }
 
-function WalkthroughView({ profile, workloadName, workloadDescription, assumptions }: WalkthroughViewProps) {
+function WalkthroughView({ profile, workloadName, workloadDescription, assumptions, state, selectedWorkload, customCategory }: WalkthroughViewProps) {
   return (
     <section className="space-y-5 rounded-2xl border border-border/60 bg-card p-6 shadow-sm">
       <h2 className="text-2xl font-semibold">Walkthrough: {workloadName}</h2>
@@ -830,7 +896,12 @@ function WalkthroughView({ profile, workloadName, workloadDescription, assumptio
       <p className="text-sm">
         <span className="font-semibold">Classification:</span> {profile.classification}
       </p>
-      <ArchitecturePipeline steps={profile.architectureSteps} />
+      <ArchitecturePipeline
+        steps={profile.architectureSteps}
+        state={state}
+        selectedWorkload={selectedWorkload}
+        customContext={{ workloadName, category: customCategory }}
+      />
       <PressurePointChips points={profile.pressurePoints} />
       <BuildingBlocks blocks={profile.buildingBlocks} />
       <BomReadinessCard profile={profile} />
@@ -901,5 +972,3 @@ function MultiSelectChips({ label, options, selected, onToggle }: MultiSelectChi
     </div>
   );
 }
-
-


### PR DESCRIPTION
### Motivation
- Provide inline, workload-aware explanations for each Architecture Pipeline step to aid discovery conversations and screen-share walkthroughs.
- Surface targeted guidance for high-value workloads (notably Fraud Detection & Investigation) using captured form fields so recommendations feel relevant without calling external APIs.

### Description
- Add a new strongly-typed helper `ui/partner-hub/components/workload-mapper/workload-mapper-pipeline-help.ts` that exports `PipelineStepHelp` and `getPipelineStepHelp(...)`, with step normalization, a fraud-specific branch, captured-field-aware scale phrasing, and a generic fallback.
- Update `ArchitecturePipeline` in `workload-mapper.tsx` to accept `state`, `selectedWorkload`, and `customContext` props and render a blue circular info button (`type="button"` with an accessible `aria-label`) for each row that toggles an inline explanation panel with single-open-step behavior.
- Wire the richer pipeline props from both main and walkthrough modes so the help text is workload-aware in all rendering paths, and ensure TypeScript types are explicit (no `any`).
- Keep all help deterministic and local; no external APIs or LLM calls were added.

### Testing
- Ran `npm run lint` in `ui/partner-hub`, which failed in this environment with `next: not found` so lint could not be fully validated.
- Ran `npm run typecheck` in `ui/partner-hub`, which failed due to missing workspace dependencies/type declarations and pre-existing repo type errors unrelated to the changes.
- Ran `npm test -- --runInBand` in `ui/partner-hub`, which failed because of missing Node type declarations and other pre-existing test compile issues in this environment.
- Ran `npm run build` in `ui/partner-hub`, which failed here due to missing tooling (`prisma: not found`).
- Ran `rg -i "chip-?8|steam[- ]?trains" .` which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f48fef759c8330b0bf228ca1203974)