### PR TITLE
Remove Walkthrough Mode from workload mapper

### DIFF
--- a/ui/partner-hub/components/workload-mapper/workload-mapper-utils.ts
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper-utils.ts
@@ -92,7 +92,7 @@ export function buildWorkloadProfile(
 
   const talkTrack = [
     `Executive framing: I start with ${workloadName} because it reveals the data pattern, constraints, and likely infrastructure pressure points before we discuss BOM scope.`,
-    `SE discovery walkthrough: For this ${pattern} flow, I validate data types (${state.dataTypes.join(", ") || "TBD"}), freshness (${state.freshnessRequirement || "TBD"}), latency (${state.latencyRequirement || "TBD"}), concurrency (${state.queryConcurrency || "TBD"}), and governance controls (${state.accessControls || "TBD"}).`,
+    `SE discovery flow: For this ${pattern} pattern, I validate data types (${state.dataTypes.join(", ") || "TBD"}), freshness (${state.freshnessRequirement || "TBD"}), latency (${state.latencyRequirement || "TBD"}), concurrency (${state.queryConcurrency || "TBD"}), and governance controls (${state.accessControls || "TBD"}).`,
     `Next-step questions before BOM: We still need ${missingInputs.length} key inputs. ${nextBestQuestions.join(" ")} This is BOM readiness, not a BOM.`,
   ];
 

--- a/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
@@ -31,16 +31,6 @@ interface WorkloadSelectionCardProps extends WorkloadStateProps {
   onCustomPressurePointsChange: (value: string) => void;
 }
 
-interface WalkthroughViewProps {
-  profile: ReturnType<typeof buildWorkloadProfile>;
-  workloadName: string;
-  workloadDescription: string;
-  assumptions: string;
-  state: WorkloadFormState;
-  selectedWorkload?: WorkloadTemplate;
-  customCategory: string;
-}
-
 interface CardProps {
   title: string;
   children: ReactNode;
@@ -116,7 +106,6 @@ const initialState: WorkloadFormState = {
 
 export function WorkloadMapper() {
   const [state, setState] = useState(initialState);
-  const [walkthroughMode, setWalkthroughMode] = useState(false);
   const [customCategory, setCustomCategory] = useState("Custom");
   const [customDescription, setCustomDescription] = useState("");
   const [customAssumptions, setCustomAssumptions] = useState("");
@@ -289,55 +278,41 @@ export function WorkloadMapper() {
   return (
     <div className="space-y-6 pb-10">
       <HeroSection />
-      <WalkthroughToggle enabled={walkthroughMode} onToggle={() => setWalkthroughMode((v) => !v)} />
+      <section className="grid gap-6 xl:grid-cols-2">
+        <div className="space-y-6">
+          <WorkloadSelectionCard
+            state={state}
+            selectedDescription={selected?.description}
+            isCustom={isCustom}
+            customCategory={customCategory}
+            customDescription={customDescription}
+            customAssumptions={customAssumptions}
+            customPressurePoints={customPressurePoints}
+            onStateChange={setState}
+            onCustomCategoryChange={setCustomCategory}
+            onCustomDescriptionChange={setCustomDescription}
+            onCustomAssumptionsChange={setCustomAssumptions}
+            onCustomPressurePointsChange={setCustomPressurePoints}
+          />
+          <DiscoveryQuestionnaire state={state} onStateChange={setState} />
+          <BomInputCapture state={state} onStateChange={setState} onApplyPreset={applyWorkloadExamplePreset} />
+        </div>
 
-      {walkthroughMode ? (
-        <WalkthroughView
-          profile={profile}
-          workloadName={state.workloadName || selected?.name || "Custom workload"}
-          workloadDescription={isCustom ? customDescription : selected?.description || ""}
-          assumptions={isCustom ? customAssumptions : selected?.assumptions.join(", ") || ""}
-          state={state}
-          selectedWorkload={selected}
-          customCategory={customCategory}
-        />
-      ) : (
-        <section className="grid gap-6 xl:grid-cols-2">
-          <div className="space-y-6">
-            <WorkloadSelectionCard
-              state={state}
-              selectedDescription={selected?.description}
-              isCustom={isCustom}
-              customCategory={customCategory}
-              customDescription={customDescription}
-              customAssumptions={customAssumptions}
-              customPressurePoints={customPressurePoints}
-              onStateChange={setState}
-              onCustomCategoryChange={setCustomCategory}
-              onCustomDescriptionChange={setCustomDescription}
-              onCustomAssumptionsChange={setCustomAssumptions}
-              onCustomPressurePointsChange={setCustomPressurePoints}
-            />
-            <DiscoveryQuestionnaire state={state} onStateChange={setState} />
-            <BomInputCapture state={state} onStateChange={setState} onApplyPreset={applyWorkloadExamplePreset} />
-          </div>
-
-          <div className="space-y-6">
-            <ArchitecturePipeline
-              steps={profile.architectureSteps}
-              state={state}
-              selectedWorkload={selected}
-              customContext={isCustom ? { workloadName: state.workloadName, category: customCategory } : undefined}
-            />
-            <PressurePointChips points={profile.pressurePoints} />
-            <BuildingBlocks blocks={profile.buildingBlocks} />
-            <BomReadinessCard profile={profile} />
-            <TalkTrackCard profile={profile} />
-            <SummarizeCard summary={summary} error={summaryError} loading={isSummarizing} onSummarize={summarizeWorkload} />
-            <BomSummaryCard summary={bomSummary} error={bomSummaryError} loading={isGeneratingBomSummary} onSummarize={summarizeBom} />
-          </div>
-        </section>
-      )}
+        <div className="space-y-6">
+          <ArchitecturePipeline
+            steps={profile.architectureSteps}
+            state={state}
+            selectedWorkload={selected}
+            customContext={isCustom ? { workloadName: state.workloadName, category: customCategory } : undefined}
+          />
+          <PressurePointChips points={profile.pressurePoints} />
+          <BuildingBlocks blocks={profile.buildingBlocks} />
+          <BomReadinessCard profile={profile} />
+          <TalkTrackCard profile={profile} />
+          <SummarizeCard summary={summary} error={summaryError} loading={isSummarizing} onSummarize={summarizeWorkload} />
+          <BomSummaryCard summary={bomSummary} error={bomSummaryError} loading={isGeneratingBomSummary} onSummarize={summarizeBom} />
+        </div>
+      </section>
     </div>
   );
 }
@@ -353,22 +328,6 @@ function HeroSection() {
         This guided flow helps align AI workload context, architecture pressure points, and BOM-readiness
         inputs before detailed solution sizing.
       </p>
-    </section>
-  );
-}
-
-function WalkthroughToggle({ enabled, onToggle }: { enabled: boolean; onToggle: () => void }) {
-  return (
-    <section className="rounded-xl border border-border/60 bg-card p-3 shadow-sm">
-      <div className="flex items-center justify-between">
-        <div>
-          <p className="text-sm font-semibold">Walkthrough Mode</p>
-          <p className="text-xs text-foreground/60">Screen-share friendly discovery narrative view.</p>
-        </div>
-        <button className="rounded-md border px-3 py-1 text-sm font-medium" onClick={onToggle}>
-          {enabled ? "Exit Walkthrough Mode" : "Enter Walkthrough Mode"}
-        </button>
-      </div>
     </section>
   );
 }
@@ -882,31 +841,6 @@ function BomSummaryCard({
         </div>
       ) : null}
     </Card>
-  );
-}
-
-function WalkthroughView({ profile, workloadName, workloadDescription, assumptions, state, selectedWorkload, customCategory }: WalkthroughViewProps) {
-  return (
-    <section className="space-y-5 rounded-2xl border border-border/60 bg-card p-6 shadow-sm">
-      <h2 className="text-2xl font-semibold">Walkthrough: {workloadName}</h2>
-      <p className="text-sm text-foreground/80">{workloadDescription || "Description to be confirmed."}</p>
-      <p className="text-sm text-foreground/70">
-        <span className="font-semibold">Assumptions:</span> {assumptions || "Assumptions not yet captured."}
-      </p>
-      <p className="text-sm">
-        <span className="font-semibold">Classification:</span> {profile.classification}
-      </p>
-      <ArchitecturePipeline
-        steps={profile.architectureSteps}
-        state={state}
-        selectedWorkload={selectedWorkload}
-        customContext={{ workloadName, category: customCategory }}
-      />
-      <PressurePointChips points={profile.pressurePoints} />
-      <BuildingBlocks blocks={profile.buildingBlocks} />
-      <BomReadinessCard profile={profile} />
-      <TalkTrackCard profile={profile} />
-    </section>
   );
 }
 


### PR DESCRIPTION
### Motivation
- Remove the Walkthrough Mode UI and related state so the AI Workload Discovery Mapper renders its main two-column content directly under the hero section.
- Eliminate walkthrough-specific components and helper text to avoid stale code paths and simplify the discovery flow while keeping all non-walkthrough functionality intact.

### Description
- Removed `walkthroughMode` / `setWalkthroughMode` state and the conditional rendering that showed `WalkthroughToggle` / `WalkthroughView` in `ui/partner-hub/components/workload-mapper/workload-mapper.tsx` so the two-column mapper now renders immediately after `HeroSection`.
- Deleted the `WalkthroughToggle` and `WalkthroughView` functions and removed the `WalkthroughViewProps` interface from the same file.
- Updated talk-track copy in `ui/partner-hub/components/workload-mapper/workload-mapper-utils.ts` (`SE discovery walkthrough` → `SE discovery flow`) to remove walkthrough-specific wording.
- Kept all other mapper behavior and components unchanged, including workload selection, questionnaire, BOM capture, architecture pipeline, pressure point chips, building blocks, BOM readiness, talk track, and summarization flows.

### Testing
- Ran a repository search for remaining walkthrough references with `rg -i "walkthrough|walkthrough mode|screen-share friendly discovery narrative" ui/partner-hub/components/workload-mapper ui/partner-hub/lib/workload-mapper ui/partner-hub/app/api/workload-mapper`, which returned no matches after the change.
- Ran `rg -i "chip-?8|steam[- ]?trains" .` which returned no matches in the project.
- Attempted `npm run lint` / `npm run typecheck` / `npm test -- --runInBand` / `npm run build` under `ui/partner-hub`, but these tasks failed in this environment due to missing global/project dependencies (`next: not found`, missing type/module dependencies, `prisma: not found`), so automated repo-level verification could not be completed here.
- Changes were committed locally with the message "Remove workload mapper walkthrough mode UI and state".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a03ab7c48330af331647953a4b23)