### PR TITLE
Refine MedGemma prompt to require morphology/distribution reasoning and enforce output sections

### DIFF
--- a/ui/partner-hub/app/api/medgemma/analyze/route.ts
+++ b/ui/partner-hub/app/api/medgemma/analyze/route.ts
@@ -10,26 +10,36 @@ export const runtime = "nodejs";
 
 const DEFAULT_PROMPT = `You are reviewing a medical or health-related image locally for educational purposes.
 
-Be direct and useful. Start with the most likely impression based on the visible image. Do not start with a disclaimer.
+Write like a professional clinician explaining the image to a patient or parent in plain English. Be direct and useful. Do not start with a disclaimer. Give the most likely impression first, then explain why.
+
+Before choosing the most likely impression, evaluate the image findings:
+- Visible morphology: papules, pustules, vesicles, crusting, scaling, swelling, or flat/diffuse rash.
+- Distribution: localized face/cheek/forehead/eye area versus trunk, hands, feet, mouth, or widespread body involvement.
+- User-provided symptoms/context, if any.
+
+Do not guess a broad/systemic rash category from a localized image alone. If the image is localized to an infant's face and shows clustered small bumps, papules, or pustules without visible hand, foot, mouth, trunk, or widespread body involvement, common localized infant facial patterns such as baby acne/neonatal acne or localized irritation/contact dermatitis should be considered before viral rash categories. Viral rash categories should be the most likely impression only when the visible distribution or user-provided symptoms support them.
 
 Return the response in this exact structure:
 
 Most likely:
-State what the image appears most consistent with. Use direct but non-absolute language such as “This appears most consistent with...” or “Most likely...”.
+State the most likely impression in direct plain English. Use wording like “This looks most consistent with...” or “This is most likely...”. Do not claim absolute certainty.
+
+Why:
+Briefly explain what visible features and distribution support that impression.
 
 Other possibilities:
-Briefly list other reasonable possibilities if the image could fit more than one common condition. Use phrasing such as “Other possibilities include...”.
+Briefly list other reasonable possibilities, if any, and explain what would make them more or less likely.
 
-Concerns / red flags:
-List signs or symptoms that would make this more concerning or require urgent medical care. Use phrasing such as “I would be more concerned if...”. If the image involves an infant, the eye area, spreading redness, swelling, drainage, fever, poor feeding, lethargy, breathing trouble, or the child acting very ill are important red flags.
+Concerns:
+List the specific findings or symptoms that would make this more concerning. For infants, include fever, rapidly spreading redness, swelling near the eye, drainage/crusting, poor feeding, unusual sleepiness/lethargy, breathing trouble, or the baby acting very ill when relevant.
 
 What to do:
-Give practical, conservative care guidance, such as keeping the area clean, avoiding irritants/fragranced products, avoiding squeezing or picking, monitoring for worsening, and contacting a clinician or pediatrician when appropriate. Do not prescribe medication, dosing, or treatment that requires a clinician.
+Give practical conservative care guidance. Do not prescribe medication or dosing. Recommend gentle care, avoiding irritants, avoiding squeezing/picking, monitoring, and contacting a pediatrician/clinician when appropriate.
 
 Disclaimer:
 This is an AI image review, not a confirmed diagnosis. A clinician should evaluate symptoms that are severe, worsening, persistent, or concerning.
 
-Keep the answer concise, practical, and easy for a non-medical person to understand. Do not claim absolute certainty.`;
+Keep the answer concise, professional, and easy for a non-medical person to understand.`;
 
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
 const ALLOWED_TYPES = new Map([

--- a/ui/partner-hub/docs/medgemma-local.md
+++ b/ui/partner-hub/docs/medgemma-local.md
@@ -2,7 +2,7 @@
 
 The `/medgemma` page adds a local-only educational image review flow to the existing Next.js app. The browser uploads a JPG, PNG, or WebP image to a Next.js API route, the API route writes the file to an ignored temporary folder, and then it calls `scripts/medgemma_runner.py` with `child_process`. Images are not sent to a remote API by this implementation.
 
-The default review is designed to be direct and practical rather than a generic caption. It starts with a likely, non-absolute impression, then gives other reasonable possibilities, concerns / red flags, and conservative care guidance such as keeping an area clean, avoiding irritants, avoiding picking or squeezing, monitoring for worsening, and contacting a clinician or pediatrician when appropriate. The disclaimer is intentionally placed at the end of the generated review.
+The default review is designed to be direct and practical rather than a generic caption. It asks the model to evaluate visible morphology, distribution, and any supplied symptoms or context before choosing a likely, non-absolute impression. The generated response uses the sections **Most likely**, **Why**, **Other possibilities**, **Concerns**, **What to do**, and **Disclaimer** so the visual reasoning appears before alternatives and care guidance. The disclaimer is intentionally placed only at the end of the generated review.
 
 > Safety note: this tool provides educational image review only. It is not a confirmed diagnosis and does not replace a clinician. Do not deploy it as a public medical diagnostic service.
 
@@ -81,7 +81,8 @@ Accept the Hugging Face model terms for `google/medgemma-1.5-4b-it` before the f
 ## Runtime notes
 
 - The first run can be noticeably slower because Hugging Face downloads gated model files and Transformers loads them into local CPU/GPU memory. After the model is downloaded and cached, generation should not take 10 minutes for a typical image review.
-- CUDA runs prefer `torch.float16`, `low_cpu_mem_usage=True`, and PyTorch SDPA attention to better fit 6 GB laptop GPUs. The default prompt asks for a structured educational image review with these sections: most likely, other possibilities, concerns / red flags, what to do, and disclaimer. It asks the model to avoid absolute certainty and to avoid prescribing medication, dosing, or clinician-only treatment.
+- CUDA runs prefer `torch.float16`, `low_cpu_mem_usage=True`, and PyTorch SDPA attention to better fit 6 GB laptop GPUs. The default prompt asks for a structured educational image review with these sections: most likely, why, other possibilities, concerns, what to do, and disclaimer. It asks the model to reason from visible morphology and distribution before the impression, avoid overcalling broad or systemic rash categories from a localized image alone, avoid absolute certainty, and avoid prescribing medication, dosing, or clinician-only treatment.
+- Prompt wording can improve output style and reasoning, but it cannot fully correct every model-quality issue. If MedGemma still performs poorly on known examples after the morphology/distribution prompt is in place, treat that as a model-quality limitation rather than continuing endless prompt tuning.
 
 ## Local files and caches
 


### PR DESCRIPTION
### Motivation
- Improve MedGemma's image-review accuracy and output style by forcing the model to reason from visible morphology and distribution (plus any supplied context) before stating a most-likely impression, preventing overcall of broad/systemic rash categories from localized images.

### Description
- Updated `DEFAULT_PROMPT` in `ui/partner-hub/app/api/medgemma/analyze/route.ts` to instruct the model to first evaluate visible morphology (e.g., papules, pustules, vesicles, crusting, scaling, swelling, flat/diffuse rash) and distribution (e.g., localized face vs trunk/hands/feet/mouth vs widespread) and to return the exact section order: `Most likely`, `Why`, `Other possibilities`, `Concerns`, `What to do`, `Disclaimer` with the disclaimer only at the bottom.
- Kept the prompt non-prescriptive (does not hard-code diagnoses), emphasized conservative non-prescription care guidance, and preserved local-only image handling and safety sanitization behaviors.
- Updated documentation in `ui/partner-hub/docs/medgemma-local.md` to describe the new morphology/distribution-first reasoning expectation, the exact response structure, and a note that persistent failures on known examples are model-quality limitations rather than endless prompt-tuning.
- No changes were made to upload validation, temp cleanup, SSE status streaming, empty-output handling, or the runner invocation logic; sanitization of sensitive strings remains in place.

### Testing
- Ran `git diff --check`, which passed with no whitespace errors.
- Attempted `npm run lint` in `ui/partner-hub` but it was blocked because project dependencies were not installed and `next` was not found (lint not executed).
- Attempted `npm ci` to install dependencies so lint could run, but it failed with a registry `403 Forbidden` for `react`, so dependency install and full linting could not be completed.
- The API route behavior and runner invocation code were not otherwise modified, and the prompt and docs changes were committed for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc7b9339c8330ac7b0a1ef4cf0f58)