### PR TITLE
Fix nullish/logical precedence in workload mapper visual title

### DIFF
--- a/ui/partner-hub/components/workload-mapper/workload-mapper-visual-map.ts
+++ b/ui/partner-hub/components/workload-mapper/workload-mapper-visual-map.ts
@@ -224,7 +224,7 @@ export function buildWorkloadVisualMap({ workloadId, selectedWorkload, state, dd
   }
 
   return {
-    title: `${selectedWorkload?.name ?? state.workloadName || "Custom Workload"} Visual Map`,
+    title: `${selectedWorkload?.name ?? (state.workloadName || "Custom Workload")} Visual Map`,
     businessGoal: state.processImproved || selectedWorkload?.description || "Clarify the business workflow and define measurable outcomes.",
     nodes: genericNodes(state),
     governance: genericGovernance(state),


### PR DESCRIPTION
### Motivation
- Resolve a build/parse error caused by mixing the nullish coalescing operator `??` with the logical OR `||` in the visual map title expression in `ui/partner-hub/components/workload-mapper/workload-mapper-visual-map.ts` so the expression has explicit precedence.

### Description
- Made precedence explicit in the title template by changing the expression to ```${selectedWorkload?.name ?? (state.workloadName || "Custom Workload")} Visual Map``` so behavior is unchanged but the syntax is valid.
- Searched the workload-mapper component/lib paths for other mixed `??`/`||` instances and found no additional matches.

### Testing
- Ran `rg "\?\?.*\|\||\|\|.*\?\?" ui/partner-hub/components/workload-mapper ui/partner-hub/lib/workload-mapper` which returned no other matches after the fix. 
- Attempted project checks: `npm run lint`, `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` were executed in the environment but failed due to missing project dependencies/tools in this environment (e.g. `next`, `prisma`, and various type packages), not due to the change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4cb0ea3e483309482b2b527f1f31d)