### PR TITLE
Update AI Workload Discovery Mapper hero heading

### DIFF
--- a/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
@@ -320,10 +320,7 @@ export function WorkloadMapper() {
 function HeroSection() {
   return (
     <section className="rounded-2xl border border-border/60 bg-gradient-to-r from-slate-50 to-white p-6 shadow-sm">
-      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground/50">
-        AI Workload Discovery Mapper
-      </p>
-      <h1 className="mt-2 text-3xl font-semibold">Story-first discovery from use case to BOM readiness</h1>
+      <h1 className="text-3xl font-semibold">AI Workload Discovery Mapper</h1>
       <p className="mt-3 text-sm text-foreground/70">
         This guided flow helps align AI workload context, architecture pressure points, and BOM-readiness
         inputs before detailed solution sizing.


### PR DESCRIPTION
### Motivation
- Make the workload mapper hero copy a single, clean main title by removing the old large headline and redundant eyebrow so the hero reads professionally as “AI Workload Discovery Mapper”.

### Description
- Replace the eyebrow label + old headline with a single main `<h1>` reading `AI Workload Discovery Mapper` and keep the existing supporting paragraph unchanged in `ui/partner-hub/components/workload-mapper/workload-mapper.tsx`.

### Testing
- Ran `npm run lint`, `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` in this environment and they failed due to missing local dependencies / repo-wide TypeScript and tooling issues (e.g. `next`, `prisma` not found), while `rg` searches for the forbidden phrases returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4bb12e12c8330a6ed4dd1743b642b)