### PR TITLE
Add local MedGemma image review

### DIFF
--- a/ui/partner-hub/.gitignore
+++ b/ui/partner-hub/.gitignore
@@ -1,3 +1,8 @@
 node_modules/
 .next/
 out/
+# Local MedGemma uploads/model artifacts
+.medgemma-uploads/
+.medgemma-cache/
+.cache/huggingface/
+hf_cache/

--- a/ui/partner-hub/app/(routes)/medgemma/page.tsx
+++ b/ui/partner-hub/app/(routes)/medgemma/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+import { MedGemmaReviewTool } from "@/components/medgemma/MedGemmaReviewTool";
+
+export const metadata: Metadata = {
+  title: "Local MedGemma Image Review",
+  description: "Upload an image for local MedGemma medical-image description and red-flag review.",
+};
+
+export default function MedGemmaPage() {
+  return <MedGemmaReviewTool />;
+}

--- a/ui/partner-hub/app/api/medgemma/analyze/route.ts
+++ b/ui/partner-hub/app/api/medgemma/analyze/route.ts
@@ -1,0 +1,181 @@
+import { randomUUID } from "crypto";
+import { spawn } from "child_process";
+import { mkdir, rm, writeFile } from "fs/promises";
+import path from "path";
+
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+const DEFAULT_PROMPT =
+  "Describe visible findings in cautious medical language. List possible benign explanations and red flags that would require a clinician. Do not provide a definitive diagnosis.";
+
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+const ALLOWED_TYPES = new Map([
+  ["image/jpeg", ".jpg"],
+  ["image/png", ".png"],
+  ["image/webp", ".webp"],
+]);
+const RUNNER_TIMEOUT_MS = Number(process.env.MEDGEMMA_RUNNER_TIMEOUT_MS || 10 * 60 * 1000);
+
+type RunnerResult = {
+  ok: boolean;
+  result?: string;
+  error?: string;
+};
+
+const jsonResponse = (body: RunnerResult, status = 200) => NextResponse.json(body, { status });
+
+const isFileLike = (value: FormDataEntryValue | null): value is File => {
+  return Boolean(value && typeof value === "object" && "arrayBuffer" in value && "type" in value);
+};
+
+const hasValidImageSignature = (bytes: Buffer, mimeType: string) => {
+  if (mimeType === "image/jpeg") {
+    return bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+  }
+
+  if (mimeType === "image/png") {
+    return (
+      bytes.length >= 8 &&
+      bytes
+        .subarray(0, 8)
+        .equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+    );
+  }
+
+  if (mimeType === "image/webp") {
+    return (
+      bytes.length >= 12 &&
+      bytes.subarray(0, 4).toString("ascii") === "RIFF" &&
+      bytes.subarray(8, 12).toString("ascii") === "WEBP"
+    );
+  }
+
+  return false;
+};
+
+const runMedGemma = (imagePath: string, prompt: string): Promise<RunnerResult> => {
+  const pythonPath = process.env.MEDGEMMA_PYTHON_PATH || "python";
+  const runnerPath = path.join(process.cwd(), "scripts", "medgemma_runner.py");
+
+  return new Promise((resolve) => {
+    const child = spawn(pythonPath, [runnerPath, "--image", imagePath, "--prompt", prompt], {
+      cwd: process.cwd(),
+      env: process.env,
+      windowsHide: true,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const finish = (result: RunnerResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(result);
+    };
+
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish({
+        ok: false,
+        error: `MedGemma runner timed out after ${Math.round(RUNNER_TIMEOUT_MS / 1000)} seconds.`,
+      });
+    }, RUNNER_TIMEOUT_MS);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      finish({ ok: false, error: `Unable to start MedGemma runner: ${error.message}` });
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      if (settled) {
+        return;
+      }
+
+      const trimmedStdout = stdout.trim();
+      try {
+        const parsed = JSON.parse(trimmedStdout) as RunnerResult;
+        if (!parsed.ok && stderr.trim() && !parsed.error) {
+          parsed.error = stderr.trim();
+        }
+        finish(parsed);
+      } catch {
+        const details = stderr.trim() || trimmedStdout || `Runner exited with code ${code}.`;
+        finish({ ok: false, error: `MedGemma runner did not return valid JSON. ${details}` });
+      }
+    });
+  });
+};
+
+export async function POST(request: NextRequest) {
+  let uploadPath = "";
+
+  try {
+    const formData = await request.formData();
+    const image = formData.get("image");
+    const rawPrompt = formData.get("prompt");
+
+    if (!isFileLike(image)) {
+      return jsonResponse(
+        { ok: false, error: "A JPG, PNG, or WebP image upload is required." },
+        400,
+      );
+    }
+
+    const extension = ALLOWED_TYPES.get(image.type);
+    if (!extension) {
+      return jsonResponse(
+        { ok: false, error: "Unsupported file type. Upload a JPG, PNG, or WebP image." },
+        400,
+      );
+    }
+
+    if (image.size <= 0) {
+      return jsonResponse({ ok: false, error: "Uploaded image is empty." }, 400);
+    }
+
+    if (image.size > MAX_UPLOAD_BYTES) {
+      return jsonResponse({ ok: false, error: "Uploaded image must be 10 MB or smaller." }, 400);
+    }
+
+    const prompt =
+      typeof rawPrompt === "string" && rawPrompt.trim() ? rawPrompt.trim() : DEFAULT_PROMPT;
+    const uploadsDir = path.join(process.cwd(), ".medgemma-uploads");
+    await mkdir(uploadsDir, { recursive: true });
+
+    uploadPath = path.join(uploadsDir, `${Date.now()}-${randomUUID()}${extension}`);
+    const bytes = Buffer.from(await image.arrayBuffer());
+
+    if (!hasValidImageSignature(bytes, image.type)) {
+      return jsonResponse(
+        { ok: false, error: "Uploaded file content does not match the selected image type." },
+        400,
+      );
+    }
+
+    await writeFile(uploadPath, bytes, { flag: "wx" });
+
+    const result = await runMedGemma(uploadPath, prompt);
+    return jsonResponse(result, result.ok ? 200 : 500);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "MedGemma analysis failed.";
+    return jsonResponse({ ok: false, error: message }, 500);
+  } finally {
+    if (uploadPath) {
+      await rm(uploadPath, { force: true }).catch(() => undefined);
+    }
+  }
+}

