### PR TITLE
MedGemma: add local-run progress streaming, UI status panel, and runner stage logs

### DIFF
--- a/ui/partner-hub/app/api/medgemma/analyze/route.ts
+++ b/ui/partner-hub/app/api/medgemma/analyze/route.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from "crypto";
 import { spawn } from "child_process";
+import { randomUUID } from "crypto";
 import { existsSync } from "fs";
 import { mkdir, rm, stat, writeFile } from "fs/promises";
 import path from "path";
@@ -21,6 +21,16 @@ const RUNNER_TIMEOUT_MS = Number(
   process.env.MEDGEMMA_RUNNER_TIMEOUT_MS || 10 * 60 * 1000,
 );
 
+const STAGE_MESSAGES: Record<string, string> = {
+  upload_received: "Upload received",
+  validating_image: "Validating image",
+  writing_temp_file: "Writing temporary local file",
+  starting_python_runner: "Starting Python runner",
+  loading_model: "Loading MedGemma model",
+  generating: "Running generation",
+  complete: "Complete",
+};
+
 type RunnerResult = {
   ok: boolean;
   result?: string;
@@ -30,30 +40,30 @@ type RunnerResult = {
     | "runner_failed"
     | "upload_validation_failed"
     | "temp_write_failed";
+  runnerStages?: string[];
 };
+
+type StatusEvent = {
+  stage: string;
+  message: string;
+};
+
+type StatusReporter = (event: StatusEvent) => void;
 
 const jsonResponse = (body: RunnerResult, status = 200) =>
   NextResponse.json(body, { status });
 
-const uploadValidationError = (error: string) =>
-  jsonResponse(
-    {
-      ok: false,
-      error: `Upload validation failed: ${error}`,
-      errorType: "upload_validation_failed",
-    },
-    400,
-  );
-
-const tempWriteError = (error: string) =>
-  jsonResponse(
-    {
-      ok: false,
-      error: `Temporary upload write failed: ${error}`,
-      errorType: "temp_write_failed",
-    },
-    500,
-  );
+const sanitizeStatusText = (value: string) => {
+  return value
+    .replace(/hf_[A-Za-z0-9]{20,}/g, "[redacted token]")
+    .replace(
+      /(?:^|\s)[A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD)=\S+/gi,
+      " [redacted env]",
+    )
+    .replace(/[A-Za-z]:\\(?:[^\\\s]+\\)*[^\\\s]*/g, "[local path]")
+    .replace(/\/(?:[^/\s]+\/)+[^/\s]*/g, "[local path]")
+    .trim();
+};
 
 const isFileLike = (value: FormDataEntryValue | null): value is File => {
   return Boolean(
@@ -109,12 +119,41 @@ const getMedGemmaPythonPath = () => {
   return existsSync(localPythonPath) ? localPythonPath : "python";
 };
 
+const reportStage = (onStatus: StatusReporter | undefined, stage: string) => {
+  onStatus?.({
+    stage,
+    message: STAGE_MESSAGES[stage] || sanitizeStatusText(stage),
+  });
+};
+
+const runnerStageFromLine = (line: string) => {
+  const match = line.match(/^STAGE:\s*([a-z0-9_:-]+)\s*$/i);
+  return match?.[1]?.toLowerCase();
+};
+
+const safeRunnerSummary = (stderr: string) => {
+  const lines = stderr
+    .split(/\r?\n/)
+    .map((line) => sanitizeStatusText(line))
+    .filter(Boolean)
+    .filter(
+      (line) =>
+        line.startsWith("STAGE:") ||
+        /failed|error|requires|could not|unable/i.test(line),
+    );
+
+  return Array.from(new Set(lines)).slice(-8);
+};
+
 const runMedGemma = (
   imagePath: string,
   prompt: string,
+  onStatus?: StatusReporter,
 ): Promise<RunnerResult> => {
   const pythonPath = getMedGemmaPythonPath();
   const runnerPath = path.join(process.cwd(), "scripts", "medgemma_runner.py");
+
+  reportStage(onStatus, "starting_python_runner");
 
   return new Promise((resolve) => {
     const child = spawn(
@@ -129,6 +168,7 @@ const runMedGemma = (
 
     let stdout = "";
     let stderr = "";
+    let stderrRemainder = "";
     let settled = false;
 
     const finish = (result: RunnerResult) => {
@@ -145,6 +185,7 @@ const runMedGemma = (
         ok: false,
         errorType: "runner_failed",
         error: `MedGemma runner timed out after ${Math.round(RUNNER_TIMEOUT_MS / 1000)} seconds.`,
+        runnerStages: safeRunnerSummary(stderr),
       });
     }, RUNNER_TIMEOUT_MS);
 
@@ -153,7 +194,17 @@ const runMedGemma = (
     });
 
     child.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString("utf8");
+      const text = chunk.toString("utf8");
+      stderr += text;
+      const lines = `${stderrRemainder}${text}`.split(/\r?\n/);
+      stderrRemainder = lines.pop() || "";
+
+      for (const line of lines) {
+        const stage = runnerStageFromLine(line.trim());
+        if (stage) {
+          reportStage(onStatus, stage);
+        }
+      }
     });
 
     child.on("error", (error) => {
@@ -161,7 +212,8 @@ const runMedGemma = (
       finish({
         ok: false,
         errorType: "runner_failed",
-        error: `Unable to start MedGemma runner: ${error.message}`,
+        error: `Unable to start MedGemma runner: ${sanitizeStatusText(error.message)}`,
+        runnerStages: safeRunnerSummary(stderr),
       });
     });
 
@@ -175,55 +227,119 @@ const runMedGemma = (
       try {
         const parsed = JSON.parse(trimmedStdout) as RunnerResult;
         if (!parsed.ok && stderr.trim() && !parsed.error) {
-          parsed.error = stderr.trim();
+          parsed.error = safeRunnerSummary(stderr).join("\n");
+        }
+        if (!parsed.ok) {
+          parsed.error = sanitizeStatusText(
+            parsed.error || "Analysis could not be completed.",
+          );
+          parsed.runnerStages = safeRunnerSummary(stderr);
         }
         finish(parsed);
       } catch {
         const details =
-          stderr.trim() || trimmedStdout || `Runner exited with code ${code}.`;
+          safeRunnerSummary(stderr).join("\n") ||
+          sanitizeStatusText(trimmedStdout) ||
+          `Runner exited with code ${code}.`;
         finish({
           ok: false,
           errorType: "runner_failed",
           error: `MedGemma runner did not return valid JSON. ${details}`,
+          runnerStages: safeRunnerSummary(stderr),
         });
       }
     });
   });
 };
 
