### PR TITLE
Harden MedGemma image upload handling

### DIFF
--- a/ui/partner-hub/app/api/medgemma/analyze/route.ts
+++ b/ui/partner-hub/app/api/medgemma/analyze/route.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "crypto";
 import { spawn } from "child_process";
 import { existsSync } from "fs";
-import { mkdir, rm, writeFile } from "fs/promises";
+import { mkdir, rm, stat, writeFile } from "fs/promises";
 import path from "path";
 
 import { NextRequest, NextResponse } from "next/server";
@@ -17,23 +17,61 @@ const ALLOWED_TYPES = new Map([
   ["image/png", ".png"],
   ["image/webp", ".webp"],
 ]);
-const RUNNER_TIMEOUT_MS = Number(process.env.MEDGEMMA_RUNNER_TIMEOUT_MS || 10 * 60 * 1000);
+const RUNNER_TIMEOUT_MS = Number(
+  process.env.MEDGEMMA_RUNNER_TIMEOUT_MS || 10 * 60 * 1000,
+);
 
 type RunnerResult = {
   ok: boolean;
   result?: string;
   error?: string;
+  errorType?:
+    | "image_decode_failed"
+    | "runner_failed"
+    | "upload_validation_failed"
+    | "temp_write_failed";
 };
 
-const jsonResponse = (body: RunnerResult, status = 200) => NextResponse.json(body, { status });
+const jsonResponse = (body: RunnerResult, status = 200) =>
+  NextResponse.json(body, { status });
+
+const uploadValidationError = (error: string) =>
+  jsonResponse(
+    {
+      ok: false,
+      error: `Upload validation failed: ${error}`,
+      errorType: "upload_validation_failed",
+    },
+    400,
+  );
+
+const tempWriteError = (error: string) =>
+  jsonResponse(
+    {
+      ok: false,
+      error: `Temporary upload write failed: ${error}`,
+      errorType: "temp_write_failed",
+    },
+    500,
+  );
 
 const isFileLike = (value: FormDataEntryValue | null): value is File => {
-  return Boolean(value && typeof value === "object" && "arrayBuffer" in value && "type" in value);
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    "arrayBuffer" in value &&
+    "type" in value,
+  );
 };
 
 const hasValidImageSignature = (bytes: Buffer, mimeType: string) => {
   if (mimeType === "image/jpeg") {
-    return bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+    return (
+      bytes.length >= 3 &&
+      bytes[0] === 0xff &&
+      bytes[1] === 0xd8 &&
+      bytes[2] === 0xff
+    );
   }
 
   if (mimeType === "image/png") {
@@ -71,16 +109,23 @@ const getMedGemmaPythonPath = () => {
   return existsSync(localPythonPath) ? localPythonPath : "python";
 };
 
-const runMedGemma = (imagePath: string, prompt: string): Promise<RunnerResult> => {
+const runMedGemma = (
+  imagePath: string,
+  prompt: string,
+): Promise<RunnerResult> => {
   const pythonPath = getMedGemmaPythonPath();
   const runnerPath = path.join(process.cwd(), "scripts", "medgemma_runner.py");
 
   return new Promise((resolve) => {
-    const child = spawn(pythonPath, [runnerPath, "--image", imagePath, "--prompt", prompt], {
-      cwd: process.cwd(),
-      env: process.env,
-      windowsHide: true,
-    });
+    const child = spawn(
+      pythonPath,
+      [runnerPath, "--image", imagePath, "--prompt", prompt],
+      {
+        cwd: process.cwd(),
+        env: process.env,
+        windowsHide: true,
+      },
+    );
 
     let stdout = "";
     let stderr = "";
@@ -98,6 +143,7 @@ const runMedGemma = (imagePath: string, prompt: string): Promise<RunnerResult> =
       child.kill("SIGTERM");
       finish({
         ok: false,
+        errorType: "runner_failed",
         error: `MedGemma runner timed out after ${Math.round(RUNNER_TIMEOUT_MS / 1000)} seconds.`,
       });
     }, RUNNER_TIMEOUT_MS);
@@ -112,7 +158,11 @@ const runMedGemma = (imagePath: string, prompt: string): Promise<RunnerResult> =
 
     child.on("error", (error) => {
       clearTimeout(timeout);
-      finish({ ok: false, error: `Unable to start MedGemma runner: ${error.message}` });
+      finish({
+        ok: false,
+        errorType: "runner_failed",
+        error: `Unable to start MedGemma runner: ${error.message}`,
+      });
     });
 
     child.on("close", (code) => {
@@ -129,8 +179,13 @@ const runMedGemma = (imagePath: string, prompt: string): Promise<RunnerResult> =
         }
         finish(parsed);
       } catch {
-        const details = stderr.trim() || trimmedStdout || `Runner exited with code ${code}.`;
-        finish({ ok: false, error: `MedGemma runner did not return valid JSON. ${details}` });
+        const details =
+          stderr.trim() || trimmedStdout || `Runner exited with code ${code}.`;
+        finish({
+          ok: false,
+          errorType: "runner_failed",
+          error: `MedGemma runner did not return valid JSON. ${details}`,
+        });
       }
     });
   });
