### PR TITLE
Fix MedGemma PyTorch version setup

### DIFF
--- a/ui/partner-hub/docs/medgemma-local.md
+++ b/ui/partner-hub/docs/medgemma-local.md
@@ -16,7 +16,7 @@ Run MedGemma setup from `ui/partner-hub` so the Python environment is self-conta
    powershell -ExecutionPolicy Bypass -File scripts/setup-medgemma.ps1
    ```
 
-   The helper creates `.venv-medgemma`, upgrades pip, installs CUDA-enabled PyTorch for CUDA 12.1, and installs the MedGemma runner dependencies.
+   The helper creates `.venv-medgemma`, upgrades pip, installs or upgrades CUDA-enabled PyTorch from the CUDA 12.4 wheel index with `torch>=2.6`, and installs the MedGemma runner dependencies.
 
 2. Activate the repo-local MedGemma environment:
 
@@ -49,7 +49,7 @@ From `ui/partner-hub`, create a repo-local environment named `.venv-medgemma` an
 python -m venv .venv-medgemma
 source .venv-medgemma/bin/activate
 python -m pip install --upgrade pip
-pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+pip install --upgrade "torch>=2.6" torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
 pip install transformers accelerate pillow huggingface_hub sentencepiece
 hf auth login
 npm install

--- a/ui/partner-hub/scripts/medgemma_runner.py
+++ b/ui/partner-hub/scripts/medgemma_runner.py
@@ -13,11 +13,16 @@ from typing import Any
 
 MODEL_ID = "google/medgemma-1.5-4b-it"
 DEFAULT_MAX_NEW_TOKENS = 512
+MIN_TORCH_VERSION = (2, 6)
 SUPPORTED_FALLBACK_FORMATS = {"JPEG", "PNG", "WEBP"}
 
 
 class ImageDecodeFailure(Exception):
     """Raised when PIL cannot safely decode the uploaded image."""
+
+
+class TorchVersionFailure(Exception):
+    """Raised when the installed PyTorch version is too old for MedGemma."""
 
 
 def emit(payload: dict[str, object], exit_code: int = 0) -> None:
@@ -36,6 +41,33 @@ def parse_args() -> argparse.Namespace:
         help=f"Maximum response tokens to generate (default: {DEFAULT_MAX_NEW_TOKENS}).",
     )
     return parser.parse_args()
+
+
+def parse_torch_version(version: str) -> tuple[int, ...]:
+    release = version.split("+", 1)[0]
+    parts: list[int] = []
+    for part in release.split("."):
+        digits = ""
+        for char in part:
+            if not char.isdigit():
+                break
+            digits += char
+        if digits == "":
+            break
+        parts.append(int(digits))
+    return tuple(parts)
+
+
+def ensure_supported_torch_version(torch_module: Any) -> None:
+    installed_version = getattr(torch_module, "__version__", "unknown")
+    parsed_version = parse_torch_version(installed_version)
+    if parsed_version < MIN_TORCH_VERSION:
+        min_version = ".".join(str(part) for part in MIN_TORCH_VERSION)
+        raise TorchVersionFailure(
+            f"PyTorch {installed_version} is installed, but MedGemma requires torch>={min_version}. "
+            "Rerun scripts/setup-medgemma.ps1 from ui/partner-hub to upgrade the repo-local "
+            ".venv-medgemma environment with a compatible CUDA PyTorch build."
+        )
 
 
 def is_truncated_image_error(exc: BaseException) -> bool:
@@ -169,6 +201,9 @@ def main() -> None:
             )
 
             import torch
+
+            ensure_supported_torch_version(torch)
+
             from transformers import AutoModelForImageTextToText, AutoProcessor
 
             device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -217,6 +252,9 @@ def main() -> None:
     except ImageDecodeFailure as exc:
         print(f"MedGemma image decode failed: {exc}", file=sys.stderr, flush=True)
         emit({"ok": False, "errorType": "image_decode_failed", "error": str(exc)}, 1)
+    except TorchVersionFailure as exc:
+        print(f"MedGemma runner failed: {exc}", file=sys.stderr, flush=True)
+        emit({"ok": False, "errorType": "runner_failed", "error": str(exc)}, 1)
     # CLI must convert all failures to JSON for the API route.
     except Exception as exc:  # noqa: BLE001
         print(f"MedGemma runner failed: {exc}", file=sys.stderr, flush=True)

--- a/ui/partner-hub/scripts/setup-medgemma.ps1
+++ b/ui/partner-hub/scripts/setup-medgemma.ps1
@@ -14,7 +14,7 @@ if (-not (Test-Path $VenvPython)) {
 }
 
 & $VenvPython -m pip install --upgrade pip
-& $VenvPip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+& $VenvPip install --upgrade "torch>=2.6" torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
 & $VenvPip install transformers accelerate pillow huggingface_hub sentencepiece
 
 Write-Host ""


### PR DESCRIPTION
### Motivation
- The MedGemma runner was failing with `Using or_mask_function or and_mask_function arguments require torch>=2.6`, so the repo-local setup must install/upgrade a compatible PyTorch build. 
- The change must be local-only, preserve the existing `/medgemma` UI/API flow and safety banner/prompt, and keep the `hf auth login` instructions.

### Description
- Updated `ui/partner-hub/scripts/setup-medgemma.ps1` to install or upgrade CUDA-enabled PyTorch with `--upgrade "torch>=2.6"` using the CUDA 12.4 wheel index `https://download.pytorch.org/whl/cu124` so rerunning the helper upgrades an existing `.venv-medgemma` environment. 
- Updated `ui/partner-hub/docs/medgemma-local.md` to document the new install command and removed the stale CUDA 12.1 install guidance while preserving the `hf auth login` and local-only instructions. 
- Added a PyTorch version guard to `ui/partner-hub/scripts/medgemma_runner.py` with `MIN_TORCH_VERSION = (2, 6)`, a `parse_torch_version` helper, and `ensure_supported_torch_version` which raises a `TorchVersionFailure` if the installed `torch.__version__` is older; the runner catches this and emits exactly one JSON object to stdout with `ok: false`, `errorType: "runner_failed"`, and a helpful message directing the user to rerun `scripts/setup-medgemma.ps1`, while diagnostic text is printed to stderr. 
- Preserved the single-JSON stdout behavior, local-only image handling, and existing safety banner/default prompt.

### Testing
- `python3 -m py_compile ui/partner-hub/scripts/medgemma_runner.py` — passed. 
- Inline assertions for `parse_torch_version` and `ensure_supported_torch_version` were executed and passed. 
- A fake-module CLI smoke test simulated an old `torch` and validated the runner emitted the strict JSON `{"ok": false, "errorType": "runner_failed", ...}` on stdout and printed diagnostics to stderr — passed. 
- `npm install` failed in this environment due to registry access returning `403 Forbidden` for `https://registry.npmjs.org/react`, so `npm run lint` and `npm run build` could not be run here because dependencies were unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffa0067d7083309e32552404f2a9c3)