### PR TITLE
Replace Talk Track with deterministic workload-specific Why DDN card

### DIFF
--- a/ui/partner-hub/components/workload-mapper/workload-mapper-types.ts
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper-types.ts
@@ -72,7 +72,7 @@ export interface WorkloadProfile {
   readinessPercent: number;
   knownInputs: Array<{ label: string; value: string }>;
   missingInputs: Array<{ label: string; whyItMatters: string }>;
-  talkTrack: string[];
+  whyDdn: string[];
 }
 
 export interface WorkloadExamplePreset {

--- a/ui/partner-hub/components/workload-mapper/workload-mapper-utils.ts
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper-utils.ts
@@ -8,6 +8,82 @@ export function getSelectedWorkload(selectedWorkloadId: string) {
 }
 
 const parseList = (value: string) => value.split(",").map((v) => v.trim()).filter(Boolean);
+const asValue = (value: string) => value.trim() || "TBD";
+
+function buildWhyDdnPitch(state: WorkloadFormState, workloadId: string, pattern: WorkloadFormState["aiPattern"], missingInputsCount: number): string[] {
+  const ingest = asValue(state.sizingInputs.dailyIngestRate || state.dailyIngestRange);
+  const objectCount = asValue(state.sizingInputs.fileObjectCount || state.filePattern);
+  const concurrency = asValue(state.sizingInputs.queryConcurrency || state.queryConcurrency);
+  const latency = asValue(state.latencyRequirement);
+  const gpu = asValue(state.sizingInputs.gpuRequirement || state.gpuDependency);
+  const governance = [state.dataSensitivity, state.accessControls, state.auditTrail, state.encryption].filter((v) => hasValue(v)).join(", ") || "governance controls";
+  const haDr = asValue(state.sizingInputs.haDrRequirements);
+
+  const workloadSpecific: Record<string, string[]> = {
+    fraud: [
+      "DDN matters here because fraud response is a data-speed and time-to-action problem: reducing loss exposure and false positives depends on fast ingest and retrieval across transactions, behaviors, and case evidence.",
+      `For this workload, DDN sits in the data path behind near-real-time scoring and investigator context retrieval. Your captured profile (${ingest} ingest, ${objectCount}, ${concurrency}, ${latency}) signals that data movement and access consistency can become the bottleneck before models do.`,
+      `Before BOM, the key question is whether the platform can keep models and investigators fed while meeting ${governance} and ${haDr}.`,
+    ],
+    risk: [
+      "DDN matters here because risk and stress workflows are decision-window problems: the goal is to compress scenario turnaround and improve intraday risk visibility, not just run bigger batches.",
+      `DDN fits as the high-throughput data foundation for large historical risk datasets, scenario execution, and reproducible outputs. With ${ingest} ingest, ${objectCount}, and ${concurrency}, storage throughput and data orchestration directly affect risk-cycle speed.`,
+      `Before BOM, validate that the data platform can sustain scenario replay, lineage, and governed recovery (${haDr}) without slowing modelers down.`,
+    ],
+    trading: [
+      "DDN matters here because quant performance is iteration speed: faster backtests and lower data wait time translate into more research cycles and better strategy decisions.",
+      `DDN sits behind low-latency access to market/time-series/feature data and high-concurrency research jobs. The workload profile (${ingest}, ${objectCount}, ${concurrency}, ${latency}) points to a shared data-path bottleneck risk.`,
+      `Before BOM, the conversation is whether the platform can deliver consistent low-latency reuse at scale while protecting proprietary strategy data and maintaining ${governance}.`,
+    ],
+    compliance: [
+      "DDN matters here because compliance outcomes depend on reducing manual review while still producing evidence-backed, explainable answers under strict controls.",
+      `DDN fits as the governed ingest, indexing, and retrieval foundation for policy and case content. With ${ingest}, ${objectCount}, and ${concurrency}, metadata and retrieval performance become core workflow constraints.`,
+      `Before BOM, test whether the data path can keep citation/evidence retrieval fast while preserving auditability, retention, and policy enforcement (${governance}, ${haDr}).`,
+    ],
+    "fsi-rag": [
+      "DDN matters here because trusted assistant quality is a retrieval problem: responses are only as good as governed access to fresh internal knowledge.",
+      `DDN sits behind document ingest, embedding/index freshness, and low-latency retrieval for frontline users. The current signals (${ingest}, ${objectCount}, ${concurrency}, ${latency}) indicate scale where stale or slow retrieval hurts adoption.`,
+      `Before BOM, confirm that RBAC/ABAC-aware retrieval and operational resilience (${haDr}) can be maintained while keeping response experience fast.`,
+    ],
+    "fsi-ft": [
+      "DDN matters here because fine-tuning outcomes depend on data readiness and training flow, not just GPU count.",
+      `DDN fits as the curated dataset and artifact/checkpoint backbone that keeps tuning pipelines fed and reproducible. The profile (${ingest}, ${objectCount}, GPU: ${gpu}) highlights pressure on throughput, checkpoint handling, and governance.`,
+      `Before BOM, validate whether the platform can accelerate model iteration while preserving lineage, policy controls, and reliable recovery (${governance}, ${haDr}).`,
+    ],
+    "ai-training": [
+      "DDN matters here because large-scale AI training success is an AI-factory data-path problem: GPU utilization depends on sustained throughput and reliable checkpointing.",
+      `DDN sits behind distributed corpus prep, high-throughput reads/writes, and checkpoint durability. Captured inputs (${ingest}, ${objectCount}, GPU: ${gpu}, ${concurrency}) indicate where stalls can waste expensive training cycles.`,
+      `Before BOM, prove the data platform can sustain throughput targets and recovery objectives (${haDr}) with governed controls (${governance}).`,
+    ],
+    inference: [
+      "DDN matters here because user-facing AI quality is tied to predictable latency under concurrency spikes.",
+      `DDN fits behind model serving as the hot context, cache/session, and artifact data layer. With ${concurrency}, ${latency}, ${ingest}, and GPU demand (${gpu}), the risk is tail latency from a saturated data path.`,
+      `Before BOM, validate that throughput, observability, and resilience (${haDr}) can hold SLOs while keeping controls and guardrails enforceable (${governance}).`,
+    ],
+    simulation: [
+      "DDN matters here because simulation productivity is run-to-insight speed: teams need faster checkpoint/output handling and less I/O wait across parallel jobs.",
+      `DDN sits in the core HPC data path for parallel I/O, scheduler-driven workflows, and post-processing access. Inputs (${ingest}, ${objectCount}, ${concurrency}) indicate potential contention at scale.`,
+      `Before BOM, verify the platform can sustain burst throughput and recovery (${haDr}) so compute cycles are spent on science, not data delays.`,
+    ],
+    genomics: [
+      "DDN matters here because genomic throughput is constrained by metadata-heavy file operations and regulated traceability requirements.",
+      `DDN fits behind sequencing ingest, pipeline staging, and reproducible downstream analysis. The workload signals (${ingest}, ${objectCount}, ${concurrency}) point to many-small-file pressure and pipeline bottlenecks.`,
+      `Before BOM, ensure the data platform can shorten sample-to-insight while meeting retention, audit, and access policies (${governance}, ${haDr}).`,
+    ],
+    media: [
+      "DDN matters here because media and rendering workflows are deadline-driven throughput problems with bursty ingest and queue pressure.",
+      `DDN sits behind high-throughput asset access, shared metadata, and render/inference queue feeds. Your profile (${ingest}, ${objectCount}, ${concurrency}, GPU: ${gpu}) indicates that storage and data locality can throttle delivery timelines.`,
+      `Before BOM, confirm the platform can absorb bursts, keep creative and render teams productive, and enforce archive/control policies with resilience (${haDr}).`,
+    ],
+  };
+
+  if (workloadSpecific[workloadId]) return workloadSpecific[workloadId];
+  return [
+    `DDN matters here because ${state.processImproved || "this business workflow"} depends on consistent data speed, governed access, and reliable execution before architecture choices are finalized.`,
+    `For this ${pattern} workload, DDN fits as the data foundation connecting ingest, retrieval/training/serving paths, and operational controls. Captured inputs (${ingest}, ${objectCount}, ${concurrency}, ${latency}, GPU: ${gpu}) indicate where data-path bottlenecks can block outcomes.`,
+    `Before BOM, use this to test readiness: can the platform sustain performance while meeting ${governance} and ${haDr}? Missing sizing inputs (${missingInputsCount}) should be closed as part of that validation.`,
+  ];
+}
 
 export function buildWorkloadProfile(
   state: WorkloadFormState,
@@ -88,13 +164,7 @@ export function buildWorkloadProfile(
   const knownInputs = sizingFields.filter((field) => hasValue(state.sizingInputs[field.key])).map((field) => ({ label: field.label, value: state.sizingInputs[field.key] }));
   const missingInputs = sizingFields.filter((field) => !hasValue(state.sizingInputs[field.key])).map((field) => ({ label: field.label, whyItMatters: field.whyItMatters }));
   const readinessPercent = Math.round((knownInputs.length / sizingFields.length) * 100);
-  const nextBestQuestions = missingInputs.slice(0, 4).map((input) => `Can we quantify ${input.label.toLowerCase()}? This matters because ${input.whyItMatters.toLowerCase()}`);
+  const whyDdn = buildWhyDdnPitch(state, state.selectedWorkloadId, pattern, missingInputs.length);
 
-  const talkTrack = [
-    `Executive framing: I start with ${workloadName} because it reveals the data pattern, constraints, and likely infrastructure pressure points before we discuss BOM scope.`,
-    `SE discovery flow: For this ${pattern} pattern, I validate data types (${state.dataTypes.join(", ") || "TBD"}), freshness (${state.freshnessRequirement || "TBD"}), latency (${state.latencyRequirement || "TBD"}), concurrency (${state.queryConcurrency || "TBD"}), and governance controls (${state.accessControls || "TBD"}).`,
-    `Next-step questions before BOM: We still need ${missingInputs.length} key inputs. ${nextBestQuestions.join(" ")} This is BOM readiness, not a BOM.`,
-  ];
-
-  return { classification, pressurePoints, architectureSteps, buildingBlocks, readinessPercent, knownInputs, missingInputs, talkTrack };
+  return { classification, pressurePoints, architectureSteps, buildingBlocks, readinessPercent, knownInputs, missingInputs, whyDdn };
 }

--- a/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper.tsx
@@ -308,7 +308,7 @@ export function WorkloadMapper() {
           <PressurePointChips points={profile.pressurePoints} />
           <BuildingBlocks blocks={profile.buildingBlocks} />
           <BomReadinessCard profile={profile} />
-          <TalkTrackCard profile={profile} />
+          <WhyDdnCard profile={profile} />
           <SummarizeCard summary={summary} error={summaryError} loading={isSummarizing} onSummarize={summarizeWorkload} />
           <BomSummaryCard summary={bomSummary} error={bomSummaryError} loading={isGeneratingBomSummary} onSummarize={summarizeBom} />
         </div>
@@ -738,11 +738,11 @@ function BomReadinessCard({ profile }: { profile: ReturnType<typeof buildWorkloa
   );
 }
 
-function TalkTrackCard({ profile }: { profile: ReturnType<typeof buildWorkloadProfile> }) {
+function WhyDdnCard({ profile }: { profile: ReturnType<typeof buildWorkloadProfile> }) {
   return (
-    <Card title="Talk track">
+    <Card title="Why DDN">
       <ul className="space-y-2 text-sm">
-        {profile.talkTrack.map((line) => (
+        {profile.whyDdn.map((line) => (
           <li key={line}>• {line}</li>
         ))}
       </ul>


### PR DESCRIPTION
### Motivation
- The existing Talk Track card was process-oriented (e.g. "Executive framing", "SE discovery flow", "Next-step questions before BOM") and not workload-centric, so replace it with a concise, workload-specific "Why DDN" elevator pitch.
- The pitch must be deterministic, use captured discovery inputs, and avoid calling Ollama so it can be rendered locally and consistently.

### Description
- Replaced `WorkloadProfile.talkTrack` with `WorkloadProfile.whyDdn` and updated the UI to render a `WhyDdnCard` with the title `Why DDN` instead of the old Talk Track card.
- Added a deterministic helper `buildWhyDdnPitch(...)` in `workload-mapper-utils.ts` that generates workload-specific three-line pitches (fraud, risk, trading, compliance, RAG, fine-tuning, ai-training, inference, simulation, genomics, media) and a generic fallback using captured fields.
- `buildWhyDdnPitch` consumes captured sizing/governance fields such as `dailyIngestRate`, `fileObjectCount`, `queryConcurrency`, `latencyRequirement`, `gpuRequirement`, data-sensitivity/access/audit/encryption, and HA/DR hints to tailor the text; it does not call external services.
- `buildWorkloadProfile(...)` was updated to populate `whyDdn` and removed generation of the old process-oriented talk-track lines (`Executive framing`, `SE discovery flow`, `Next-step questions before BOM`).

### Testing
- Ran repository searches with `rg` to verify talk-track and walkthrough references, and to check for unwanted "chip-8 / steam trains" strings; those targeted `rg` checks completed successfully.
- Ran `npm run lint` and `npm run typecheck` in this environment and they failed due to missing project environment/tools (e.g. `next` binary missing and missing Node typings / `package.json` at root), so lint/typecheck did not complete here.
- Ran the unit test command (`npm run test -- --runInBand`) under `ui/partner-hub` and it failed due to missing test/runtime dependencies and Node typings (errors like `Cannot find module 'node:test'`, missing packages such as `zod`/`jszip`), so tests did not pass in this container.
- `npm run build` was not completed after the above failures in this environment; build was not verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4c198945c83308cf331c63c0d53fb)