### PR TITLE
Optimize MedGemma local inference defaults

### DIFF
--- a/ui/partner-hub/app/api/medgemma/analyze/route.ts
+++ b/ui/partner-hub/app/api/medgemma/analyze/route.ts
@@ -9,7 +9,7 @@ import { NextRequest, NextResponse } from "next/server";
 export const runtime = "nodejs";
 
 const DEFAULT_PROMPT =
-  "Describe visible findings in cautious medical language. List possible benign explanations and red flags that would require a clinician. Do not provide a definitive diagnosis.";
+  "Provide a concise local image review in cautious medical language. Use brief bullets for visible findings, possible benign explanations, and red flags that would require a clinician. Do not provide a definitive diagnosis.";
 
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
 const ALLOWED_TYPES = new Map([
@@ -20,6 +20,7 @@ const ALLOWED_TYPES = new Map([
 const RUNNER_TIMEOUT_MS = Number(
   process.env.MEDGEMMA_RUNNER_TIMEOUT_MS || 10 * 60 * 1000,
 );
+const DEFAULT_MAX_NEW_TOKENS = 192;
 
 const STAGE_MESSAGES: Record<string, string> = {
   upload_received: "Upload received",
@@ -104,6 +105,20 @@ const hasValidImageSignature = (bytes: Buffer, mimeType: string) => {
   return false;
 };
 
+const getMedGemmaMaxNewTokensArg = () => {
+  const rawValue = process.env.MEDGEMMA_MAX_NEW_TOKENS;
+  if (!rawValue) {
+    return String(DEFAULT_MAX_NEW_TOKENS);
+  }
+
+  const value = Number(rawValue);
+  if (!Number.isInteger(value) || value < 1) {
+    return String(DEFAULT_MAX_NEW_TOKENS);
+  }
+
+  return String(value);
+};
+
 const getMedGemmaPythonPath = () => {
   if (process.env.MEDGEMMA_PYTHON_PATH) {
     return process.env.MEDGEMMA_PYTHON_PATH;
@@ -152,13 +167,22 @@ const runMedGemma = (
 ): Promise<RunnerResult> => {
   const pythonPath = getMedGemmaPythonPath();
   const runnerPath = path.join(process.cwd(), "scripts", "medgemma_runner.py");
+  const maxNewTokens = getMedGemmaMaxNewTokensArg();
 
   reportStage(onStatus, "starting_python_runner");
 
   return new Promise((resolve) => {
     const child = spawn(
       pythonPath,
-      [runnerPath, "--image", imagePath, "--prompt", prompt],
+      [
+        runnerPath,
+        "--image",
+        imagePath,
+        "--prompt",
+        prompt,
+        "--max-new-tokens",
+        maxNewTokens,
+      ],
       {
         cwd: process.cwd(),
         env: process.env,

--- a/ui/partner-hub/components/medgemma/MedGemmaReviewTool.tsx
+++ b/ui/partner-hub/components/medgemma/MedGemmaReviewTool.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { withBasePath } from "@/lib/basePath";
 
 const DEFAULT_PROMPT =
-  "Describe visible findings in cautious medical language. List possible benign explanations and red flags that would require a clinician. Do not provide a definitive diagnosis.";
+  "Provide a concise local image review in cautious medical language. Use brief bullets for visible findings, possible benign explanations, and red flags that would require a clinician. Do not provide a definitive diagnosis.";
 
 const acceptedImageTypes = ["image/jpeg", "image/png", "image/webp"];
 
@@ -270,7 +270,8 @@ export function MedGemmaReviewTool() {
                   className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm transition placeholder:text-foreground/40 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
                 />
                 <p className="text-xs text-foreground/60">
-                  Leave blank to use the cautious default prompt.
+                  Leave blank to use the cautious concise default prompt. Set
+                  MEDGEMMA_MAX_NEW_TOKENS if you need a longer local response.
                 </p>
               </div>
 
@@ -308,10 +309,11 @@ export function MedGemmaReviewTool() {
               </CardHeader>
               <CardContent className="space-y-4">
                 <p className="text-sm text-foreground/70">
-                  Loading MedGemma and generating a response can take several
-                  minutes on the first run while model files are prepared
-                  locally. Status messages are generated locally and omit tokens
-                  and full local paths.
+                  The first run may be slow while model files download and load
+                  into GPU memory. After the model is cached, the concise default
+                  output is intended to finish well before the 10-minute timeout
+                  on a 6 GB laptop GPU. Status messages are generated locally and
+                  omit tokens and full local paths.
                 </p>
                 <ol className="space-y-2 text-sm text-foreground/75">
                   {progressMessages.map((message, index) => (

--- a/ui/partner-hub/docs/medgemma-local.md
+++ b/ui/partner-hub/docs/medgemma-local.md
@@ -69,6 +69,18 @@ Accept the Hugging Face model terms for `google/medgemma-1.5-4b-it` before the f
 
 - `MEDGEMMA_RUNNER_TIMEOUT_MS`: Optional API timeout in milliseconds. The default is 10 minutes, which allows for slower first-run model loading.
 
+- `MEDGEMMA_MAX_NEW_TOKENS`: Optional response length override for local generation. The default is 192 tokens so a typical cached run stays practical on a 6 GB RTX 4050 laptop GPU. Increase this only when you need longer detail and can tolerate slower generation. Example for PowerShell:
+
+  ```powershell
+  $env:MEDGEMMA_MAX_NEW_TOKENS = "256"
+  npm run dev
+  ```
+
+## Runtime notes
+
+- The first run can be noticeably slower because Hugging Face downloads gated model files and Transformers loads them into local CPU/GPU memory. After the model is downloaded and cached, generation should not take 10 minutes for a typical image review.
+- CUDA runs prefer `torch.float16`, `low_cpu_mem_usage=True`, and PyTorch SDPA attention to better fit 6 GB laptop GPUs. The default prompt asks for concise bullets to reduce generation time while preserving cautious no-diagnosis language.
+
 ## Local files and caches
 
 - The preferred setup creates `.venv-medgemma/` under `ui/partner-hub` for MedGemma Python dependencies.

--- a/ui/partner-hub/scripts/medgemma_runner.py
+++ b/ui/partner-hub/scripts/medgemma_runner.py
@@ -6,13 +6,14 @@ from __future__ import annotations
 import argparse
 import contextlib
 import json
+import os
 import sys
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 MODEL_ID = "google/medgemma-1.5-4b-it"
-DEFAULT_MAX_NEW_TOKENS = 512
+DEFAULT_MAX_NEW_TOKENS = 192
 MIN_TORCH_VERSION = (2, 6)
 SUPPORTED_FALLBACK_FORMATS = {"JPEG", "PNG", "WEBP"}
 
@@ -34,15 +35,54 @@ def emit(payload: dict[str, object], exit_code: int = 0) -> None:
     raise SystemExit(exit_code)
 
 
+def positive_int(value: str) -> int:
+    parsed_value = int(value)
+    if parsed_value < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed_value
+
+
+def env_max_new_tokens() -> int:
+    raw_value = os.environ.get("MEDGEMMA_MAX_NEW_TOKENS")
+    if raw_value is None or raw_value.strip() == "":
+        return DEFAULT_MAX_NEW_TOKENS
+
+    try:
+        value = int(raw_value)
+    except ValueError:
+        print(
+            "Ignoring MEDGEMMA_MAX_NEW_TOKENS because it is not an integer; "
+            f"using {DEFAULT_MAX_NEW_TOKENS}.",
+            file=sys.stderr,
+            flush=True,
+        )
+        return DEFAULT_MAX_NEW_TOKENS
+
+    if value < 1:
+        print(
+            "Ignoring MEDGEMMA_MAX_NEW_TOKENS because it must be at least 1; "
+            f"using {DEFAULT_MAX_NEW_TOKENS}.",
+            file=sys.stderr,
+            flush=True,
+        )
+        return DEFAULT_MAX_NEW_TOKENS
+
+    return value
+
+
 def parse_args() -> argparse.Namespace:
+    default_max_new_tokens = env_max_new_tokens()
     parser = argparse.ArgumentParser(description="Run local MedGemma image review.")
     parser.add_argument("--image", required=True, help="Path to a local JPG, PNG, or WebP image.")
     parser.add_argument("--prompt", required=True, help="Prompt to send with the image.")
     parser.add_argument(
         "--max-new-tokens",
-        type=int,
-        default=DEFAULT_MAX_NEW_TOKENS,
-        help=f"Maximum response tokens to generate (default: {DEFAULT_MAX_NEW_TOKENS}).",
+        type=positive_int,
+        default=default_max_new_tokens,
+        help=(
+            "Maximum response tokens to generate "
+            f"(default: MEDGEMMA_MAX_NEW_TOKENS or {DEFAULT_MAX_NEW_TOKENS})."
+        ),
     )
     return parser.parse_args()
 
@@ -212,15 +252,25 @@ def main() -> None:
             from transformers import AutoModelForImageTextToText, AutoProcessor
 
             device = "cuda" if torch.cuda.is_available() else "cpu"
-            dtype = torch.bfloat16 if device == "cuda" else torch.float32
+            dtype = torch.float16 if device == "cuda" else torch.float32
+            model_kwargs: dict[str, Any] = {
+                "torch_dtype": dtype,
+                "low_cpu_mem_usage": True,
+            }
+            if device == "cuda":
+                model_kwargs["device_map"] = "auto"
+                model_kwargs["attn_implementation"] = "sdpa"
 
             log_stage("loading_model")
-            print(f"Loading {MODEL_ID} on {device}...", file=sys.stderr, flush=True)
+            print(
+                f"Loading {MODEL_ID} on {device} with {dtype} and max_new_tokens={args.max_new_tokens}...",
+                file=sys.stderr,
+                flush=True,
+            )
             processor = AutoProcessor.from_pretrained(MODEL_ID)
             model = AutoModelForImageTextToText.from_pretrained(
                 MODEL_ID,
-                torch_dtype=dtype,
-                device_map="auto" if device == "cuda" else None,
+                **model_kwargs,
             )
             if device != "cuda":
                 model = model.to(device)
@@ -242,10 +292,7 @@ def main() -> None:
                 return_dict=True,
                 return_tensors="pt",
             )
-            if device == "cuda":
-                inputs = inputs.to(model.device, dtype=dtype)
-            else:
-                inputs = inputs.to(model.device)
+            inputs = inputs.to(model.device)
             input_token_count = inputs["input_ids"].shape[-1]
 
             log_stage("generating")


### PR DESCRIPTION
### Motivation
- Make the local MedGemma flow practical on constrained GPUs (e.g. 6 GB RTX 4050) by reducing generation work and improving model load/runtime behavior. 
- Provide a safe, concise default output while letting advanced users increase length via environment configuration. 
- Preserve the single-JSON stdout contract and the local-only upload/validation/cleanup safety model.

### Description
- Reduced default generation budget from `512` to `192` tokens and added support for an environment override via `MEDGEMMA_MAX_NEW_TOKENS` (validated as a positive integer), with the Node API route passing `--max-new-tokens` to the runner. 
- Optimized Python runner model loading for low-memory CUDA devices by preferring `torch.float16`, enabling `low_cpu_mem_usage=True`, using `device_map="auto"` plus `attn_implementation="sdpa"` on CUDA, and avoiding unnecessary dtype conversions when moving processor outputs to the model device. 
- Kept strict JSON stdout behavior and error conversion unchanged (all failures remain emitted as a single JSON object while progress/logging goes to `stderr`). 
- Updated UX and docs: changed the default prompt to a concise, bullet-oriented safe prompt, clarified first-run/warmup and cached-run expectations in the UI copy and `ui/partner-hub/docs/medgemma-local.md` and added `MEDGEMMA_MAX_NEW_TOKENS` documentation.

### Testing
- `python -m py_compile ui/partner-hub/scripts/medgemma_runner.py` passed (runner syntactic validation). 
- Ran `MEDGEMMA_MAX_NEW_TOKENS=abc python ui/partner-hub/scripts/medgemma_runner.py --image /tmp/does-not-exist.jpg --prompt test` to validate env parsing and JSON output; runner printed a stderr warning about the invalid env value and returned a single JSON error object on stdout (exit code handled). 
- `git diff --check` passed (no whitespace/git-diff issues). 
- `npm ci`, `npm run lint`, and `npm run build` could not be completed in this environment because `node_modules` is not present and registry access failed; these are reported as warnings rather than failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffa5c383c88330befea07fed06a382)