### PR TITLE
Fix MedGemma decoded output selection

### DIFF
--- a/ui/partner-hub/scripts/medgemma_runner.py
+++ b/ui/partner-hub/scripts/medgemma_runner.py
@@ -7,6 +7,7 @@ import argparse
 import contextlib
 import json
 import os
+import re
 import sys
 from collections.abc import Iterator
 from pathlib import Path
@@ -246,6 +247,47 @@ def decode_ids(processor: Any, token_ids: Any) -> str:
     return processor.batch_decode(token_ids, skip_special_tokens=True)[0].strip()
 
 
+def strip_obvious_chat_template_wrapper(text: str) -> str:
+    """Remove visible chat role wrappers without erasing valid model text."""
+    stripped_text = text.strip()
+    if not stripped_text:
+        return ""
+
+    # Some tokenizers decode a full prompt+completion as role-labeled text after
+    # special-token removal, for example: "user\n...\nmodel\nresponse".
+    # Only strip when a role marker is obvious and the extracted suffix remains
+    # non-empty; otherwise preserve the decoded model content exactly.
+    role_marker_pattern = re.compile(
+        r"(?im)(?:^|\n)\s*(?:assistant|model)\s*(?P<separator>:|\n)"
+    )
+    user_marker_pattern = re.compile(r"(?im)(?:^|\n)\s*user\s*(?::|\n)")
+    matches = list(role_marker_pattern.finditer(stripped_text))
+    for match in reversed(matches):
+        candidate = stripped_text[match.end() :].strip()
+        if not candidate:
+            continue
+
+        prefix = stripped_text[: match.start()]
+        marker_at_start = prefix.strip() == ""
+        marker_uses_role_line = match.group("separator") == "\n"
+        if user_marker_pattern.search(prefix) or (
+            marker_at_start and marker_uses_role_line
+        ):
+            return candidate
+
+    return stripped_text
+
+
+def select_decoded_output(
+    *, decoded_full_output: str, decoded_sliced_output: str
+) -> tuple[str, str]:
+    if decoded_sliced_output.strip():
+        return decoded_sliced_output, "sliced"
+    if decoded_full_output.strip():
+        return strip_obvious_chat_template_wrapper(decoded_full_output), "full"
+    return "", "empty"
+
+
 def first_token_is_eos(token_ids: Any, eos_token_ids: set[int]) -> bool:
     if not eos_token_ids or token_ids.shape[-1] <= 0:
         return False
@@ -267,6 +309,7 @@ def log_generation_debug(
     decoded_full_output_length: int,
     decoded_sliced_output_length: int,
     used_sliced_output: bool,
+    selected_output: str,
     eos_returned_immediately: bool,
 ) -> None:
     print(
@@ -279,6 +322,7 @@ def log_generation_debug(
         f"decoded_full_output_length={decoded_full_output_length} "
         f"decoded_sliced_output_length={decoded_sliced_output_length} "
         f"used_sliced_output={str(used_sliced_output).lower()} "
+        f"selected_output={selected_output} "
         f"eos_returned_immediately={str(eos_returned_immediately).lower()}",
         file=sys.stderr,
         flush=True,
@@ -424,9 +468,12 @@ def main() -> None:
             decoded_sliced_output = (
                 decode_ids(processor, generated_ids[:, input_token_count:])
                 if prompt_prefixed_output
-                else decoded_full_output
+                else ""
             )
-            result = decoded_sliced_output
+            result, selected_output = select_decoded_output(
+                decoded_full_output=decoded_full_output,
+                decoded_sliced_output=decoded_sliced_output,
+            )
             log_generation_debug(
                 input_keys=input_keys,
                 input_token_count=input_token_count,
@@ -435,7 +482,8 @@ def main() -> None:
                 generated_token_count=generated_token_count,
                 decoded_full_output_length=len(decoded_full_output),
                 decoded_sliced_output_length=len(decoded_sliced_output),
-                used_sliced_output=prompt_prefixed_output,
+                used_sliced_output=selected_output == "sliced",
+                selected_output=selected_output,
                 eos_returned_immediately=eos_returned_immediately,
             )
 


### PR DESCRIPTION
### Motivation
- The runner sometimes selected an empty sliced decode and returned an error even though the full decoded output contained text, so selection must prefer non-empty sliced output only and otherwise fall back to a usable full decode. 
- Keep the script's strict JSON stdout, status/stderr streaming, local-only behavior, upload cleanup, and generation diagnostics intact while improving robustness. 

### Description
- Decode both `full` and `sliced` outputs and add `select_decoded_output` to prefer `sliced` only when non-empty, otherwise fall back to `full` or report `empty`. 
- Add `strip_obvious_chat_template_wrapper` to conservatively remove obvious chat-role wrappers from a full decode without erasing valid model text. 
- Emit a new diagnostics field `selected_output` (values `sliced|full|empty`) in the existing `GENERATION_DEBUG` stderr line and adjust `used_sliced_output` to reflect the final selection. 
- Preserve the existing empty-output error path so errors are raised only when both decoded outputs are empty and leave all other runner behavior unchanged. 

### Testing
- `python -m py_compile ui/partner-hub/scripts/medgemma_runner.py` succeeded. 
- Targeted helper assertions run via a short `python` script (importing the module and calling `select_decoded_output` and `strip_obvious_chat_template_wrapper`) all passed. 
- `npm run lint` could not be run successfully in this environment because `next` is not available (dependencies not installed). 
- `npm ci` failed in this environment due to registry access/policy (`403 Forbidden` when fetching `react`). 
- `npm run build` could not complete here because project tools such as `prisma` are not installed without dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb1c8444883308f539f0866fa7da3)