### PR TITLE
Expose MedGemma generation diagnostics

### DIFF
--- a/ui/partner-hub/app/api/medgemma/analyze/route.ts
+++ b/ui/partner-hub/app/api/medgemma/analyze/route.ts
@@ -146,11 +146,12 @@ const runnerStageFromLine = (line: string) => {
   return match?.[1]?.toLowerCase();
 };
 
-const resultForEmptyRunnerOutput = (): RunnerResult => ({
+const resultForEmptyRunnerOutput = (runnerStages?: string[]): RunnerResult => ({
   ok: false,
   errorType: "runner_failed",
   error:
     "MedGemma runner returned an empty response. The model generated no displayable text; check server stderr for safe generation metadata.",
+  ...(runnerStages?.length ? { runnerStages } : {}),
 });
 
 const safeRunnerSummary = (stderr: string) => {
@@ -161,6 +162,7 @@ const safeRunnerSummary = (stderr: string) => {
     .filter(
       (line) =>
         line.startsWith("STAGE:") ||
+        line.startsWith("GENERATION_DEBUG:") ||
         /failed|error|requires|could not|unable/i.test(line),
     );
 
@@ -258,9 +260,7 @@ const runMedGemma = (
       try {
         const parsed = JSON.parse(trimmedStdout) as RunnerResult;
         if (parsed.ok && !parsed.result?.trim()) {
-          const emptyResult = resultForEmptyRunnerOutput();
-          emptyResult.runnerStages = safeRunnerSummary(stderr);
-          finish(emptyResult);
+          finish(resultForEmptyRunnerOutput(safeRunnerSummary(stderr)));
           return;
         }
         if (!parsed.ok && stderr.trim() && !parsed.error) {
@@ -423,7 +423,7 @@ const analyzeMedGemmaRequest = async (
     const result = await runMedGemma(uploadPath, prompt, onStatus);
     if (result.ok && !result.result?.trim()) {
       return {
-        result: resultForEmptyRunnerOutput(),
+        result: resultForEmptyRunnerOutput(result.runnerStages),
         status: 500,
       };
     }

--- a/ui/partner-hub/components/medgemma/MedGemmaReviewTool.tsx
+++ b/ui/partner-hub/components/medgemma/MedGemmaReviewTool.tsx
@@ -45,6 +45,14 @@ const formatElapsed = (elapsedMs: number) => {
   return `${seconds}s`;
 };
 
+const formatAnalysisError = (data: AnalysisResponse) => {
+  const runnerDetails = data.runnerStages?.length
+    ? `\n\nRunner status:\n${data.runnerStages.join("\n")}`
+    : "";
+
+  return `${data.error || "MedGemma analysis failed."}${runnerDetails}`;
+};
+
 const requireResponseText = (value: string | undefined) => {
   const responseText = value?.trim();
   if (!responseText) {
@@ -110,7 +118,7 @@ export function MedGemmaReviewTool() {
     if (!response.body) {
       const data = (await response.json()) as AnalysisResponse;
       if (!response.ok || !data.ok) {
-        throw new Error(data.error || "MedGemma analysis failed.");
+        throw new Error(formatAnalysisError(data));
       }
       setResult(requireResponseText(data.result));
       return;
@@ -143,18 +151,13 @@ export function MedGemmaReviewTool() {
 
         if (event.event === "result") {
           if (!event.data.ok) {
-            throw new Error(event.data.error || "MedGemma analysis failed.");
+            throw new Error(formatAnalysisError(event.data));
           }
           setResult(requireResponseText(event.data.result));
         }
 
         if (event.event === "error") {
-          const runnerDetails = event.data.runnerStages?.length
-            ? `\n\nRunner status:\n${event.data.runnerStages.join("\n")}`
-            : "";
-          throw new Error(
-            `${event.data.error || "MedGemma analysis failed."}${runnerDetails}`,
-          );
+          throw new Error(formatAnalysisError(event.data));
         }
       }
 


### PR DESCRIPTION
### Motivation
- Make sanitized `GENERATION_DEBUG:` metadata emitted by the local MedGemma runner visible in UI error details so empty-output failures can be diagnosed without leaking secrets or prompt text.

### Description
- Preserve sanitized `GENERATION_DEBUG:` lines in the runner summary by updating `safeRunnerSummary` to include lines that start with `GENERATION_DEBUG:`. 
- Carry runner diagnostics through empty-output failures by changing `resultForEmptyRunnerOutput` to accept and include `runnerStages` when present. 
- Surface runner diagnostics in the UI by adding `formatAnalysisError` and using it for both JSON fallback errors and SSE `error`/`result` handling so `runnerStages` appear in visible error messages. 
- Kept existing sanitization (`sanitizeStatusText`), strict JSON stdout expectations, and SSE/status streaming behavior unchanged.

### Testing
- `git diff --check` succeeded locally against the modified files. 
- `npm run lint` could not be run to completion because dependencies are not installed in the execution environment and `next` was not found. 
- `npm run build` could not be run to completion because dependencies are not installed and `prisma` was not available during `prebuild`. 
- `npm ci` / `npm install` attempts were blocked by environment/lockfile/registry issues so dependency installation and full build/lint verification were not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffadf627a48330a82bbc641406a652)