--- a/ui/partner-hub/app/page.tsx
+++ b/ui/partner-hub/app/page.tsx
@@ -77,6 +77,11 @@ const caseStudies = [
 
 const toolCards = [
   {
+    title: "MedGemma Image Review",
+    description: "Upload an image for local medical-image description and red-flag review.",
+    href: "/medgemma",
+  },
+  {
     title: "Account Mapping",
     description: "Normalize and match account lists to streamline partner alignment.",
     href: "/accountmap",

--- a/ui/partner-hub/components/medgemma/MedGemmaReviewTool.tsx
+++ b/ui/partner-hub/components/medgemma/MedGemmaReviewTool.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { withBasePath } from "@/lib/basePath";
+
+const DEFAULT_PROMPT =
+  "Describe visible findings in cautious medical language. List possible benign explanations and red flags that would require a clinician. Do not provide a definitive diagnosis.";
+
+const acceptedImageTypes = ["image/jpeg", "image/png", "image/webp"];
+
+type AnalysisResponse = {
+  ok: boolean;
+  result?: string;
+  error?: string;
+};
+
+export function MedGemmaReviewTool() {
+  const [image, setImage] = useState<File | null>(null);
+  const [prompt, setPrompt] = useState("");
+  const [result, setResult] = useState("");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const helperText = useMemo(() => {
+    if (!image) {
+      return "Choose a JPG, PNG, or WebP image to review locally.";
+    }
+
+    const sizeInMb = image.size / (1024 * 1024);
+    return `${image.name} • ${sizeInMb.toFixed(2)} MB`;
+  }, [image]);
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError("");
+    setResult("");
+
+    if (!image) {
+      setError("Please select a JPG, PNG, or WebP image before analyzing.");
+      return;
+    }
+
+    if (!acceptedImageTypes.includes(image.type)) {
+      setError("Unsupported file type. Please upload a JPG, PNG, or WebP image.");
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const formData = new FormData();
+      formData.append("image", image);
+      formData.append("prompt", prompt.trim());
+
+      const response = await fetch(withBasePath("/api/medgemma/analyze"), {
+        method: "POST",
+        body: formData,
+      });
+      const data = (await response.json()) as AnalysisResponse;
+
+      if (!response.ok || !data.ok) {
+        throw new Error(data.error || "MedGemma analysis failed.");
+      }
+
+      setResult(data.result || "No response text was returned.");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "MedGemma analysis failed.";
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-8">
+      <section className="space-y-4 rounded-3xl border border-border/70 bg-gradient-to-br from-primary/10 via-card to-secondary/10 p-8 shadow-sm md:p-10">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground/50">
+          Local AI Tool
+        </p>
+        <div className="space-y-3">
+          <h1 className="text-3xl font-semibold tracking-tight md:text-4xl">
+            Local MedGemma Image Review
+          </h1>
+          <p className="max-w-3xl text-base leading-relaxed text-foreground/70">
+            Upload an image and run a local MedGemma review from this Next.js app. Images are
+            passed only to the local Python runner and are not sent to a remote API.
+          </p>
+        </div>
+        <div className="rounded-2xl border border-amber-300/70 bg-amber-50 p-4 text-sm font-medium text-amber-900 dark:border-amber-400/40 dark:bg-amber-950/40 dark:text-amber-100">
+          This tool is for image description and red-flag review only. It is not a diagnosis and
+          does not replace a clinician.
+        </div>
+      </section>
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_0.9fr]">
+        <Card className="border-border/70">
+          <CardHeader>
+            <CardTitle>Analyze an image</CardTitle>
+            <p className="text-sm text-foreground/60">
+              The API route stores the upload in a temporary ignored folder, calls the local Python
+              runner, then removes the temporary file.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-5" onSubmit={onSubmit}>
+              <div className="space-y-2">
+                <label className="text-sm font-semibold text-foreground" htmlFor="medgemma-image">
+                  Image file
+                </label>
+                <input
+                  id="medgemma-image"
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp,.jpg,.jpeg,.png,.webp"
+                  className="block w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground file:mr-4 file:rounded-md file:border-0 file:bg-muted file:px-3 file:py-2 file:text-sm file:font-semibold file:text-foreground hover:file:bg-muted/80"
+                  onChange={(event) => setImage(event.target.files?.[0] ?? null)}
+                />
+                <p className="text-xs text-foreground/60">{helperText}</p>
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-semibold text-foreground" htmlFor="medgemma-prompt">
+                  Optional prompt
+                </label>
+                <textarea
+                  id="medgemma-prompt"
+                  rows={7}
+                  value={prompt}
+                  onChange={(event) => setPrompt(event.target.value)}
+                  placeholder={DEFAULT_PROMPT}
+                  className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm transition placeholder:text-foreground/40 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
+                />
+                <p className="text-xs text-foreground/60">
+                  Leave blank to use the cautious default prompt.
+                </p>
+              </div>
+
+              <Button type="submit" disabled={isLoading} className="w-full sm:w-auto">
+                {isLoading ? "Analyzing locally..." : "Analyze image"}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+
+        <div className="space-y-6">
+          <Card className="border-border/70">
+            <CardHeader>
+              <CardTitle>Default safety prompt</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="rounded-lg bg-muted/50 p-4 text-sm leading-relaxed text-foreground/75">
+                {DEFAULT_PROMPT}
+              </p>
+            </CardContent>
+          </Card>
+
+          {isLoading ? (
+            <Card className="border-primary/30 bg-primary/5">
+              <CardHeader>
+                <CardTitle>Model running</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-foreground/70">
+                  Loading MedGemma and generating a response can take several minutes on the first
+                  run while model files are prepared locally.
+                </p>
+              </CardContent>
+            </Card>
+          ) : null}
+
+          {error ? (
+            <Card className="border-red-300 bg-red-50 dark:border-red-900/70 dark:bg-red-950/30">
+              <CardHeader>
+                <CardTitle>Error</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="whitespace-pre-wrap text-sm text-red-800 dark:text-red-100">{error}</p>
+              </CardContent>
+            </Card>
+          ) : null}
+
+          {result ? (
+            <Card className="border-emerald-300 bg-emerald-50 dark:border-emerald-900/70 dark:bg-emerald-950/30">
+              <CardHeader>
+                <CardTitle>MedGemma response</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="whitespace-pre-wrap text-sm leading-relaxed text-emerald-950 dark:text-emerald-50">
+                  {result}
+                </p>
+              </CardContent>
+            </Card>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/partner-hub/docs/medgemma-local.md
+++ b/ui/partner-hub/docs/medgemma-local.md
@@ -1,0 +1,62 @@
+# Local MedGemma Image Review
+
+The `/medgemma` page adds a local-only image review flow to the existing Next.js app. The browser uploads a JPG, PNG, or WebP image to a Next.js API route, the API route writes the file to an ignored temporary folder, and then it calls `scripts/medgemma_runner.py` with `child_process`. Images are not sent to a remote API by this implementation.
+
+> Safety note: this tool is for image description and red-flag review only. It is not a diagnosis and does not replace a clinician. Do not deploy it as a public medical diagnostic service.
+
+## Windows setup with NVIDIA RTX/CUDA
+
+Run these commands from `ui/partner-hub` unless noted otherwise.
+
+1. Create and activate a Python virtual environment:
+
+   ```powershell
+   py -3.11 -m venv .venv
+   .\.venv\Scripts\Activate.ps1
+   ```
+
+2. Install CUDA-enabled PyTorch for CUDA 12.1:
+
+   ```powershell
+   pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+   ```
+
+3. Install the MedGemma runner dependencies:
+
+   ```powershell
+   pip install transformers accelerate pillow huggingface_hub sentencepiece
+   ```
+
+4. Log in to Hugging Face using the token configured for your local account:
+
+   ```powershell
+   huggingface-cli login
+   ```
+
+5. In a browser, accept the model terms for `google/medgemma-1.5-4b-it` on Hugging Face. The local token must have access before the first run can download the model.
+
+6. Install Node dependencies and run the Next.js app:
+
+   ```powershell
+   npm install
+   npm run dev
+   ```
+
+7. Open the app and navigate to `/medgemma` (or click **MedGemma Image Review** on the home page).
+
+## Environment variables
+
+- `MEDGEMMA_PYTHON_PATH`: Optional path to the Python interpreter that has the MedGemma dependencies installed. Example for PowerShell:
+
+  ```powershell
+  $env:MEDGEMMA_PYTHON_PATH = ".\.venv\Scripts\python.exe"
+  npm run dev
+  ```
+
+- `MEDGEMMA_RUNNER_TIMEOUT_MS`: Optional API timeout in milliseconds. The default is 10 minutes, which allows for slower first-run model loading.
+
+## Local files and caches
+
+- Uploads are written under `.medgemma-uploads/` and removed after each API request completes.
+- `.medgemma-uploads/`, `.medgemma-cache/`, and local Hugging Face cache folders are ignored by Git so uploaded images and model artifacts are not committed.
+- Hugging Face Transformers may still use your normal user-level cache outside this repo, depending on your local Hugging Face configuration.

--- a/ui/partner-hub/scripts/medgemma_runner.py
+++ b/ui/partner-hub/scripts/medgemma_runner.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Run a local MedGemma image review and emit one JSON object on stdout."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import sys
+from pathlib import Path
+
+MODEL_ID = "google/medgemma-1.5-4b-it"
+DEFAULT_MAX_NEW_TOKENS = 512
+
+
+def emit(payload: dict[str, object], exit_code: int = 0) -> None:
+    print(json.dumps(payload, ensure_ascii=False), flush=True)
+    raise SystemExit(exit_code)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run local MedGemma image review.")
+    parser.add_argument("--image", required=True, help="Path to a local JPG, PNG, or WebP image.")
+    parser.add_argument("--prompt", required=True, help="Prompt to send with the image.")
+    parser.add_argument(
+        "--max-new-tokens",
+        type=int,
+        default=DEFAULT_MAX_NEW_TOKENS,
+        help=f"Maximum response tokens to generate (default: {DEFAULT_MAX_NEW_TOKENS}).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    image_path = Path(args.image).expanduser().resolve()
+
+    if not image_path.is_file():
+        emit({"ok": False, "error": f"Image file not found: {image_path}"}, 2)
+
+    try:
+        with contextlib.redirect_stdout(sys.stderr):
+            import torch
+            from PIL import Image
+            from transformers import AutoModelForImageTextToText, AutoProcessor
+
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+            dtype = torch.bfloat16 if device == "cuda" else torch.float32
+
+            print(f"Loading {MODEL_ID} on {device}...", file=sys.stderr, flush=True)
+            processor = AutoProcessor.from_pretrained(MODEL_ID)
+            model = AutoModelForImageTextToText.from_pretrained(
+                MODEL_ID,
+                torch_dtype=dtype,
+                device_map="auto" if device == "cuda" else None,
+            )
+            if device != "cuda":
+                model = model.to(device)
+
+            image = Image.open(image_path).convert("RGB")
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image", "image": image},
+                        {"type": "text", "text": args.prompt},
+                    ],
+                }
+            ]
+
+            inputs = processor.apply_chat_template(
+                messages,
+                add_generation_prompt=True,
+                tokenize=True,
+                return_dict=True,
+                return_tensors="pt",
+            )
+            if device == "cuda":
+                inputs = inputs.to(model.device, dtype=dtype)
+            else:
+                inputs = inputs.to(model.device)
+            input_token_count = inputs["input_ids"].shape[-1]
+
+            with torch.inference_mode():
+                generated_ids = model.generate(**inputs, max_new_tokens=args.max_new_tokens)
+
+            generated_ids = generated_ids[:, input_token_count:]
+            result = processor.batch_decode(generated_ids, skip_special_tokens=True)[0].strip()
+
+        emit({"ok": True, "result": result})
+    except Exception as exc:  # noqa: BLE001 - CLI must convert all failures to JSON for the API route.
+        print(f"MedGemma runner failed: {exc}", file=sys.stderr, flush=True)
+        emit({"ok": False, "error": str(exc)}, 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a local-only MedGemma image review flow embedded in the Next.js partner-hub so users can run a cautious image-description / red-flag review with local model artifacts instead of a remote medical API.
- Ensure uploads are handled safely and transiently (temporary ignored folder + runner invocation + cleanup) and document local setup for CUDA/Hugging Face usage.

### Description
- Add a new route and UI: `app/(routes)/medgemma/page.tsx` and `components/medgemma/MedGemmaReviewTool.tsx` implement the client-side upload UI, default safety prompt, loading/result/error panels, and an analyze button that posts to the API using `withBasePath("/api/medgemma/analyze")`.
- Add API route: `app/api/medgemma/analyze/route.ts` validates `JPG/PNG/WebP` uploads (size/type/signature), writes uploads under `.medgemma-uploads/`, spawns the local Python runner via `child_process`, returns the runner JSON, and removes the temp file; it respects `MEDGEMMA_PYTHON_PATH` and `MEDGEMMA_RUNNER_TIMEOUT_MS`.
- Add Python runner: `scripts/medgemma_runner.py` loads `google/medgemma-1.5-4b-it` via Hugging Face Transformers, prefers CUDA when available, emits a single JSON object to stdout on success/failure, and returns nonzero exit codes for CLI failure modes.
- Docs and housekeeping: `ui/partner-hub/docs/medgemma-local.md` documents setup (Windows/CUDA/HF token notes), and `.gitignore` was updated to ignore `.medgemma-uploads/`, `.medgemma-cache/`, and local Hugging Face cache folders.
- UX change: add a home page tool card linking to `/medgemma` in `app/page.tsx`.

### Testing
- PASS: `python -m py_compile scripts/medgemma_runner.py` succeeded (runner is syntactically valid).
- PASS: `python scripts/medgemma_runner.py --image /tmp/does-not-exist.png --prompt test` returned the expected JSON error and exit code for a missing file.
- WARNING: `npm run lint` could not run because `next` and local `node_modules` were not available in this environment (`sh: 1: next: not found`).
- WARNING: `npm run build` prebuild failed because `prisma` was not available locally (`sh: 1: prisma: not found`).
- WARNING: `npm ci`/`npm install` attempts were blocked or failed in this environment (lockfile mismatch and registry `403`), so full JS dependency install and Next.js build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff95bc729083308f77309264c2aec9)