### PR TITLE
Tone down Architecture Pipeline info button prominence

### DIFF
--- a/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
@@ -680,7 +680,7 @@ function ArchitecturePipeline({
               <button
                 type="button"
                 aria-label={`Explain ${step}`}
-                className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-blue-500 bg-blue-500 text-xs font-bold text-white hover:bg-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+                className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-blue-500/80 bg-blue-500/90 text-[11px] font-semibold text-white hover:bg-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
                 onClick={() => setOpenStep((current) => (current === step ? null : step))}
               >
                 i


### PR DESCRIPTION
### Motivation
- Reduce the visual dominance of the blue circular info `i` buttons in the Architecture Pipeline so they read as subtle help affordances while preserving accessibility and existing behavior.

### Description
- Changed the info button `className` in `ui/partner-hub/components/workload-mapper/workload-mapper.tsx` to use `inline-flex h-5 w-5 ... text-[11px] font-semibold bg-blue-500/90 border-blue-500/80`, keeping the button circular and retaining `type="button"`, `aria-label`, the `onClick` handler, and focus/hover ring behavior.

### Testing
- Executed the requested checks: `npm run lint`, `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` all failed in this environment due to missing project dependencies/tools, and `rg -i "chip-?8|steam[- ]?trains" .` returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49e5028788330acacb5df2c017477)