### PR TITLE
Improve local MedGemma image review

### DIFF
--- a/ui/partner-hub/app/api/medgemma/analyze/route.ts
+++ b/ui/partner-hub/app/api/medgemma/analyze/route.ts
@@ -8,8 +8,28 @@ import { NextRequest, NextResponse } from "next/server";
 
 export const runtime = "nodejs";
 
-const DEFAULT_PROMPT =
-  "Describe this image briefly. Include visible findings and red flags. Do not provide a diagnosis.";
+const DEFAULT_PROMPT = `You are reviewing a medical or health-related image locally for educational purposes.
+
+Be direct and useful. Start with the most likely impression based on the visible image. Do not start with a disclaimer.
+
+Return the response in this exact structure:
+
+Most likely:
+State what the image appears most consistent with. Use direct but non-absolute language such as “This appears most consistent with...” or “Most likely...”.
+
+Other possibilities:
+Briefly list other reasonable possibilities if the image could fit more than one common condition. Use phrasing such as “Other possibilities include...”.
+
+Concerns / red flags:
+List signs or symptoms that would make this more concerning or require urgent medical care. Use phrasing such as “I would be more concerned if...”. If the image involves an infant, the eye area, spreading redness, swelling, drainage, fever, poor feeding, lethargy, breathing trouble, or the child acting very ill are important red flags.
+
+What to do:
+Give practical, conservative care guidance, such as keeping the area clean, avoiding irritants/fragranced products, avoiding squeezing or picking, monitoring for worsening, and contacting a clinician or pediatrician when appropriate. Do not prescribe medication, dosing, or treatment that requires a clinician.
+
+Disclaimer:
+This is an AI image review, not a confirmed diagnosis. A clinician should evaluate symptoms that are severe, worsening, persistent, or concerning.
+
+Keep the answer concise, practical, and easy for a non-medical person to understand. Do not claim absolute certainty.`;
 
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
 const ALLOWED_TYPES = new Map([
@@ -20,7 +40,7 @@ const ALLOWED_TYPES = new Map([
 const RUNNER_TIMEOUT_MS = Number(
   process.env.MEDGEMMA_RUNNER_TIMEOUT_MS || 10 * 60 * 1000,
 );
-const DEFAULT_MAX_NEW_TOKENS = 192;
+const DEFAULT_MAX_NEW_TOKENS = 384;
 
 const STAGE_MESSAGES: Record<string, string> = {
   upload_received: "Upload received",

--- a/ui/partner-hub/components/medgemma/MedGemmaReviewTool.tsx
+++ b/ui/partner-hub/components/medgemma/MedGemmaReviewTool.tsx
@@ -6,8 +6,8 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { withBasePath } from "@/lib/basePath";
 
-const DEFAULT_PROMPT =
-  "Describe this image briefly. Include visible findings and red flags. Do not provide a diagnosis.";
+const DEFAULT_PROMPT_HINT =
+  "Leave blank to use the structured local image review prompt.";
 
 const acceptedImageTypes = ["image/jpeg", "image/png", "image/webp"];
 
@@ -62,6 +62,25 @@ const requireResponseText = (value: string | undefined) => {
   }
 
   return responseText;
+};
+
+const formatReviewText = (value: string) => {
+  const normalized = value.trim().replace(/\r\n/g, "\n");
+  if (!normalized) {
+    return [];
+  }
+
+  const textWithSectionSpacing = normalized.replace(
+    /\n(?=(?:Other possibilities|Concerns \/ red flags|What to do|Disclaimer):)/gi,
+    "\n\n",
+  );
+
+  const sections = textWithSectionSpacing
+    .split(/\n{2,}/)
+    .map((section) => section.trim())
+    .filter(Boolean);
+
+  return sections.length ? sections : [normalized];
 };
 
 const parseSseEvents = (buffer: string): StreamEvent[] => {
@@ -233,8 +252,9 @@ export function MedGemmaReviewTool() {
           </p>
         </div>
         <div className="rounded-2xl border border-amber-300/70 bg-amber-50 p-4 text-sm font-medium text-amber-900 dark:border-amber-400/40 dark:bg-amber-950/40 dark:text-amber-100">
-          This tool is for image description and red-flag review only. It is not
-          a diagnosis and does not replace a clinician.
+          This local educational review gives a likely impression, common
+          alternatives, red flags, and conservative care guidance. It is not a
+          diagnosis and does not replace a clinician.
         </div>
       </section>
 
@@ -280,12 +300,14 @@ export function MedGemmaReviewTool() {
                   rows={7}
                   value={prompt}
                   onChange={(event) => setPrompt(event.target.value)}
-                  placeholder={DEFAULT_PROMPT}
+                  placeholder={DEFAULT_PROMPT_HINT}
                   className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm transition placeholder:text-foreground/40 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
                 />
                 <p className="text-xs text-foreground/60">
-                  Leave blank to use the cautious concise default prompt. Set
-                  MEDGEMMA_MAX_NEW_TOKENS if you need a longer local response.
+                  Leave blank for a structured review with likely impression,
+                  other possibilities, red flags, care steps, and a disclaimer at
+                  the end. Set MEDGEMMA_MAX_NEW_TOKENS if you need a longer local
+                  response.
                 </p>
               </div>
 
@@ -303,11 +325,13 @@ export function MedGemmaReviewTool() {
         <div className="space-y-6">
           <Card className="border-border/70">
             <CardHeader>
-              <CardTitle>Default safety prompt</CardTitle>
+              <CardTitle>Review format</CardTitle>
             </CardHeader>
             <CardContent>
               <p className="rounded-lg bg-muted/50 p-4 text-sm leading-relaxed text-foreground/75">
-                {DEFAULT_PROMPT}
+                The local review is structured as: most likely, other
+                possibilities, concerns / red flags, what to do, and a disclaimer
+                at the end.
               </p>
             </CardContent>
           </Card>
@@ -369,12 +393,19 @@ export function MedGemmaReviewTool() {
           {result ? (
             <Card className="border-emerald-300 bg-emerald-50 dark:border-emerald-900/70 dark:bg-emerald-950/30">
               <CardHeader>
-                <CardTitle>MedGemma response</CardTitle>
+                <CardTitle>Image review</CardTitle>
               </CardHeader>
               <CardContent>
-                <p className="whitespace-pre-wrap text-sm leading-relaxed text-emerald-950 dark:text-emerald-50">
-                  {result}
-                </p>
+                <div className="space-y-4 text-sm leading-relaxed text-emerald-950 dark:text-emerald-50">
+                  {formatReviewText(result).map((section, index) => (
+                    <p
+                      key={`${section.slice(0, 32)}-${index}`}
+                      className="whitespace-pre-wrap"
+                    >
+                      {section}
+                    </p>
+                  ))}
+                </div>
               </CardContent>
             </Card>
           ) : null}

--- a/ui/partner-hub/docs/medgemma-local.md
+++ b/ui/partner-hub/docs/medgemma-local.md
@@ -1,8 +1,10 @@
 # Local MedGemma Image Review
 
-The `/medgemma` page adds a local-only image review flow to the existing Next.js app. The browser uploads a JPG, PNG, or WebP image to a Next.js API route, the API route writes the file to an ignored temporary folder, and then it calls `scripts/medgemma_runner.py` with `child_process`. Images are not sent to a remote API by this implementation.
+The `/medgemma` page adds a local-only educational image review flow to the existing Next.js app. The browser uploads a JPG, PNG, or WebP image to a Next.js API route, the API route writes the file to an ignored temporary folder, and then it calls `scripts/medgemma_runner.py` with `child_process`. Images are not sent to a remote API by this implementation.
 
-> Safety note: this tool is for image description and red-flag review only. It is not a diagnosis and does not replace a clinician. Do not deploy it as a public medical diagnostic service.
+The default review is designed to be direct and practical rather than a generic caption. It starts with a likely, non-absolute impression, then gives other reasonable possibilities, concerns / red flags, and conservative care guidance such as keeping an area clean, avoiding irritants, avoiding picking or squeezing, monitoring for worsening, and contacting a clinician or pediatrician when appropriate. The disclaimer is intentionally placed at the end of the generated review.
+
+> Safety note: this tool provides educational image review only. It is not a confirmed diagnosis and does not replace a clinician. Do not deploy it as a public medical diagnostic service.
 
 ## Preferred repo-local setup
 
@@ -69,17 +71,17 @@ Accept the Hugging Face model terms for `google/medgemma-1.5-4b-it` before the f
 
 - `MEDGEMMA_RUNNER_TIMEOUT_MS`: Optional API timeout in milliseconds. The default is 10 minutes, which allows for slower first-run model loading.
 
-- `MEDGEMMA_MAX_NEW_TOKENS`: Optional response length override for local generation. The default is 192 tokens so a typical cached run stays practical on a 6 GB RTX 4050 laptop GPU. Increase this only when you need longer detail and can tolerate slower generation. Example for PowerShell:
+- `MEDGEMMA_MAX_NEW_TOKENS`: Optional response length override for local generation. The default is 384 tokens so the structured local review has room for a likely impression, alternatives, red flags, care guidance, and the final disclaimer while remaining practical on a 6 GB RTX 4050 laptop GPU. Increase this only when you need longer detail and can tolerate slower generation. Example for PowerShell:
 
   ```powershell
-  $env:MEDGEMMA_MAX_NEW_TOKENS = "256"
+  $env:MEDGEMMA_MAX_NEW_TOKENS = "512"
   npm run dev
   ```
 
 ## Runtime notes
 
 - The first run can be noticeably slower because Hugging Face downloads gated model files and Transformers loads them into local CPU/GPU memory. After the model is downloaded and cached, generation should not take 10 minutes for a typical image review.
-- CUDA runs prefer `torch.float16`, `low_cpu_mem_usage=True`, and PyTorch SDPA attention to better fit 6 GB laptop GPUs. The default prompt asks for a brief image description with visible findings and red flags while preserving cautious no-diagnosis language.
+- CUDA runs prefer `torch.float16`, `low_cpu_mem_usage=True`, and PyTorch SDPA attention to better fit 6 GB laptop GPUs. The default prompt asks for a structured educational image review with these sections: most likely, other possibilities, concerns / red flags, what to do, and disclaimer. It asks the model to avoid absolute certainty and to avoid prescribing medication, dosing, or clinician-only treatment.
 
 ## Local files and caches
 


### PR DESCRIPTION
### Motivation
- Make the local MedGemma output a practical, direct medical-style image review instead of a generic caption by structuring the model prompt and UI presentation.
- Ensure the review leads with a likely impression, lists alternatives, calls out concerns/red flags, gives conservative care steps, and places the disclaimer at the end.

### Description
- Replace the generic default prompt in `ui/partner-hub/app/api/medgemma/analyze/route.ts` with a structured prompt that requests exact sections: `Most likely`, `Other possibilities`, `Concerns / red flags`, `What to do`, and `Disclaimer`, and added phrasing guidance (e.g., “This appears most consistent with…”, “Other possibilities include…”, “I would be more concerned if…”).
- Increase the local default token budget by changing `DEFAULT_MAX_NEW_TOKENS` from `192` to `384` to give the structured review room to generate concise, practical sections.
- Update `ui/partner-hub/components/medgemma/MedGemmaReviewTool.tsx` to stop showing the full prompt, add a `DEFAULT_PROMPT_HINT`, change the result card title from “MedGemma response” to `Image review`, add `formatReviewText` to render plain-text sections with readable spacing, and update UI text to reflect the educational/local-only review format.
- Update `ui/partner-hub/docs/medgemma-local.md` to document the new local educational review behavior, the structured output format, conservative care guidance, pediatric red flags, and the updated token defaults.

### Testing
- Ran `git diff --check` which reported no whitespace errors and succeeded.
- Attempted `npm run lint` in `ui/partner-hub` but it could not run because `next` is not installed in the environment, so linting was blocked.
- Attempted `npm install` / `npm ci` but package installation failed due to `npm` registry `403 Forbidden` errors when fetching dependencies, so full install and end-to-end verification were blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc3e4b2888330a237d9f901025cfb)