-export async function POST(request: NextRequest) {
+const resultForUploadValidationError = (error: string): RunnerResult => ({
+  ok: false,
+  error: `Upload validation failed: ${sanitizeStatusText(error)}`,
+  errorType: "upload_validation_failed",
+});
+
+const resultForTempWriteError = (error: string): RunnerResult => ({
+  ok: false,
+  error: `Temporary upload write failed: ${sanitizeStatusText(error)}`,
+  errorType: "temp_write_failed",
+});
+
+const analyzeMedGemmaRequest = async (
+  request: NextRequest,
+  onStatus?: StatusReporter,
+): Promise<{ result: RunnerResult; status: number }> => {
   let uploadPath = "";
 
   try {
     const formData = await request.formData();
+    reportStage(onStatus, "upload_received");
+
     const image = formData.get("image");
     const rawPrompt = formData.get("prompt");
 
+    reportStage(onStatus, "validating_image");
+
     if (!isFileLike(image)) {
-      return uploadValidationError(
-        "A JPG, PNG, or WebP image upload is required.",
-      );
+      return {
+        result: resultForUploadValidationError(
+          "A JPG, PNG, or WebP image upload is required.",
+        ),
+        status: 400,
+      };
     }
 
     const extension = ALLOWED_TYPES.get(image.type);
     if (!extension) {
-      return uploadValidationError(
-        "Unsupported file type. Upload a JPG, PNG, or WebP image.",
-      );
+      return {
+        result: resultForUploadValidationError(
+          "Unsupported file type. Upload a JPG, PNG, or WebP image.",
+        ),
+        status: 400,
+      };
     }
 
     if (image.size <= 0) {
-      return uploadValidationError("Uploaded image is empty.");
+      return {
+        result: resultForUploadValidationError("Uploaded image is empty."),
+        status: 400,
+      };
     }
 
     if (image.size > MAX_UPLOAD_BYTES) {
-      return uploadValidationError("Uploaded image must be 10 MB or smaller.");
+      return {
+        result: resultForUploadValidationError(
+          "Uploaded image must be 10 MB or smaller.",
+        ),
+        status: 400,
+      };
     }
 
     const prompt =
       typeof rawPrompt === "string" && rawPrompt.trim()
         ? rawPrompt.trim()
         : DEFAULT_PROMPT;
+    const bytes = Buffer.from(await image.arrayBuffer());
+
+    if (bytes.length !== image.size) {
+      return {
+        result: resultForUploadValidationError(
+          `Uploaded image size changed while reading form data (expected ${image.size} bytes, got ${bytes.length} bytes).`,
+        ),
+        status: 400,
+      };
+    }
+
+    if (!hasValidImageSignature(bytes, image.type)) {
+      return {
+        result: resultForUploadValidationError(
+          "Uploaded file content does not match the selected image type.",
+        ),
+        status: 400,
+      };
+    }
+
+    reportStage(onStatus, "writing_temp_file");
+
     const uploadsDir = path.join(process.cwd(), ".medgemma-uploads");
     await mkdir(uploadsDir, { recursive: true });
 
@@ -231,19 +347,6 @@ export async function POST(request: NextRequest) {
       uploadsDir,
       `${Date.now()}-${randomUUID()}${extension}`,
     );
-    const bytes = Buffer.from(await image.arrayBuffer());
-
-    if (bytes.length !== image.size) {
-      return uploadValidationError(
-        `Uploaded image size changed while reading form data (expected ${image.size} bytes, got ${bytes.length} bytes).`,
-      );
-    }
-
-    if (!hasValidImageSignature(bytes, image.type)) {
-      return uploadValidationError(
-        "Uploaded file content does not match the selected image type.",
-      );
-    }
 
     try {
       await writeFile(uploadPath, bytes, { flag: "wx" });
@@ -252,7 +355,7 @@ export async function POST(request: NextRequest) {
         error instanceof Error
           ? error.message
           : "Could not write uploaded image.";
-      return tempWriteError(message);
+      return { result: resultForTempWriteError(message), status: 500 };
     }
 
     let uploadStats;
@@ -263,40 +366,104 @@ export async function POST(request: NextRequest) {
         error instanceof Error
           ? error.message
           : "Temporary upload file is missing.";
-      return tempWriteError(
-        `Temporary file was not readable after write. ${message}`,
-      );
+      return {
+        result: resultForTempWriteError(
+          `Temporary file was not readable after write. ${message}`,
+        ),
+        status: 500,
+      };
     }
 
     if (!uploadStats.isFile() || uploadStats.size !== bytes.length) {
-      return tempWriteError(
-        `Temporary file size mismatch after write (expected ${bytes.length} bytes, got ${uploadStats.size} bytes).`,
-      );
+      return {
+        result: resultForTempWriteError(
+          `Temporary file size mismatch after write (expected ${bytes.length} bytes, got ${uploadStats.size} bytes).`,
+        ),
+        status: 500,
+      };
     }
 
-    const result = await runMedGemma(uploadPath, prompt);
+    const result = await runMedGemma(uploadPath, prompt, onStatus);
     if (!result.ok) {
       const prefix =
         result.errorType === "image_decode_failed"
           ? "Image decode failed"
           : "MedGemma runner failed";
-      return jsonResponse(
-        {
+      return {
+        result: {
           ...result,
-          error: `${prefix}: ${result.error || "Analysis could not be completed."}`,
+          error: `${prefix}: ${sanitizeStatusText(
+            result.error || "Analysis could not be completed.",
+          )}`,
         },
-        500,
-      );
+        status: 500,
+      };
     }
 
-    return jsonResponse(result);
+    reportStage(onStatus, "complete");
+    return { result, status: 200 };
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "MedGemma analysis failed.";
-    return jsonResponse({ ok: false, error: message }, 500);
+    return {
+      result: { ok: false, error: sanitizeStatusText(message) },
+      status: 500,
+    };
   } finally {
     if (uploadPath) {
       await rm(uploadPath, { force: true }).catch(() => undefined);
     }
   }
+};
+
+const wantsStatusStream = (request: NextRequest) => {
+  return request.headers.get("accept")?.includes("text/event-stream");
+};
+
+const encodeSse = (event: string, data: unknown) => {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+};
+
+const streamResponse = (request: NextRequest) => {
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send = (event: string, data: unknown) => {
+        controller.enqueue(encoder.encode(encodeSse(event, data)));
+      };
+
+      const startedAt = Date.now();
+      const onStatus: StatusReporter = (event) => {
+        send("status", {
+          ...event,
+          elapsedMs: Date.now() - startedAt,
+        });
+      };
+
+      const { result, status } = await analyzeMedGemmaRequest(
+        request,
+        onStatus,
+      );
+      send(result.ok ? "result" : "error", { ...result, status });
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "Content-Type": "text/event-stream; charset=utf-8",
+    },
+  });
+};
+
+export async function POST(request: NextRequest) {
+  if (wantsStatusStream(request)) {
+    return streamResponse(request);
+  }
+
+  const { result, status } = await analyzeMedGemmaRequest(request);
+  return jsonResponse(result, status);
 }