@@ -145,49 +200,99 @@ export async function POST(request: NextRequest) {
     const rawPrompt = formData.get("prompt");
 
     if (!isFileLike(image)) {
-      return jsonResponse(
-        { ok: false, error: "A JPG, PNG, or WebP image upload is required." },
-        400,
+      return uploadValidationError(
+        "A JPG, PNG, or WebP image upload is required.",
       );
     }
 
     const extension = ALLOWED_TYPES.get(image.type);
     if (!extension) {
-      return jsonResponse(
-        { ok: false, error: "Unsupported file type. Upload a JPG, PNG, or WebP image." },
-        400,
+      return uploadValidationError(
+        "Unsupported file type. Upload a JPG, PNG, or WebP image.",
       );
     }
 
     if (image.size <= 0) {
-      return jsonResponse({ ok: false, error: "Uploaded image is empty." }, 400);
+      return uploadValidationError("Uploaded image is empty.");
     }
 
     if (image.size > MAX_UPLOAD_BYTES) {
-      return jsonResponse({ ok: false, error: "Uploaded image must be 10 MB or smaller." }, 400);
+      return uploadValidationError("Uploaded image must be 10 MB or smaller.");
     }
 
     const prompt =
-      typeof rawPrompt === "string" && rawPrompt.trim() ? rawPrompt.trim() : DEFAULT_PROMPT;
+      typeof rawPrompt === "string" && rawPrompt.trim()
+        ? rawPrompt.trim()
+        : DEFAULT_PROMPT;
     const uploadsDir = path.join(process.cwd(), ".medgemma-uploads");
     await mkdir(uploadsDir, { recursive: true });
 
-    uploadPath = path.join(uploadsDir, `${Date.now()}-${randomUUID()}${extension}`);
+    uploadPath = path.join(
+      uploadsDir,
+      `${Date.now()}-${randomUUID()}${extension}`,
+    );
     const bytes = Buffer.from(await image.arrayBuffer());
 
-    if (!hasValidImageSignature(bytes, image.type)) {
-      return jsonResponse(
-        { ok: false, error: "Uploaded file content does not match the selected image type." },
-        400,
+    if (bytes.length !== image.size) {
+      return uploadValidationError(
+        `Uploaded image size changed while reading form data (expected ${image.size} bytes, got ${bytes.length} bytes).`,
       );
     }
 
-    await writeFile(uploadPath, bytes, { flag: "wx" });
+    if (!hasValidImageSignature(bytes, image.type)) {
+      return uploadValidationError(
+        "Uploaded file content does not match the selected image type.",
+      );
+    }
+
+    try {
+      await writeFile(uploadPath, bytes, { flag: "wx" });
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Could not write uploaded image.";
+      return tempWriteError(message);
+    }
+
+    let uploadStats;
+    try {
+      uploadStats = await stat(uploadPath);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Temporary upload file is missing.";
+      return tempWriteError(
+        `Temporary file was not readable after write. ${message}`,
+      );
+    }
+
+    if (!uploadStats.isFile() || uploadStats.size !== bytes.length) {
+      return tempWriteError(
+        `Temporary file size mismatch after write (expected ${bytes.length} bytes, got ${uploadStats.size} bytes).`,
+      );
+    }
 
     const result = await runMedGemma(uploadPath, prompt);
-    return jsonResponse(result, result.ok ? 200 : 500);
+    if (!result.ok) {
+      const prefix =
+        result.errorType === "image_decode_failed"
+          ? "Image decode failed"
+          : "MedGemma runner failed";
+      return jsonResponse(
+        {
+          ...result,
+          error: `${prefix}: ${result.error || "Analysis could not be completed."}`,
+        },
+        500,
+      );
+    }
+
+    return jsonResponse(result);
   } catch (error) {
-    const message = error instanceof Error ? error.message : "MedGemma analysis failed.";
+    const message =
+      error instanceof Error ? error.message : "MedGemma analysis failed.";
     return jsonResponse({ ok: false, error: message }, 500);
   } finally {
     if (uploadPath) {

--- a/ui/partner-hub/scripts/medgemma_runner.py
+++ b/ui/partner-hub/scripts/medgemma_runner.py
@@ -7,10 +7,17 @@ import argparse
 import contextlib
 import json
 import sys
+from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 MODEL_ID = "google/medgemma-1.5-4b-it"
 DEFAULT_MAX_NEW_TOKENS = 512
+SUPPORTED_FALLBACK_FORMATS = {"JPEG", "PNG", "WEBP"}
+
+
+class ImageDecodeFailure(Exception):
+    """Raised when PIL cannot safely decode the uploaded image."""
 
 
 def emit(payload: dict[str, object], exit_code: int = 0) -> None:
@@ -31,17 +38,137 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def is_truncated_image_error(exc: BaseException) -> bool:
+    message = str(exc).lower()
+    return any(
+        fragment in message
+        for fragment in (
+            "truncated",
+            "broken data stream",
+            "image file is incomplete",
+            "unexpected end of file",
+        )
+    )
+
+
+@contextlib.contextmanager
+def allow_truncated_images_temporarily(image_file: Any) -> Iterator[None]:
+    previous = image_file.LOAD_TRUNCATED_IMAGES
+    # This is deliberately scoped to a single fallback read after Image.verify()
+    # has accepted the file container. Some valid mobile/screenshot images fail
+    # a strict pixel load because of trailing/ancillary chunk quirks, but keeping
+    # the PIL flag local prevents later reads from silently accepting corrupt
+    # uploads that did not pass the initial validation step.
+    image_file.LOAD_TRUNCATED_IMAGES = True
+    try:
+        yield
+    finally:
+        image_file.LOAD_TRUNCATED_IMAGES = previous
+
+
+def decode_error(message: str, exc: BaseException | None = None) -> ImageDecodeFailure:
+    if exc is None:
+        return ImageDecodeFailure(message)
+    return ImageDecodeFailure(f"{message} ({exc})")
+
+
+def load_verified_rgb_image(
+    image_path: Path,
+    image_module: Any,
+    image_ops: Any,
+    image_file: Any,
+    unidentified_error: type[Exception],
+) -> Any:
+    print(f"Validating image file {image_path}...", file=sys.stderr, flush=True)
+
+    image_format = "unknown"
+    try:
+        with image_module.open(image_path) as image:
+            image_format = image.format or "unknown"
+            image.verify()
+    except unidentified_error as exc:
+        raise decode_error(
+            "PIL could not identify the uploaded image. Upload a valid JPG, PNG, or WebP file.",
+            exc,
+        ) from exc
+    except OSError as exc:
+        hint = (
+            "The uploaded image appears to be corrupt or truncated. "
+            "Try opening it locally and re-exporting it as a new PNG or JPG."
+        )
+        raise decode_error(f"PIL could not verify the uploaded image. {hint}", exc) from exc
+
+    try:
+        with image_module.open(image_path) as image:
+            image = image_ops.exif_transpose(image)
+            image.load()
+            return image.convert("RGB")
+    except unidentified_error as exc:
+        raise decode_error(
+            "PIL could not identify the uploaded image after verification. "
+            "Upload a valid JPG, PNG, or WebP file.",
+            exc,
+        ) from exc
+    except OSError as exc:
+        if image_format not in SUPPORTED_FALLBACK_FORMATS or not is_truncated_image_error(exc):
+            raise decode_error(
+                "PIL verified the uploaded image container but could not decode the image pixels. "
+                "Try re-exporting the file as a new PNG or JPG.",
+                exc,
+            ) from exc
+
+        print(
+            "Strict PIL image load failed after verification; attempting scoped fallback decode.",
+            file=sys.stderr,
+            flush=True,
+        )
+        try:
+            with allow_truncated_images_temporarily(image_file):
+                with image_module.open(image_path) as image:
+                    image = image_ops.exif_transpose(image)
+                    image.load()
+                    fallback_image = image.convert("RGB")
+        except (unidentified_error, OSError) as fallback_exc:
+            raise decode_error(
+                "PIL could not fully decode the uploaded image. It appears to be corrupt "
+                "or truncated; try re-exporting it as a new PNG or JPG before uploading again.",
+                fallback_exc,
+            ) from fallback_exc
+
+        if fallback_image.width <= 0 or fallback_image.height <= 0:
+            raise decode_error("PIL decoded an invalid image with empty dimensions.")
+
+        print("Scoped fallback image decode succeeded.", file=sys.stderr, flush=True)
+        return fallback_image
+
+
 def main() -> None:
     args = parse_args()
     image_path = Path(args.image).expanduser().resolve()
 
     if not image_path.is_file():
-        emit({"ok": False, "error": f"Image file not found: {image_path}"}, 2)
+        emit(
+            {
+                "ok": False,
+                "errorType": "image_decode_failed",
+                "error": f"Image file not found: {image_path}",
+            },
+            2,
+        )
 
     try:
         with contextlib.redirect_stdout(sys.stderr):
+            from PIL import Image, ImageFile, ImageOps, UnidentifiedImageError
+
+            image = load_verified_rgb_image(
+                image_path,
+                Image,
+                ImageOps,
+                ImageFile,
+                UnidentifiedImageError,
+            )
+
             import torch
-            from PIL import Image
             from transformers import AutoModelForImageTextToText, AutoProcessor
 
             device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -57,7 +184,6 @@ def main() -> None:
             if device != "cuda":
                 model = model.to(device)
 
-            image = Image.open(image_path).convert("RGB")
             messages = [
                 {
                     "role": "user",
@@ -88,9 +214,13 @@ def main() -> None:
             result = processor.batch_decode(generated_ids, skip_special_tokens=True)[0].strip()
 
         emit({"ok": True, "result": result})
-    except Exception as exc:  # noqa: BLE001 - CLI must convert all failures to JSON for the API route.
+    except ImageDecodeFailure as exc:
+        print(f"MedGemma image decode failed: {exc}", file=sys.stderr, flush=True)
+        emit({"ok": False, "errorType": "image_decode_failed", "error": str(exc)}, 1)
+    # CLI must convert all failures to JSON for the API route.
+    except Exception as exc:  # noqa: BLE001
         print(f"MedGemma runner failed: {exc}", file=sys.stderr, flush=True)
-        emit({"ok": False, "error": str(exc)}, 1)
+        emit({"ok": False, "errorType": "runner_failed", "error": str(exc)}, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Fix vague `image file is truncated` failures by validating the uploaded buffer and making Python runner image loading defensive. 
- Ensure the temp file written by the Next.js API exists and its byte size matches the uploaded buffer before invoking the local runner. 
- Surface clear, distinct API errors for upload validation, temp-write/size mismatch, runner failures, and image decode failures. 
- Preserve the existing `/medgemma` UI, local-only architecture, cleanup behavior, and default safety prompt.

### Description
- Update `ui/partner-hub/app/api/medgemma/analyze/route.ts` to validate that `bytes.length === image.size`, write the temp file, `stat` the file, and assert the written file size matches the buffer before spawning the runner. 
- Add structured error categories and helpers that return `errorType` (`upload_validation_failed`, `temp_write_failed`, `image_decode_failed`, `runner_failed`) and user-facing error prefixes. 
- Improve `runMedGemma` handling to include `errorType` for runner timeouts/start/JSON parse issues so the API can present clearer messages. 
- Replace the naive PIL load in `ui/partner-hub/scripts/medgemma_runner.py` with a defensive `load_verified_rgb_image` flow that uses `Image.verify()` then reopens and converts to RGB, catches `UnidentifiedImageError` and `OSError`, emits a single JSON object on stdout for results/errors, and logs diagnostics to stderr. 
- Implement a scoped fallback decode path using a local toggle of `ImageFile.LOAD_TRUNCATED_IMAGES` for otherwise-verified JPEG/PNG/WEBP files that fail strict pixel loads, with code comments explaining the limited justification and scope. 
- Preserve cleanup of the temp upload, do not send images to any remote API, and keep the existing default safety prompt unchanged.

### Testing
- ✅ `git diff --check` reported no issues. 
- ✅ `python -m py_compile ui/partner-hub/scripts/medgemma_runner.py` succeeded. 
- ✅ Runner helper assertions (scoped fallback helper and flag behaviour) executed in a Python check and passed. 
- ⚠️ `python -m pip install --user Pillow` could not complete in this environment due to registry/proxy `403` so Pillow-backed integration fixture tests were not runnable here. 
- ⚠️ `cd ui/partner-hub && npm ci`, `npm run lint`, and `npm run build` could not complete in this environment because package registry access was blocked, so CI/lint/build checks could not be verified locally here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9d9f90f48330a64d7dde9098d8d3)