### PR TITLE
Make MedGemma setup repo-local (add Windows helper and prefer .venv-medgemma python)

### DIFF
--- a/ui/partner-hub/.gitignore
+++ b/ui/partner-hub/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 .next/
 out/
 # Local MedGemma uploads/model artifacts
+.venv-medgemma/
 .medgemma-uploads/
 .medgemma-cache/
 .cache/huggingface/

--- a/ui/partner-hub/app/api/medgemma/analyze/route.ts
+++ b/ui/partner-hub/app/api/medgemma/analyze/route.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto";
 import { spawn } from "child_process";
+import { existsSync } from "fs";
 import { mkdir, rm, writeFile } from "fs/promises";
 import path from "path";
 
@@ -55,8 +56,23 @@ const hasValidImageSignature = (bytes: Buffer, mimeType: string) => {
   return false;
 };
 
+const getMedGemmaPythonPath = () => {
+  if (process.env.MEDGEMMA_PYTHON_PATH) {
+    return process.env.MEDGEMMA_PYTHON_PATH;
+  }
+
+  const localPythonPath = path.join(
+    process.cwd(),
+    ".venv-medgemma",
+    process.platform === "win32" ? "Scripts" : "bin",
+    process.platform === "win32" ? "python.exe" : "python",
+  );
+
+  return existsSync(localPythonPath) ? localPythonPath : "python";
+};
+
 const runMedGemma = (imagePath: string, prompt: string): Promise<RunnerResult> => {
-  const pythonPath = process.env.MEDGEMMA_PYTHON_PATH || "python";
+  const pythonPath = getMedGemmaPythonPath();
   const runnerPath = path.join(process.cwd(), "scripts", "medgemma_runner.py");
 
   return new Promise((resolve) => {

--- a/ui/partner-hub/docs/medgemma-local.md
+++ b/ui/partner-hub/docs/medgemma-local.md
@@ -4,52 +4,66 @@ The `/medgemma` page adds a local-only image review flow to the existing Next.js
 
 > Safety note: this tool is for image description and red-flag review only. It is not a diagnosis and does not replace a clinician. Do not deploy it as a public medical diagnostic service.
 
-## Windows setup with NVIDIA RTX/CUDA
+## Preferred repo-local setup
 
-Run these commands from `ui/partner-hub` unless noted otherwise.
+Run MedGemma setup from `ui/partner-hub` so the Python environment is self-contained inside this app directory.
 
-1. Create and activate a Python virtual environment:
+### Windows with NVIDIA RTX/CUDA
 
-   ```powershell
-   py -3.11 -m venv .venv
-   .\.venv\Scripts\Activate.ps1
-   ```
-
-2. Install CUDA-enabled PyTorch for CUDA 12.1:
+1. From `ui/partner-hub`, run the setup helper:
 
    ```powershell
-   pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+   powershell -ExecutionPolicy Bypass -File scripts/setup-medgemma.ps1
    ```
 
-3. Install the MedGemma runner dependencies:
+   The helper creates `.venv-medgemma`, upgrades pip, installs CUDA-enabled PyTorch for CUDA 12.1, and installs the MedGemma runner dependencies.
+
+2. Activate the repo-local MedGemma environment:
 
    ```powershell
-   pip install transformers accelerate pillow huggingface_hub sentencepiece
+   .\.venv-medgemma\Scripts\Activate.ps1
    ```
 
-4. Log in to Hugging Face using the token configured for your local account:
+3. Log in to Hugging Face using the token configured for your local account:
 
    ```powershell
-   huggingface-cli login
+   hf auth login
    ```
 
-5. In a browser, accept the model terms for `google/medgemma-1.5-4b-it` on Hugging Face. The local token must have access before the first run can download the model.
+4. In a browser, accept the model terms for `google/medgemma-1.5-4b-it` on Hugging Face. The local token must have access before the first run can download the model.
 
-6. Install Node dependencies and run the Next.js app:
+5. Install Node dependencies and run the Next.js app:
 
    ```powershell
    npm install
    npm run dev
    ```
 
-7. Open the app and navigate to `/medgemma` (or click **MedGemma Image Review** on the home page).
+6. Open the app and navigate to `/medgemma` (or click **MedGemma Image Review** on the home page).
+
+### Manual macOS/Linux setup
+
+From `ui/partner-hub`, create a repo-local environment named `.venv-medgemma` and install the same runner dependencies:
+
+```bash
+python -m venv .venv-medgemma
+source .venv-medgemma/bin/activate
+python -m pip install --upgrade pip
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+pip install transformers accelerate pillow huggingface_hub sentencepiece
+hf auth login
+npm install
+npm run dev
+```
+
+Accept the Hugging Face model terms for `google/medgemma-1.5-4b-it` before the first run.
 
 ## Environment variables
 
-- `MEDGEMMA_PYTHON_PATH`: Optional path to the Python interpreter that has the MedGemma dependencies installed. Example for PowerShell:
+- `MEDGEMMA_PYTHON_PATH`: Optional override only. By default, the API route first uses the repo-local `.venv-medgemma` interpreter for the current platform (`.venv-medgemma/Scripts/python.exe` on Windows or `.venv-medgemma/bin/python` on macOS/Linux) and falls back to `python` when that interpreter is not present. Set this only if you intentionally want to use a different Python interpreter with the MedGemma dependencies installed. Example for PowerShell:
 
   ```powershell
-  $env:MEDGEMMA_PYTHON_PATH = ".\.venv\Scripts\python.exe"
+  $env:MEDGEMMA_PYTHON_PATH = ".\.venv-medgemma\Scripts\python.exe"
   npm run dev
   ```
 
@@ -57,6 +71,7 @@ Run these commands from `ui/partner-hub` unless noted otherwise.
 
 ## Local files and caches
 
+- The preferred setup creates `.venv-medgemma/` under `ui/partner-hub` for MedGemma Python dependencies.
 - Uploads are written under `.medgemma-uploads/` and removed after each API request completes.
-- `.medgemma-uploads/`, `.medgemma-cache/`, and local Hugging Face cache folders are ignored by Git so uploaded images and model artifacts are not committed.
+- `.venv-medgemma/`, `.medgemma-uploads/`, `.medgemma-cache/`, and local Hugging Face cache folders are ignored by Git so uploaded images, dependencies, and model artifacts are not committed.
 - Hugging Face Transformers may still use your normal user-level cache outside this repo, depending on your local Hugging Face configuration.

--- a/ui/partner-hub/scripts/setup-medgemma.ps1
+++ b/ui/partner-hub/scripts/setup-medgemma.ps1
@@ -1,0 +1,25 @@
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $ProjectRoot
+
+$VenvPath = Join-Path $ProjectRoot ".venv-medgemma"
+$VenvPython = Join-Path $VenvPath "Scripts\python.exe"
+$VenvPip = Join-Path $VenvPath "Scripts\pip.exe"
+
+Write-Host "Setting up MedGemma Python environment in $VenvPath"
+
+if (-not (Test-Path $VenvPython)) {
+  python -m venv .venv-medgemma
+}
+
+& $VenvPython -m pip install --upgrade pip
+& $VenvPip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+& $VenvPip install transformers accelerate pillow huggingface_hub sentencepiece
+
+Write-Host ""
+Write-Host "MedGemma setup complete. Next steps:"
+Write-Host ".\.venv-medgemma\Scripts\Activate.ps1"
+Write-Host "hf auth login"
+Write-Host "Accept Hugging Face model terms for google/medgemma-1.5-4b-it"
+Write-Host "npm run dev"


### PR DESCRIPTION
### Motivation
- Ensure MedGemma can be set up entirely inside the repo so local installs do not rely on global or repo-wide `.venv` paths and to provide a Windows helper for reproducible local development.
- Prefer a repo-local Python interpreter for the MedGemma runner while keeping an environment override to support advanced use cases.

### Description
- Added a Windows setup helper at `ui/partner-hub/scripts/setup-medgemma.ps1` that creates `.venv-medgemma`, upgrades `pip`, installs CUDA-enabled PyTorch (`torch`, `torchvision`, `torchaudio`) with the CUDA 12.1 index URL, installs `transformers`, `accelerate`, `pillow`, `huggingface_hub`, and `sentencepiece`, and prints next steps (`.\.venv-medgemma\Scripts\Activate.ps1`, `hf auth login`, accept model terms, `npm run dev`).
- Updated the MedGemma API runner path resolution in `app/api/medgemma/analyze/route.ts` to prefer `process.env.MEDGEMMA_PYTHON_PATH` as an override, then the repo-local `.venv-medgemma` interpreter for the current platform (`.venv-medgemma\Scripts\python.exe` on Windows or `.venv-medgemma/bin/python` on macOS/Linux), and finally fall back to `python`.
- Documented the repo-local setup in `docs/medgemma-local.md` to prefer running setup from `ui/partner-hub`, to use `.venv-medgemma` rather than `.venv`, to use `hf auth login` (instead of the deprecated CLI), to show the PowerShell helper invocation `powershell -ExecutionPolicy Bypass -File scripts/setup-medgemma.ps1`, and to state that `MEDGEMMA_PYTHON_PATH` is an optional override only.
- Added `.venv-medgemma/` to `ui/partner-hub/.gitignore` and ensured existing `.medgemma-uploads/` and caches remain ignored, while keeping `/medgemma` UI and API behavior intact (only the Python path resolution and setup docs/helpers changed).

### Testing
- `git diff --check` — passed with no whitespace or diff errors.
- `npm run lint` — attempted but failed in this environment because `next` was not available from `node_modules` (`node_modules` was not installed here), so lint could not complete.
- `npm install` — attempted but failed with a registry error (`403 Forbidden` when fetching `react`) causing dependency installation to be unavailable in this environment.
- `npm run build` — attempted but failed because `prisma`/other tooling were not available due to the failed `npm install`, so a full build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff98e37cf883309161b93a0711bc32)