--- a/ui/partner-hub/components/medgemma/MedGemmaReviewTool.tsx
+++ b/ui/partner-hub/components/medgemma/MedGemmaReviewTool.tsx
@@ -11,10 +11,56 @@ const DEFAULT_PROMPT =
 
 const acceptedImageTypes = ["image/jpeg", "image/png", "image/webp"];
 
+const initialProgressMessages: ProgressMessage[] = [
+  { stage: "waiting", message: "Waiting for an image", elapsedMs: 0 },
+];
+
 type AnalysisResponse = {
   ok: boolean;
   result?: string;
   error?: string;
+  runnerStages?: string[];
+};
+
+type ProgressMessage = {
+  stage: string;
+  message: string;
+  elapsedMs: number;
+};
+
+type StreamEvent = {
+  event: string;
+  data: AnalysisResponse & Partial<ProgressMessage> & { status?: number };
+};
+
+const formatElapsed = (elapsedMs: number) => {
+  const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes > 0) {
+    return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
+  }
+
+  return `${seconds}s`;
+};
+
+const parseSseEvents = (buffer: string): StreamEvent[] => {
+  return buffer
+    .split("\n\n")
+    .filter(Boolean)
+    .map((block) => {
+      const event = block.match(/^event:\s*(.+)$/m)?.[1]?.trim() || "message";
+      const dataLines = block
+        .split("\n")
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.replace(/^data:\s?/, ""));
+
+      return {
+        event,
+        data: JSON.parse(dataLines.join("\n")) as StreamEvent["data"],
+      };
+    });
 };
 
 export function MedGemmaReviewTool() {
@@ -23,6 +69,9 @@ export function MedGemmaReviewTool() {
   const [result, setResult] = useState("");
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [progressMessages, setProgressMessages] = useState<ProgressMessage[]>(
+    initialProgressMessages,
+  );
 
   const helperText = useMemo(() => {
     if (!image) {
@@ -32,6 +81,77 @@ export function MedGemmaReviewTool() {
     const sizeInMb = image.size / (1024 * 1024);
     return `${image.name} • ${sizeInMb.toFixed(2)} MB`;
   }, [image]);
+
+  const latestProgress = progressMessages[progressMessages.length - 1];
+
+  const addProgressMessage = (message: ProgressMessage) => {
+    setProgressMessages((current) => {
+      const previous = current[current.length - 1];
+      if (previous?.stage === message.stage) {
+        return current;
+      }
+
+      return [...current, message];
+    });
+  };
+
+  const readStreamingResponse = async (response: Response) => {
+    if (!response.body) {
+      const data = (await response.json()) as AnalysisResponse;
+      if (!response.ok || !data.ok) {
+        throw new Error(data.error || "MedGemma analysis failed.");
+      }
+      setResult(data.result || "No response text was returned.");
+      return;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { value, done } = await reader.read();
+      buffer += decoder.decode(value, { stream: !done });
+      const eventBlocks = buffer.split("\n\n");
+      buffer = eventBlocks.pop() || "";
+
+      const events = parseSseEvents(eventBlocks.join("\n\n"));
+      if (done && buffer.trim()) {
+        events.push(...parseSseEvents(buffer));
+        buffer = "";
+      }
+
+      for (const event of events) {
+        if (event.event === "status") {
+          addProgressMessage({
+            stage: event.data.stage || "status",
+            message: event.data.message || "Working locally",
+            elapsedMs: event.data.elapsedMs || 0,
+          });
+        }
+
+        if (event.event === "result") {
+          if (!event.data.ok) {
+            throw new Error(event.data.error || "MedGemma analysis failed.");
+          }
+          setResult(event.data.result || "No response text was returned.");
+        }
+
+        if (event.event === "error") {
+          const runnerDetails = event.data.runnerStages?.length
+            ? `\n\nRunner status:\n${event.data.runnerStages.join("\n")}`
+            : "";
+          throw new Error(
+            `${event.data.error || "MedGemma analysis failed."}${runnerDetails}`,
+          );
+        }
+      }
+
+      if (done) {
+        break;
+      }
+    }
+  };
 
   const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -44,11 +164,20 @@ export function MedGemmaReviewTool() {
     }
 
     if (!acceptedImageTypes.includes(image.type)) {
-      setError("Unsupported file type. Please upload a JPG, PNG, or WebP image.");
+      setError(
+        "Unsupported file type. Please upload a JPG, PNG, or WebP image.",
+      );
       return;
     }
 
     setIsLoading(true);
+    setProgressMessages([
+      {
+        stage: "queued",
+        message: "Preparing local analysis request",
+        elapsedMs: 0,
+      },
+    ]);
 
     try {
       const formData = new FormData();
@@ -57,17 +186,16 @@ export function MedGemmaReviewTool() {
 
       const response = await fetch(withBasePath("/api/medgemma/analyze"), {
         method: "POST",
+        headers: {
+          Accept: "text/event-stream",
+        },
         body: formData,
       });
-      const data = (await response.json()) as AnalysisResponse;
 
-      if (!response.ok || !data.ok) {
-        throw new Error(data.error || "MedGemma analysis failed.");
-      }
-
-      setResult(data.result || "No response text was returned.");
+      await readStreamingResponse(response);
     } catch (err) {
-      const message = err instanceof Error ? err.message : "MedGemma analysis failed.";
+      const message =
+        err instanceof Error ? err.message : "MedGemma analysis failed.";
       setError(message);
     } finally {
       setIsLoading(false);
@@ -85,13 +213,14 @@ export function MedGemmaReviewTool() {
             Local MedGemma Image Review
           </h1>
           <p className="max-w-3xl text-base leading-relaxed text-foreground/70">
-            Upload an image and run a local MedGemma review from this Next.js app. Images are
-            passed only to the local Python runner and are not sent to a remote API.
+            Upload an image and run a local MedGemma review from this Next.js
+            app. Images are passed only to the local Python runner and are not
+            sent to a remote API.
           </p>
         </div>
         <div className="rounded-2xl border border-amber-300/70 bg-amber-50 p-4 text-sm font-medium text-amber-900 dark:border-amber-400/40 dark:bg-amber-950/40 dark:text-amber-100">
-          This tool is for image description and red-flag review only. It is not a diagnosis and
-          does not replace a clinician.
+          This tool is for image description and red-flag review only. It is not
+          a diagnosis and does not replace a clinician.
         </div>
       </section>
 
@@ -100,14 +229,17 @@ export function MedGemmaReviewTool() {
           <CardHeader>
             <CardTitle>Analyze an image</CardTitle>
             <p className="text-sm text-foreground/60">
-              The API route stores the upload in a temporary ignored folder, calls the local Python
-              runner, then removes the temporary file.
+              The API route stores the upload in a temporary ignored folder,
+              calls the local Python runner, then removes the temporary file.
             </p>
           </CardHeader>
           <CardContent>
             <form className="space-y-5" onSubmit={onSubmit}>
               <div className="space-y-2">
-                <label className="text-sm font-semibold text-foreground" htmlFor="medgemma-image">
+                <label
+                  className="text-sm font-semibold text-foreground"
+                  htmlFor="medgemma-image"
+                >
                   Image file
                 </label>
                 <input
@@ -115,13 +247,18 @@ export function MedGemmaReviewTool() {
                   type="file"
                   accept="image/jpeg,image/png,image/webp,.jpg,.jpeg,.png,.webp"
                   className="block w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground file:mr-4 file:rounded-md file:border-0 file:bg-muted file:px-3 file:py-2 file:text-sm file:font-semibold file:text-foreground hover:file:bg-muted/80"
-                  onChange={(event) => setImage(event.target.files?.[0] ?? null)}
+                  onChange={(event) =>
+                    setImage(event.target.files?.[0] ?? null)
+                  }
                 />
                 <p className="text-xs text-foreground/60">{helperText}</p>
               </div>
 
               <div className="space-y-2">
-                <label className="text-sm font-semibold text-foreground" htmlFor="medgemma-prompt">
+                <label
+                  className="text-sm font-semibold text-foreground"
+                  htmlFor="medgemma-prompt"
+                >
                   Optional prompt
                 </label>
                 <textarea
@@ -137,7 +274,11 @@ export function MedGemmaReviewTool() {
                 </p>
               </div>
 
-              <Button type="submit" disabled={isLoading} className="w-full sm:w-auto">
+              <Button
+                type="submit"
+                disabled={isLoading}
+                className="w-full sm:w-auto"
+              >
                 {isLoading ? "Analyzing locally..." : "Analyze image"}
               </Button>
             </form>
@@ -159,13 +300,39 @@ export function MedGemmaReviewTool() {
           {isLoading ? (
             <Card className="border-primary/30 bg-primary/5">
               <CardHeader>
-                <CardTitle>Model running</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-foreground/70">
-                  Loading MedGemma and generating a response can take several minutes on the first
-                  run while model files are prepared locally.
+                <CardTitle>Local run status</CardTitle>
+                <p className="text-sm text-foreground/60">
+                  {latestProgress?.message || "Working locally"} · elapsed{" "}
+                  {formatElapsed(latestProgress?.elapsedMs || 0)}
                 </p>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-sm text-foreground/70">
+                  Loading MedGemma and generating a response can take several
+                  minutes on the first run while model files are prepared
+                  locally. Status messages are generated locally and omit tokens
+                  and full local paths.
+                </p>
+                <ol className="space-y-2 text-sm text-foreground/75">
+                  {progressMessages.map((message, index) => (
+                    <li
+                      key={`${message.stage}-${index}`}
+                      className="flex items-start gap-3 rounded-lg bg-background/60 p-3"
+                    >
+                      <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">
+                        {index + 1}
+                      </span>
+                      <span>
+                        <span className="font-medium text-foreground">
+                          {message.message}
+                        </span>
+                        <span className="ml-2 text-xs text-foreground/50">
+                          {formatElapsed(message.elapsedMs)}
+                        </span>
+                      </span>
+                    </li>
+                  ))}
+                </ol>
               </CardContent>
             </Card>
           ) : null}
@@ -176,7 +343,9 @@ export function MedGemmaReviewTool() {
                 <CardTitle>Error</CardTitle>
               </CardHeader>
               <CardContent>
-                <p className="whitespace-pre-wrap text-sm text-red-800 dark:text-red-100">{error}</p>
+                <p className="whitespace-pre-wrap text-sm text-red-800 dark:text-red-100">
+                  {error}
+                </p>
               </CardContent>
             </Card>
           ) : null}

--- a/ui/partner-hub/scripts/medgemma_runner.py
+++ b/ui/partner-hub/scripts/medgemma_runner.py
@@ -17,6 +17,10 @@ MIN_TORCH_VERSION = (2, 6)
 SUPPORTED_FALLBACK_FORMATS = {"JPEG", "PNG", "WEBP"}
 
 
+def log_stage(stage: str) -> None:
+    print(f"STAGE: {stage}", file=sys.stderr, flush=True)
+
+
 class ImageDecodeFailure(Exception):
     """Raised when PIL cannot safely decode the uploaded image."""
 
@@ -111,7 +115,8 @@ def load_verified_rgb_image(
     image_file: Any,
     unidentified_error: type[Exception],
 ) -> Any:
-    print(f"Validating image file {image_path}...", file=sys.stderr, flush=True)
+    log_stage("validating_image")
+    print("Validating uploaded image file...", file=sys.stderr, flush=True)
 
     image_format = "unknown"
     try:
@@ -183,7 +188,7 @@ def main() -> None:
             {
                 "ok": False,
                 "errorType": "image_decode_failed",
-                "error": f"Image file not found: {image_path}",
+                "error": "Image file not found.",
             },
             2,
         )
@@ -209,6 +214,7 @@ def main() -> None:
             device = "cuda" if torch.cuda.is_available() else "cpu"
             dtype = torch.bfloat16 if device == "cuda" else torch.float32
 
+            log_stage("loading_model")
             print(f"Loading {MODEL_ID} on {device}...", file=sys.stderr, flush=True)
             processor = AutoProcessor.from_pretrained(MODEL_ID)
             model = AutoModelForImageTextToText.from_pretrained(
@@ -242,12 +248,14 @@ def main() -> None:
                 inputs = inputs.to(model.device)
             input_token_count = inputs["input_ids"].shape[-1]
 
+            log_stage("generating")
             with torch.inference_mode():
                 generated_ids = model.generate(**inputs, max_new_tokens=args.max_new_tokens)
 
             generated_ids = generated_ids[:, input_token_count:]
             result = processor.batch_decode(generated_ids, skip_special_tokens=True)[0].strip()
 
+        log_stage("complete")
         emit({"ok": True, "result": result})
     except ImageDecodeFailure as exc:
         print(f"MedGemma image decode failed: {exc}", file=sys.stderr, flush=True)


### PR DESCRIPTION
### Motivation
- Provide visible, staged progress feedback for long local MedGemma runs so the user sees upload/validation/model loading/generation stages instead of a single "Analyzing locally..." message.
- Preserve the local-only architecture and ensure the Python runner continues to emit a single JSON result on stdout while exposing safe stage markers to stderr.
- Avoid leaking secrets or full local paths in surfaced status messages.

### Description
- UI: `ui/partner-hub/components/medgemma/MedGemmaReviewTool.tsx` now requests `Accept: text/event-stream`, consumes SSE-style status events, accumulates sanitized progress messages with elapsed times, and renders a run-status panel showing deterministic stages and elapsed-time entries.
- API: `ui/partner-hub/app/api/medgemma/analyze/route.ts` was refactored to support streaming status via a ReadableStream (SSE events) while preserving the non-stream JSON fallback; it sanitizes runner text (`sanitizeStatusText`), maps runner `STAGE:` stderr lines to friendly messages (`reportStage`, `STAGE_MESSAGES`), and includes a safe runner summary (`safeRunnerSummary`) on errors.
- Runner: `ui/partner-hub/scripts/medgemma_runner.py` adds a `log_stage` helper and emits `STAGE:` markers to stderr at key points (`validating_image`, `loading_model`, `generating`, `complete`); stdout remains reserved for the single final JSON object as before.
- Safety: status text is sanitized to redact long HF tokens, env-like secrets, and full local filesystem paths before being sent to the UI.
- Minimal, isolated changes: upload validation, temp-file write, cleanup, torch checks, default prompt, and final-json behavior are preserved.

### Testing
- `git diff --check` passed locally after changes (no whitespace errors).
- Python syntax check `python -m py_compile ui/partner-hub/scripts/medgemma_runner.py` passed.
- Attempted `npm ci` and `npm run lint` / `npm run build` but dependency installation/build could not complete in this environment due to npm registry access errors (HTTP 403 for `react`) and missing global tooling (`next`, `prisma`), so lints/builds were not run to completion here.
- Verified through local repo checks that the runner still emits a single JSON object on stdout and that stderr now includes `STAGE:` markers; committed changes and prepared the PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffa3c8df748330a4328d8a2a5bd340)