### PR TITLE
Support multi-image skin reviews

### DIFF
--- a/ui/partner-hub/app/api/skin-review/analyze/route.ts
+++ b/ui/partner-hub/app/api/skin-review/analyze/route.ts
@@ -9,6 +9,7 @@ import { NextRequest, NextResponse } from "next/server";
 export const runtime = "nodejs";
 
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+const MAX_IMAGE_COUNT = 5;
 const ALLOWED_TYPES = new Map([
   ["image/jpeg", ".jpg"],
   ["image/png", ".png"],
@@ -40,10 +41,17 @@ type SkinReviewMatch = {
   redFlags: string[];
 };
 
+type PerImageMatches = {
+  imageIndex: number;
+  topMatches: SkinReviewMatch[];
+};
+
 type RunnerResult = {
   ok: boolean;
   model?: string;
+  imageCount?: number;
   topMatches?: SkinReviewMatch[];
+  perImageMatches?: PerImageMatches[];
   reviewText?: string;
   error?: string;
   errorType?:
@@ -79,9 +87,9 @@ const sanitizeStatusText = (value: string) => {
 const isFileLike = (value: FormDataEntryValue | null): value is File => {
   return Boolean(
     value &&
-      typeof value === "object" &&
-      "arrayBuffer" in value &&
-      "type" in value,
+    typeof value === "object" &&
+    "arrayBuffer" in value &&
+    "type" in value,
   );
 };
 
@@ -171,25 +179,35 @@ const safeRunnerSummary = (stderr: string) => {
     .filter(Boolean)
     .filter(
       (line) =>
-        line.startsWith("STAGE:") || /failed|error|requires|could not|unable/i.test(line),
+        line.startsWith("STAGE:") ||
+        /failed|error|requires|could not|unable/i.test(line),
     );
 
   return Array.from(new Set(lines)).slice(-8);
 };
 
 const runSkinReview = (
-  imagePath: string,
+  imagePaths: string[],
   onStatus?: StatusReporter,
 ): Promise<RunnerResult> => {
   const pythonPath = getSkinReviewPythonPath();
-  const runnerPath = path.join(process.cwd(), "scripts", "skin_review_runner.py");
+  const runnerPath = path.join(
+    process.cwd(),
+    "scripts",
+    "skin_review_runner.py",
+  );
 
   reportStage(onStatus, "starting_python_runner");
 
   return new Promise((resolve) => {
     const child = spawn(
       pythonPath,
-      [runnerPath, "--image", imagePath, "--max-matches", getMaxMatchesArg()],
+      [
+        runnerPath,
+        ...imagePaths.flatMap((imagePath) => ["--image", imagePath]),
+        "--max-matches",
+        getMaxMatchesArg(),
+      ],
       {
         cwd: process.cwd(),
         env: process.env,
@@ -257,7 +275,10 @@ const runSkinReview = (
       const trimmedStdout = stdout.trim();
       try {
         const parsed = JSON.parse(trimmedStdout) as RunnerResult;
-        if (parsed.ok && (!parsed.reviewText?.trim() || !parsed.topMatches?.length)) {
+        if (
+          parsed.ok &&
+          (!parsed.reviewText?.trim() || !parsed.topMatches?.length)
+        ) {
           finish(resultForEmptyRunnerOutput(safeRunnerSummary(stderr)));
           return;
         }
@@ -299,73 +320,125 @@ const resultForTempWriteError = (error: string): RunnerResult => ({
   errorType: "temp_write_failed",
 });
 
+type ValidatedUpload = {
+  bytes: Buffer;
+  extension: string;
+};
+
+const getRequestedImages = (formData: FormData) => {
+  const images = formData.getAll("images");
+  if (images.length) {
+    return images;
+  }
+
+  const legacyImage = formData.get("image");
+  return legacyImage ? [legacyImage] : [];
+};
+
+const validateUpload = async (
+  image: FormDataEntryValue,
+  index: number,
+): Promise<ValidatedUpload | RunnerResult> => {
+  const label = `Image ${index + 1}`;
+
+  if (!isFileLike(image)) {
+    return resultForUploadValidationError(
+      `${label} must be a JPG, PNG, or WebP image upload.`,
+    );
+  }
+
+  const extension = ALLOWED_TYPES.get(image.type);
+  if (!extension) {
+    return resultForUploadValidationError(
+      `${label} has an unsupported file type. Upload JPG, PNG, or WebP image(s).`,
+    );
+  }
+
+  if (image.size <= 0) {
+    return resultForUploadValidationError(`${label} is empty.`);
+  }
+
+  if (image.size > MAX_UPLOAD_BYTES) {
+    return resultForUploadValidationError(`${label} must be 10 MB or smaller.`);
+  }
+
+  const bytes = Buffer.from(await image.arrayBuffer());
+
+  if (bytes.length !== image.size) {
+    return resultForUploadValidationError(
+      `${label} size changed while reading form data (expected ${image.size} bytes, got ${bytes.length} bytes).`,
+    );
+  }
+
+  if (!hasValidImageSignature(bytes, image.type)) {
+    return resultForUploadValidationError(
+      `${label} content does not match the selected image type.`,
+    );
+  }
+
+  return { bytes, extension };
+};
+
+const writeValidatedUpload = async (
+  upload: ValidatedUpload,
+  uploadsDir: string,
+) => {
+  const uploadPath = path.join(
+    uploadsDir,
+    `${Date.now()}-${randomUUID()}${upload.extension}`,
+  );
+
+  await writeFile(uploadPath, upload.bytes, { flag: "wx" });
+
+  const uploadStats = await stat(uploadPath);
+  if (!uploadStats.isFile() || uploadStats.size !== upload.bytes.length) {
+    throw new Error(
+      `Temporary file size mismatch after write (expected ${upload.bytes.length} bytes, got ${uploadStats.size} bytes).`,
+    );
+  }
+
+  return uploadPath;
+};
+
 const analyzeSkinReviewRequest = async (
   request: NextRequest,
   onStatus?: StatusReporter,
 ): Promise<{ result: RunnerResult; status: number }> => {
-  let uploadPath = "";
+  const uploadPaths: string[] = [];
 
   try {
     const formData = await request.formData();
     reportStage(onStatus, "upload_received");
 
-    const image = formData.get("image");
+    const requestedImages = getRequestedImages(formData);
 
     reportStage(onStatus, "validating_image");
 
-    if (!isFileLike(image)) {
+    if (!requestedImages.length) {
       return {
         result: resultForUploadValidationError(
-          "A JPG, PNG, or WebP image upload is required.",
+          "At least one JPG, PNG, or WebP image upload is required.",
         ),
         status: 400,
       };
     }
 
-    const extension = ALLOWED_TYPES.get(image.type);
-    if (!extension) {
+    if (requestedImages.length > MAX_IMAGE_COUNT) {
       return {
         result: resultForUploadValidationError(
-          "Unsupported file type. Upload a JPG, PNG, or WebP image.",
+          "Upload no more than 5 image(s) for one skin review.",
         ),
         status: 400,
       };
     }
 
-    if (image.size <= 0) {
-      return {
-        result: resultForUploadValidationError("Uploaded image is empty."),
-        status: 400,
-      };
-    }
-
-    if (image.size > MAX_UPLOAD_BYTES) {
-      return {
-        result: resultForUploadValidationError(
-          "Uploaded image must be 10 MB or smaller.",
-        ),
-        status: 400,
-      };
-    }
-
-    const bytes = Buffer.from(await image.arrayBuffer());
-
-    if (bytes.length !== image.size) {
-      return {
-        result: resultForUploadValidationError(
-          `Uploaded image size changed while reading form data (expected ${image.size} bytes, got ${bytes.length} bytes).`,
-        ),
-        status: 400,
-      };
-    }
-
-    if (!hasValidImageSignature(bytes, image.type)) {
-      return {
-        result: resultForUploadValidationError(
-          "Uploaded file content does not match the selected image type.",
-        ),
-        status: 400,
-      };
+    const validatedUploads: ValidatedUpload[] = [];
+    for (const [index, image] of requestedImages.entries()) {
+      const validation = await validateUpload(image, index);
+      if ("ok" in validation) {
+        return { result: validation, status: 400 };
+      }
+      validatedUploads.push(validation);
     }
 
     reportStage(onStatus, "writing_temp_file");
@@ -373,48 +446,23 @@ const analyzeSkinReviewRequest = async (
     const uploadsDir = path.join(process.cwd(), ".skin-review-uploads");
     await mkdir(uploadsDir, { recursive: true });
 
-    uploadPath = path.join(
-      uploadsDir,
-      `${Date.now()}-${randomUUID()}${extension}`,
-    );
-
     try {
-      await writeFile(uploadPath, bytes, { flag: "wx" });
+      for (const upload of validatedUploads) {
+        uploadPaths.push(await writeValidatedUpload(upload, uploadsDir));
+      }
     } catch (error) {
       const message =
         error instanceof Error
           ? error.message
-          : "Could not write uploaded image.";
+          : "Could not write uploaded image(s).";
       return { result: resultForTempWriteError(message), status: 500 };
     }
 
-    let uploadStats;
-    try {
-      uploadStats = await stat(uploadPath);
-    } catch (error) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : "Temporary upload file is missing.";
-      return {
-        result: resultForTempWriteError(
-          `Temporary file was not readable after write. ${message}`,
-        ),
-        status: 500,
-      };
-    }
-
-    if (!uploadStats.isFile() || uploadStats.size !== bytes.length) {
-      return {
-        result: resultForTempWriteError(
-          `Temporary file size mismatch after write (expected ${bytes.length} bytes, got ${uploadStats.size} bytes).`,
-        ),
-        status: 500,
-      };
-    }
-
-    const result = await runSkinReview(uploadPath, onStatus);
-    if (result.ok && (!result.reviewText?.trim() || !result.topMatches?.length)) {
+    const result = await runSkinReview(uploadPaths, onStatus);
+    if (
+      result.ok &&
+      (!result.reviewText?.trim() || !result.topMatches?.length)
+    ) {
       return {
         result: resultForEmptyRunnerOutput(result.runnerStages),
         status: 500,
@@ -447,9 +495,11 @@ const analyzeSkinReviewRequest = async (
       status: 500,
     };
   } finally {
-    if (uploadPath) {
-      await rm(uploadPath, { force: true }).catch(() => undefined);
-    }
+    await Promise.all(
+      uploadPaths.map((uploadPath) =>
+        rm(uploadPath, { force: true }).catch(() => undefined),
+      ),
+    );
   }
 };
 

--- a/ui/partner-hub/components/skin-review/SkinReviewTool.tsx
+++ b/ui/partner-hub/components/skin-review/SkinReviewTool.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { withBasePath } from "@/lib/basePath";
 
 const acceptedImageTypes = ["image/jpeg", "image/png", "image/webp"];
+const maxImageCount = 5;
 
 const initialProgressMessages: ProgressMessage[] = [
-  { stage: "waiting", message: "Waiting for an image", elapsedMs: 0 },
+  { stage: "waiting", message: "Waiting for image(s)", elapsedMs: 0 },
 ];
 
 type SkinReviewMatch = {
@@ -23,10 +24,17 @@ type SkinReviewMatch = {
   redFlags: string[];
 };
 
+type PerImageMatches = {
+  imageIndex: number;
+  topMatches: SkinReviewMatch[];
+};
+
 type AnalysisResponse = {
   ok: boolean;
   model?: string;
+  imageCount?: number;
   topMatches?: SkinReviewMatch[];
+  perImageMatches?: PerImageMatches[];
   reviewText?: string;
   error?: string;
   runnerStages?: string[];
@@ -73,6 +81,8 @@ const requireReview = (data: AnalysisResponse) => {
 
   return {
     model: data.model || "local DermLIP skin review model",
+    imageCount: data.imageCount || 1,
+    perImageMatches: data.perImageMatches || [],
     reviewText,
     topMatches: data.topMatches,
   };
@@ -116,9 +126,11 @@ const parseSseEvents = (buffer: string): StreamEvent[] => {
 };
 
 export function SkinReviewTool() {
-  const [image, setImage] = useState<File | null>(null);
+  const [images, setImages] = useState<File[]>([]);
   const [reviewText, setReviewText] = useState("");
   const [topMatches, setTopMatches] = useState<SkinReviewMatch[]>([]);
+  const [perImageMatches, setPerImageMatches] = useState<PerImageMatches[]>([]);
+  const [imageCount, setImageCount] = useState(0);
   const [model, setModel] = useState("");
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -126,14 +138,31 @@ export function SkinReviewTool() {
     initialProgressMessages,
   );
 
+  const selectedImagePreviews = useMemo(
+    () =>
+      images.map((image) => ({
+        name: image.name,
+        sizeInMb: image.size / (1024 * 1024),
+        url: URL.createObjectURL(image),
+      })),
+    [images],
+  );
+
+  useEffect(() => {
+    return () => {
+      selectedImagePreviews.forEach((preview) =>
+        URL.revokeObjectURL(preview.url),
+      );
+    };
+  }, [selectedImagePreviews]);
+
   const helperText = useMemo(() => {
-    if (!image) {
-      return "Choose a JPG, PNG, or WebP image to review locally.";
+    if (!images.length) {
+      return "Choose 1–5 JPG, PNG, or WebP image(s) to review locally.";
     }
 
-    const sizeInMb = image.size / (1024 * 1024);
-    return `${image.name} • ${sizeInMb.toFixed(2)} MB`;
-  }, [image]);
+    return `${images.length} selected image${images.length === 1 ? "" : "s"}`;
+  }, [images]);
 
   const latestProgress = progressMessages[progressMessages.length - 1];
 
@@ -152,6 +181,8 @@ export function SkinReviewTool() {
     const review = requireReview(data);
     setReviewText(review.reviewText);
     setTopMatches(review.topMatches);
+    setPerImageMatches(review.perImageMatches);
+    setImageCount(review.imageCount);
     setModel(review.model);
   };
 
@@ -213,16 +244,25 @@ export function SkinReviewTool() {
     setError("");
     setReviewText("");
     setTopMatches([]);
+    setPerImageMatches([]);
+    setImageCount(0);
     setModel("");
 
-    if (!image) {
-      setError("Please select a JPG, PNG, or WebP image before reviewing.");
+    if (!images.length) {
+      setError(
+        "Please select 1–5 JPG, PNG, or WebP image(s) before reviewing.",
+      );
       return;
     }
 
-    if (!acceptedImageTypes.includes(image.type)) {
+    if (images.length > maxImageCount) {
+      setError("Please select no more than 5 image(s) for one review.");
+      return;
+    }
+
+    if (images.some((image) => !acceptedImageTypes.includes(image.type))) {
       setError(
-        "Unsupported file type. Please upload a JPG, PNG, or WebP image.",
+        "Unsupported file type. Please upload JPG, PNG, or WebP image(s).",
       );
       return;
     }
@@ -238,7 +278,7 @@ export function SkinReviewTool() {
 
     try {
       const formData = new FormData();
-      formData.append("image", image);
+      images.forEach((image) => formData.append("images", image));
 
       const response = await fetch(withBasePath("/api/skin-review/analyze"), {
         method: "POST",
@@ -269,7 +309,7 @@ export function SkinReviewTool() {
             Skin Image Review
           </h1>
           <p className="max-w-3xl text-base leading-relaxed text-foreground/70">
-            Upload a skin image and run a local dermatology-focused visual
+            Upload 1–5 skin images and run one local dermatology-focused visual
             ranking workflow. Images are passed only to the local Python runner
             and are not sent to a remote image API.
           </p>
@@ -285,11 +325,11 @@ export function SkinReviewTool() {
       <div className="grid gap-6 lg:grid-cols-[1fr_0.9fr]">
         <Card className="border-border/70">
           <CardHeader>
-            <CardTitle>Review an image</CardTitle>
+            <CardTitle>Review image(s)</CardTitle>
             <p className="text-sm text-foreground/60">
-              The API route stores the upload in a temporary ignored folder,
-              calls the local DermLIP ranking runner, then removes the temporary
-              file.
+              The API route stores uploads in a temporary ignored folder, calls
+              the local DermLIP ranking runner, then removes the temporary
+              files.
             </p>
           </CardHeader>
           <CardContent>
@@ -299,18 +339,63 @@ export function SkinReviewTool() {
                   className="text-sm font-semibold text-foreground"
                   htmlFor="skin-review-image"
                 >
-                  Image file
+                  Image file(s)
                 </label>
                 <input
                   id="skin-review-image"
                   type="file"
                   accept="image/jpeg,image/png,image/webp,.jpg,.jpeg,.png,.webp"
+                  multiple
                   className="block w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground file:mr-4 file:rounded-md file:border-0 file:bg-muted file:px-3 file:py-2 file:text-sm file:font-semibold file:text-foreground hover:file:bg-muted/80"
-                  onChange={(event) =>
-                    setImage(event.target.files?.[0] ?? null)
-                  }
+                  onChange={(event) => {
+                    const selectedFiles = Array.from(event.target.files ?? []);
+                    const limitedFiles = selectedFiles.slice(0, maxImageCount);
+                    setImages(limitedFiles);
+                    if (selectedFiles.length > maxImageCount) {
+                      setError(
+                        "Only the first 5 image(s) will be included in one local review.",
+                      );
+                    } else if (error.startsWith("Only the first 5")) {
+                      setError("");
+                    }
+                  }}
                 />
                 <p className="text-xs text-foreground/60">{helperText}</p>
+                <div className="rounded-lg bg-muted/50 p-3 text-xs leading-relaxed text-foreground/65">
+                  <p className="font-semibold text-foreground/75">
+                    Recommended image set:
+                  </p>
+                  <ul className="mt-2 list-disc space-y-1 pl-5">
+                    <li>context/orientation shot</li>
+                    <li>close-up</li>
+                    <li>side angle if raised or swollen</li>
+                    <li>another affected area</li>
+                    <li>normal nearby skin if useful for comparison</li>
+                  </ul>
+                </div>
+                {selectedImagePreviews.length ? (
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    {selectedImagePreviews.map((preview, index) => (
+                      <div
+                        key={`${preview.name}-${index}`}
+                        className="rounded-xl border border-border bg-background p-3"
+                      >
+                        {/* eslint-disable-next-line @next/next/no-img-element -- Local object URL previews are not remote optimized assets. */}
+                        <img
+                          src={preview.url}
+                          alt={`Selected skin review image ${index + 1}`}
+                          className="h-32 w-full rounded-lg object-cover"
+                        />
+                        <p className="mt-2 truncate text-sm font-medium text-foreground">
+                          {index + 1}. {preview.name}
+                        </p>
+                        <p className="text-xs text-foreground/60">
+                          {preview.sizeInMb.toFixed(2)} MB
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
               </div>
 
               <Button
@@ -318,7 +403,7 @@ export function SkinReviewTool() {
                 disabled={isLoading}
                 className="w-full sm:w-auto"
               >
-                {isLoading ? "Reviewing locally..." : "Review image"}
+                {isLoading ? "Reviewing locally..." : "Review image(s)"}
               </Button>
             </form>
           </CardContent>
@@ -331,10 +416,10 @@ export function SkinReviewTool() {
             </CardHeader>
             <CardContent>
               <p className="rounded-lg bg-muted/50 p-4 text-sm leading-relaxed text-foreground/75">
-                The local review returns top ranked visual possibilities,
-                plain-English context, other possibilities, red flags,
-                conservative care guidance, and a bottom disclaimer. It does not
-                show raw prompts or embeddings.
+                The local review returns combined top ranked visual
+                possibilities, plain-English context, other possibilities, red
+                flags, conservative care guidance, and a bottom disclaimer. It
+                does not show raw prompts or embeddings.
               </p>
             </CardContent>
           </Card>
@@ -352,7 +437,8 @@ export function SkinReviewTool() {
                 <p className="text-sm text-foreground/70">
                   The first run may be slow while model files download and load
                   into GPU memory. Status messages are generated locally and
-                  omit tokens, raw embeddings, raw prompts, and full local paths.
+                  omit tokens, raw embeddings, raw prompts, and full local
+                  paths.
                 </p>
                 <ol className="space-y-2 text-sm text-foreground/75">
                   {progressMessages.map((message, index) => (
@@ -394,10 +480,12 @@ export function SkinReviewTool() {
           {topMatches.length ? (
             <Card className="border-emerald-300 bg-emerald-50 dark:border-emerald-900/70 dark:bg-emerald-950/30">
               <CardHeader>
-                <CardTitle>Top ranked possibilities</CardTitle>
+                <CardTitle>Combined top ranked possibilities</CardTitle>
                 <p className="text-sm text-emerald-950/70 dark:text-emerald-50/70">
-                  Model: {model}. Scores are visual similarity rankings, not
-                  diagnosis confidence.
+                  Model: {model}. Image count:{" "}
+                  {imageCount || images.length || 1}. Scores are averaged visual
+                  similarity rankings, not diagnosis confidence. All image
+                  processing stays local.
                 </p>
               </CardHeader>
               <CardContent>
@@ -423,6 +511,45 @@ export function SkinReviewTool() {
                     </li>
                   ))}
                 </ol>
+              </CardContent>
+            </Card>
+          ) : null}
+
+          {perImageMatches.length ? (
+            <Card className="border-emerald-300 bg-emerald-50 dark:border-emerald-900/70 dark:bg-emerald-950/30">
+              <CardHeader>
+                <CardTitle>Per-image top matches</CardTitle>
+                <p className="text-sm text-emerald-950/70 dark:text-emerald-50/70">
+                  These local-only per-image rankings are shown for visibility
+                  when images disagree.
+                </p>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {perImageMatches.map((imageResult) => (
+                  <details
+                    key={imageResult.imageIndex}
+                    className="rounded-xl border border-emerald-200 bg-white/70 p-4 text-sm text-emerald-950 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-50"
+                  >
+                    <summary className="cursor-pointer font-semibold">
+                      Image {imageResult.imageIndex} top matches
+                    </summary>
+                    <ol className="mt-3 space-y-2">
+                      {imageResult.topMatches.map((match, index) => (
+                        <li
+                          key={match.id}
+                          className="flex justify-between gap-3"
+                        >
+                          <span>
+                            {index + 1}. {match.label}
+                          </span>
+                          <span className="font-semibold">
+                            {match.percent.toFixed(1)}%
+                          </span>
+                        </li>
+                      ))}
+                    </ol>
+                  </details>
+                ))}
               </CardContent>
             </Card>
           ) : null}

--- a/ui/partner-hub/scripts/skin_review_runner.py
+++ b/ui/partner-hub/scripts/skin_review_runner.py
@@ -13,6 +13,8 @@ from typing import Any
 
 DEFAULT_MODEL_ID = "redlessone/DermLIP_ViT-B-16"
 DEFAULT_MAX_MATCHES = 5
+PER_IMAGE_MATCHES = 3
+MAX_IMAGE_COUNT = 5
 MAX_IMAGE_PIXELS = 40_000_000
 GENERAL_RED_FLAGS = [
     "fever",
@@ -48,17 +50,38 @@ LABELS: tuple[SkinLabel, ...] = (
         label="neonatal acne / baby acne",
         prompt="a clinical skin image showing neonatal acne or baby acne with small papules or pustules on an infant face",
         plain_english="Common baby acne can look like small red or white bumps on an infant's cheeks, forehead, or face.",
-        what_supports=("small facial papules or pustules", "localized infant facial distribution", "no obvious widespread rash pattern"),
-        what_argues_against=("honey-colored crusting", "grouped clear blisters", "rapid spreading swelling or warmth"),
-        red_flags=("fever", "poor feeding", "baby acting ill", "rapidly spreading redness"),
+        what_supports=(
+            "small facial papules or pustules",
+            "localized infant facial distribution",
+            "no obvious widespread rash pattern",
+        ),
+        what_argues_against=(
+            "honey-colored crusting",
+            "grouped clear blisters",
+            "rapid spreading swelling or warmth",
+        ),
+        red_flags=(
+            "fever",
+            "poor feeding",
+            "baby acting ill",
+            "rapidly spreading redness",
+        ),
     ),
     SkinLabel(
         id="infantile_acne",
         label="infantile acne",
         prompt="a clinical skin image showing infantile acne with comedones papules or pustules on a baby's face",
         plain_english="Infantile acne can show acne-like bumps on the face after the newborn period.",
-        what_supports=("acne-like bumps", "face-centered pattern", "comedone-like spots if visible"),
-        what_argues_against=("diffuse body rash", "yellow crusting", "clear grouped blisters"),
+        what_supports=(
+            "acne-like bumps",
+            "face-centered pattern",
+            "comedone-like spots if visible",
+        ),
+        what_argues_against=(
+            "diffuse body rash",
+            "yellow crusting",
+            "clear grouped blisters",
+        ),
         red_flags=("painful swelling", "rapid worsening", "fever"),
     ),
     SkinLabel(
@@ -66,7 +89,11 @@ LABELS: tuple[SkinLabel, ...] = (
         label="milia",
         prompt="a clinical skin image showing milia with tiny white bumps on an infant face",
         plain_english="Milia are tiny white bumps that are common on infant faces and often look uniform and non-inflamed.",
-        what_supports=("tiny white bumps", "minimal surrounding redness", "nose cheek or forehead distribution"),
+        what_supports=(
+            "tiny white bumps",
+            "minimal surrounding redness",
+            "nose cheek or forehead distribution",
+        ),
         what_argues_against=("pus drainage", "marked redness", "spreading rash"),
         red_flags=("rapid redness", "swelling near the eye", "drainage or crusting"),
     ),
@@ -75,8 +102,16 @@ LABELS: tuple[SkinLabel, ...] = (
         label="neonatal cephalic pustulosis",
         prompt="a clinical skin image showing neonatal cephalic pustulosis with facial pustules on a newborn scalp or face",
         plain_english="This newborn facial or scalp pattern can resemble baby acne with small pustules concentrated on the head or face.",
-        what_supports=("newborn face or scalp involvement", "small pustules", "localized head and neck pattern"),
-        what_argues_against=("widespread trunk involvement", "honey crusting", "grouped vesicles"),
+        what_supports=(
+            "newborn face or scalp involvement",
+            "small pustules",
+            "localized head and neck pattern",
+        ),
+        what_argues_against=(
+            "widespread trunk involvement",
+            "honey crusting",
+            "grouped vesicles",
+        ),
         red_flags=("fever", "poor feeding", "baby acting ill"),
     ),
     SkinLabel(
@@ -84,17 +119,38 @@ LABELS: tuple[SkinLabel, ...] = (
         label="irritant contact dermatitis",
         prompt="a clinical skin image showing irritant contact dermatitis with localized redness and irritation",
         plain_english="Irritation from saliva, rubbing, wipes, products, or fabrics can cause localized redness and roughness.",
-        what_supports=("localized redness", "area exposed to rubbing or products", "irritated rather than blistering pattern"),
-        what_argues_against=("rapidly spreading warmth", "fever", "thick yellow crusting"),
-        red_flags=("skin breakdown", "drainage", "rapid spread", "swelling near the eye"),
+        what_supports=(
+            "localized redness",
+            "area exposed to rubbing or products",
+            "irritated rather than blistering pattern",
+        ),
+        what_argues_against=(
+            "rapidly spreading warmth",
+            "fever",
+            "thick yellow crusting",
+        ),
+        red_flags=(
+            "skin breakdown",
+            "drainage",
+            "rapid spread",
+            "swelling near the eye",
+        ),
     ),
     SkinLabel(
         id="atopic_dermatitis",
         label="atopic dermatitis / eczema",
         prompt="a clinical skin image showing atopic dermatitis or eczema with dry red scaly itchy patches",
         plain_english="Eczema often appears as dry, itchy, red, rough, or scaly patches that may come and go.",
-        what_supports=("dry or scaly patches", "itchy-looking irritated skin", "recurrent patchy redness"),
-        what_argues_against=("localized pustules only", "grouped blisters", "rapidly spreading painful swelling"),
+        what_supports=(
+            "dry or scaly patches",
+            "itchy-looking irritated skin",
+            "recurrent patchy redness",
+        ),
+        what_argues_against=(
+            "localized pustules only",
+            "grouped blisters",
+            "rapidly spreading painful swelling",
+        ),
         red_flags=("weeping or crusting", "pain", "fever", "rapid worsening"),
     ),
     SkinLabel(
@@ -102,8 +158,16 @@ LABELS: tuple[SkinLabel, ...] = (
         label="seborrheic dermatitis / cradle cap",
         prompt="a clinical skin image showing seborrheic dermatitis or cradle cap with greasy scale and redness on infant scalp face or folds",
         plain_english="Cradle cap and seborrheic dermatitis can cause greasy scale with redness on the scalp, eyebrows, face, or skin folds.",
-        what_supports=("greasy yellow-white scale", "scalp eyebrow or fold involvement", "mild redness under scale"),
-        what_argues_against=("clear grouped blisters", "rapid spread", "marked swelling"),
+        what_supports=(
+            "greasy yellow-white scale",
+            "scalp eyebrow or fold involvement",
+            "mild redness under scale",
+        ),
+        what_argues_against=(
+            "clear grouped blisters",
+            "rapid spread",
+            "marked swelling",
+        ),
         red_flags=("oozing", "bad smell", "fever", "baby acting ill"),
     ),
     SkinLabel(
@@ -111,8 +175,16 @@ LABELS: tuple[SkinLabel, ...] = (
         label="heat rash / miliaria",
         prompt="a clinical skin image showing heat rash or miliaria with tiny red bumps in warm occluded skin areas",
         plain_english="Heat rash can show many tiny bumps in warm, sweaty, or covered areas.",
-        what_supports=("many tiny bumps", "warm or occluded area", "recent heat or sweating context"),
-        what_argues_against=("yellow crusting", "localized eye swelling", "grouped blisters"),
+        what_supports=(
+            "many tiny bumps",
+            "warm or occluded area",
+            "recent heat or sweating context",
+        ),
+        what_argues_against=(
+            "yellow crusting",
+            "localized eye swelling",
+            "grouped blisters",
+        ),
         red_flags=("fever", "rapid spread", "painful swelling", "baby acting ill"),
     ),
     SkinLabel(
@@ -120,17 +192,38 @@ LABELS: tuple[SkinLabel, ...] = (
         label="impetigo",
         prompt="a clinical skin image showing impetigo with yellow crusting or drainage",
         plain_english="Impetigo is a contagious superficial skin infection that often has honey-yellow crusting, oozing, or drainage.",
-        what_supports=("honey-colored crust", "oozing or drainage", "sores around nose mouth or irritated skin"),
-        what_argues_against=("only dry non-crusted bumps", "uniform tiny white bumps", "no drainage or crust"),
-        red_flags=("spreading redness", "fever", "swelling near the eye", "baby acting ill"),
+        what_supports=(
+            "honey-colored crust",
+            "oozing or drainage",
+            "sores around nose mouth or irritated skin",
+        ),
+        what_argues_against=(
+            "only dry non-crusted bumps",
+            "uniform tiny white bumps",
+            "no drainage or crust",
+        ),
+        red_flags=(
+            "spreading redness",
+            "fever",
+            "swelling near the eye",
+            "baby acting ill",
+        ),
     ),
     SkinLabel(
         id="folliculitis",
         label="folliculitis",
         prompt="a clinical skin image showing folliculitis with small pustules centered around hair follicles",
         plain_english="Folliculitis can look like small inflamed bumps or pustules centered on hair follicles.",
-        what_supports=("pustules around follicles", "hair-bearing area", "similar small inflamed bumps"),
-        what_argues_against=("flat diffuse rash", "greasy scale", "grouped clear blisters"),
+        what_supports=(
+            "pustules around follicles",
+            "hair-bearing area",
+            "similar small inflamed bumps",
+        ),
+        what_argues_against=(
+            "flat diffuse rash",
+            "greasy scale",
+            "grouped clear blisters",
+        ),
         red_flags=("painful boil", "spreading redness", "fever"),
     ),
     SkinLabel(
@@ -138,53 +231,123 @@ LABELS: tuple[SkinLabel, ...] = (
         label="viral exanthem",
         prompt="a clinical skin image showing viral exanthem with widespread red macules or papules on the body",
         plain_english="A viral rash is usually considered when there is a more widespread pattern or illness symptoms along with the rash.",
-        what_supports=("widespread trunk or body rash", "many similar red spots", "fever or viral symptoms if present"),
-        what_argues_against=("single localized face patch", "only a few infant facial bumps", "yellow crusting"),
-        red_flags=("fever in a young infant", "breathing trouble", "lethargy", "non-blanching purple spots"),
+        what_supports=(
+            "widespread trunk or body rash",
+            "many similar red spots",
+            "fever or viral symptoms if present",
+        ),
+        what_argues_against=(
+            "single localized face patch",
+            "only a few infant facial bumps",
+            "yellow crusting",
+        ),
+        red_flags=(
+            "fever in a young infant",
+            "breathing trouble",
+            "lethargy",
+            "non-blanching purple spots",
+        ),
     ),
     SkinLabel(
         id="hand_foot_mouth",
         label="hand-foot-mouth pattern",
         prompt="a clinical skin image showing hand foot and mouth disease pattern with vesicles on hands feet or around the mouth",
         plain_english="Hand-foot-mouth pattern is more likely when spots or blisters involve the hands, feet, mouth, or diaper area with illness symptoms.",
-        what_supports=("hands feet or mouth involvement", "small blisters or erosions", "compatible distribution"),
-        what_argues_against=("only localized cheek bumps", "no hand foot or mouth distribution", "greasy scale"),
-        red_flags=("dehydration", "breathing trouble", "lethargy", "fever in a young infant"),
+        what_supports=(
+            "hands feet or mouth involvement",
+            "small blisters or erosions",
+            "compatible distribution",
+        ),
+        what_argues_against=(
+            "only localized cheek bumps",
+            "no hand foot or mouth distribution",
+            "greasy scale",
+        ),
+        red_flags=(
+            "dehydration",
+            "breathing trouble",
+            "lethargy",
+            "fever in a young infant",
+        ),
     ),
     SkinLabel(
         id="herpes_simplex_grouped_vesicles",
         label="herpes simplex / grouped vesicles",
         prompt="a clinical skin image showing grouped vesicles consistent with herpes simplex",
         plain_english="Grouped clear blisters, especially near the eye or in a young infant, need prompt clinician review.",
-        what_supports=("clustered clear blisters", "erosions after blisters", "localized painful-looking grouped lesions"),
-        what_argues_against=("solid acne-like papules", "tiny uniform white bumps", "dry scale without blisters"),
-        red_flags=("grouped clear blisters", "eye-area involvement", "fever", "poor feeding", "lethargy"),
+        what_supports=(
+            "clustered clear blisters",
+            "erosions after blisters",
+            "localized painful-looking grouped lesions",
+        ),
+        what_argues_against=(
+            "solid acne-like papules",
+            "tiny uniform white bumps",
+            "dry scale without blisters",
+        ),
+        red_flags=(
+            "grouped clear blisters",
+            "eye-area involvement",
+            "fever",
+            "poor feeding",
+            "lethargy",
+        ),
     ),
     SkinLabel(
         id="cellulitis_spreading_bacterial_infection",
         label="cellulitis / spreading bacterial skin infection",
         prompt="a clinical skin image showing cellulitis with spreading redness and swelling",
         plain_english="Cellulitis is a deeper spreading infection pattern with expanding redness, warmth, swelling, pain, or fever.",
-        what_supports=("spreading redness", "swelling", "warmth or tenderness if present"),
-        what_argues_against=("stable tiny bumps", "no swelling", "dry scaly patch only"),
-        red_flags=("rapidly spreading redness", "fever", "swelling near the eye", "baby acting ill"),
+        what_supports=(
+            "spreading redness",
+            "swelling",
+            "warmth or tenderness if present",
+        ),
+        what_argues_against=(
+            "stable tiny bumps",
+            "no swelling",
+            "dry scaly patch only",
+        ),
+        red_flags=(
+            "rapidly spreading redness",
+            "fever",
+            "swelling near the eye",
+            "baby acting ill",
+        ),
     ),
     SkinLabel(
         id="urticaria_allergic_reaction",
         label="allergic reaction / urticaria",
         prompt="a clinical skin image showing allergic reaction or urticaria with raised wheals or hives",
         plain_english="Hives are raised welts that often move around and can occur with allergic reactions or viral illnesses.",
-        what_supports=("raised welts", "changing or migrating spots", "itchy-looking swelling"),
+        what_supports=(
+            "raised welts",
+            "changing or migrating spots",
+            "itchy-looking swelling",
+        ),
         what_argues_against=("fixed pustules", "yellow crusting", "tiny white bumps"),
-        red_flags=("breathing trouble", "face or lip swelling", "vomiting with hives", "baby acting ill"),
+        red_flags=(
+            "breathing trouble",
+            "face or lip swelling",
+            "vomiting with hives",
+            "baby acting ill",
+        ),
     ),
     SkinLabel(
         id="insect_bites",
         label="insect bites",
         prompt="a clinical skin image showing insect bites with discrete itchy red papules possibly with central puncta",
         plain_english="Bites often appear as separate itchy red bumps and may have a central dot or occur in exposed areas.",
-        what_supports=("discrete separated bumps", "central punctum if visible", "exposed skin distribution"),
-        what_argues_against=("widespread viral pattern", "greasy scale", "uniform tiny white facial bumps"),
+        what_supports=(
+            "discrete separated bumps",
+            "central punctum if visible",
+            "exposed skin distribution",
+        ),
+        what_argues_against=(
+            "widespread viral pattern",
+            "greasy scale",
+            "uniform tiny white facial bumps",
+        ),
         red_flags=("rapid swelling", "spreading redness", "drainage", "fever"),
     ),
     SkinLabel(
@@ -192,8 +355,16 @@ LABELS: tuple[SkinLabel, ...] = (
         label="nonspecific rash / unclear",
         prompt="a clinical skin image showing a nonspecific unclear rash without a definitive visual pattern",
         plain_english="Some images do not have enough distinctive visual information for a confident visual category.",
-        what_supports=("mixed or subtle findings", "limited image context", "no single distinctive pattern"),
-        what_argues_against=("classic honey crust", "classic grouped blisters", "classic tiny white milia"),
+        what_supports=(
+            "mixed or subtle findings",
+            "limited image context",
+            "no single distinctive pattern",
+        ),
+        what_argues_against=(
+            "classic honey crust",
+            "classic grouped blisters",
+            "classic tiny white milia",
+        ),
         red_flags=tuple(GENERAL_RED_FLAGS),
     ),
 )
@@ -218,13 +389,24 @@ def default_max_matches_from_env() -> int:
     try:
         return int(raw_value)
     except ValueError:
-        print("Ignoring SKIN_REVIEW_MAX_MATCHES because it is not an integer.", file=sys.stderr, flush=True)
+        print(
+            "Ignoring SKIN_REVIEW_MAX_MATCHES because it is not an integer.",
+            file=sys.stderr,
+            flush=True,
+        )
         return DEFAULT_MAX_MATCHES
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run local DermLIP skin image ranking.")
-    parser.add_argument("--image", required=True, help="Path to a local JPG, PNG, or WebP image.")
+    parser = argparse.ArgumentParser(
+        description="Run local DermLIP skin image ranking."
+    )
+    parser.add_argument(
+        "--image",
+        action="append",
+        required=True,
+        help="Path to a local JPG, PNG, or WebP image. Repeat for multiple images.",
+    )
     parser.add_argument(
         "--max-matches",
         type=int,
@@ -242,13 +424,20 @@ def parse_args() -> argparse.Namespace:
 def requested_device() -> str:
     value = os.environ.get("SKIN_REVIEW_DEVICE", "auto").strip().lower()
     if value not in {"auto", "cuda", "cpu"}:
-        print("Ignoring SKIN_REVIEW_DEVICE because it is not auto, cuda, or cpu.", file=sys.stderr, flush=True)
+        print(
+            "Ignoring SKIN_REVIEW_DEVICE because it is not auto, cuda, or cpu.",
+            file=sys.stderr,
+            flush=True,
+        )
         return "auto"
     return value
 
 
 def model_id() -> str:
-    return os.environ.get("SKIN_REVIEW_MODEL_ID", DEFAULT_MODEL_ID).strip() or DEFAULT_MODEL_ID
+    return (
+        os.environ.get("SKIN_REVIEW_MODEL_ID", DEFAULT_MODEL_ID).strip()
+        or DEFAULT_MODEL_ID
+    )
 
 
 def clamp_max_matches(value: int) -> int:
@@ -276,7 +465,9 @@ def load_image(image_path: str):
     except ImageDecodeError:
         raise
     except Exception as exc:  # noqa: BLE001 - converted to safe JSON error.
-        raise ImageDecodeError("PIL could not decode the uploaded image safely.") from exc
+        raise ImageDecodeError(
+            "PIL could not decode the uploaded image safely."
+        ) from exc
 
 
 def validate_image_signature_for_smoke(image_path: str) -> None:
@@ -288,7 +479,9 @@ def validate_image_signature_for_smoke(image_path: str) -> None:
     is_png = len(data) >= 8 and data[:8] == b"\x89PNG\r\n\x1a\n"
     is_webp = len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP"
     if not (is_jpeg or is_png or is_webp):
-        raise ImageDecodeError("Image file did not look like a JPG, PNG, or WebP image.")
+        raise ImageDecodeError(
+            "Image file did not look like a JPG, PNG, or WebP image."
+        )
 
 
 def choose_device(torch_module: Any) -> str:
@@ -297,12 +490,40 @@ def choose_device(torch_module: Any) -> str:
         return "cpu"
     if request == "cuda":
         if not torch_module.cuda.is_available():
-            raise RunnerFailure("SKIN_REVIEW_DEVICE=cuda was requested, but CUDA is not available.")
+            raise RunnerFailure(
+                "SKIN_REVIEW_DEVICE=cuda was requested, but CUDA is not available."
+            )
         return "cuda"
     return "cuda" if torch_module.cuda.is_available() else "cpu"
 
 
-def classify_image(image: Any, max_matches: int) -> list[dict[str, Any]]:
+def match_from_score(index: int, score: float) -> dict[str, Any]:
+    label = LABELS[index]
+    percent = round(float(score) * 100.0, 1)
+    return {
+        "id": label.id,
+        "label": label.label,
+        "score": round(float(score), 4),
+        "percent": percent,
+        "plainEnglish": label.plain_english,
+        "whatSupports": list(label.what_supports),
+        "whatArguesAgainst": list(label.what_argues_against),
+        "redFlags": list(dict.fromkeys([*label.red_flags, *GENERAL_RED_FLAGS])),
+    }
+
+
+def top_matches_from_scores(
+    scores: list[float], max_matches: int
+) -> list[dict[str, Any]]:
+    ranked_indices = sorted(
+        range(len(scores)), key=lambda index: scores[index], reverse=True
+    )[:max_matches]
+    return [match_from_score(index, scores[index]) for index in ranked_indices]
+
+
+def classify_images(
+    images: list[Any], max_matches: int
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     emit_stage("loading_model")
     try:
         import open_clip
@@ -316,95 +537,137 @@ def classify_image(image: Any, max_matches: int) -> list[dict[str, Any]]:
     device = choose_device(torch)
 
     try:
-        model, _, preprocess = open_clip.create_model_and_transforms(f"hf-hub:{selected_model_id}")
+        model, _, preprocess = open_clip.create_model_and_transforms(
+            f"hf-hub:{selected_model_id}"
+        )
         tokenizer = open_clip.get_tokenizer(f"hf-hub:{selected_model_id}")
     except Exception as exc:  # noqa: BLE001 - avoid leaking cache paths/tokens.
-        raise RunnerFailure("Could not load the local DermLIP model from the configured Hugging Face model ID.") from exc
+        raise RunnerFailure(
+            "Could not load the local DermLIP model from the configured Hugging Face model ID."
+        ) from exc
 
     model = model.to(device)
     model.eval()
 
     emit_stage("running_classification")
     prompts = [label.prompt for label in LABELS]
+    all_scores: list[list[float]] = []
 
     with torch.no_grad():
-        image_tensor = preprocess(image).unsqueeze(0).to(device)
         text_tokens = tokenizer(prompts).to(device)
-        image_features = model.encode_image(image_tensor)
         text_features = model.encode_text(text_tokens)
-        image_features = image_features / image_features.norm(dim=-1, keepdim=True)
         text_features = text_features / text_features.norm(dim=-1, keepdim=True)
-        similarities = (100.0 * image_features @ text_features.T).softmax(dim=-1)[0]
 
-    scores = similarities.detach().cpu().tolist()
-    ranked_indices = sorted(range(len(scores)), key=lambda index: scores[index], reverse=True)[:max_matches]
-    matches: list[dict[str, Any]] = []
-    for index in ranked_indices:
-        label = LABELS[index]
-        percent = round(float(scores[index]) * 100.0, 1)
-        matches.append(
-            {
-                "id": label.id,
-                "label": label.label,
-                "score": round(float(scores[index]), 4),
-                "percent": percent,
-                "plainEnglish": label.plain_english,
-                "whatSupports": list(label.what_supports),
-                "whatArguesAgainst": list(label.what_argues_against),
-                "redFlags": list(dict.fromkeys([*label.red_flags, *GENERAL_RED_FLAGS])),
-            }
-        )
-    return matches
+        for image in images:
+            image_tensor = preprocess(image).unsqueeze(0).to(device)
+            image_features = model.encode_image(image_tensor)
+            image_features = image_features / image_features.norm(dim=-1, keepdim=True)
+            similarities = (100.0 * image_features @ text_features.T).softmax(dim=-1)[0]
+            all_scores.append(
+                [float(score) for score in similarities.detach().cpu().tolist()]
+            )
+
+    average_scores = [
+        sum(image_scores[label_index] for image_scores in all_scores) / len(all_scores)
+        for label_index in range(len(LABELS))
+    ]
+    combined_matches = top_matches_from_scores(average_scores, max_matches)
+    per_image_matches = [
+        {
+            "imageIndex": image_index + 1,
+            "topMatches": top_matches_from_scores(
+                image_scores, min(PER_IMAGE_MATCHES, max_matches)
+            ),
+        }
+        for image_index, image_scores in enumerate(all_scores)
+    ]
+    return combined_matches, per_image_matches
 
 
 def smoke_matches(max_matches: int) -> list[dict[str, Any]]:
-    matches: list[dict[str, Any]] = []
-    for label in LABELS[-max_matches:]:
-        matches.append(
-            {
-                "id": label.id,
-                "label": label.label,
-                "score": 0.0,
-                "percent": 0.0,
-                "plainEnglish": label.plain_english,
-                "whatSupports": list(label.what_supports),
-                "whatArguesAgainst": list(label.what_argues_against),
-                "redFlags": list(dict.fromkeys([*label.red_flags, *GENERAL_RED_FLAGS])),
-            }
-        )
-    return matches
+    scores = [0.0 for _ in LABELS]
+    return top_matches_from_scores(scores, max_matches)
 
 
-def build_review_text(matches: list[dict[str, Any]]) -> str:
+def smoke_per_image_matches(image_count: int, max_matches: int) -> list[dict[str, Any]]:
+    top_matches = top_matches_from_scores(
+        [0.0 for _ in LABELS], min(PER_IMAGE_MATCHES, max_matches)
+    )
+    return [
+        {"imageIndex": image_index + 1, "topMatches": top_matches}
+        for image_index in range(image_count)
+    ]
+
+
+def has_mixed_per_image_evidence(per_image_matches: list[dict[str, Any]]) -> bool:
+    top_labels = {
+        image_result["topMatches"][0]["id"]
+        for image_result in per_image_matches
+        if image_result.get("topMatches")
+    }
+    return len(top_labels) > 1
+
+
+def build_review_text(
+    matches: list[dict[str, Any]],
+    image_count: int,
+    per_image_matches: list[dict[str, Any]],
+) -> str:
     top = matches[0]
     alternatives = matches[1:4]
     support_text = "; ".join(top["whatSupports"][:3])
     argues_text = []
     for match in alternatives:
-        argues_text.append(f"{match['label']} would be more likely with {', '.join(match['whatSupports'][:2])}.")
+        argues_text.append(
+            f"{match['label']} would be more likely with {', '.join(match['whatSupports'][:2])}."
+        )
     red_flags = list(dict.fromkeys([*top.get("redFlags", []), *GENERAL_RED_FLAGS]))
+    mixed_evidence = has_mixed_per_image_evidence(per_image_matches)
+    image_word = "image" if image_count == 1 else "images"
+    mixed_text = (
+        " The per-image top labels differ, so the visual evidence is mixed/inconsistent across the submitted views."
+        if mixed_evidence
+        else ""
+    )
 
     return "\n\n".join(
         [
             "Most likely matches:\n"
-            + "\n".join(f"- {match['label']} ({match['percent']:.1f}%)" for match in matches),
+            + "\n".join(
+                f"- {match['label']} ({match['percent']:.1f}%)" for match in matches
+            ),
             "Plain-English read:\n"
-            + f"Based on the image, the top visual match is {top['label']}. This is a pattern match, not a confirmed diagnosis.",
-            "Why it may fit:\n" + f"{top['plainEnglish']} Visual features that can support this category include {support_text}.",
-            "Other possibilities:\n" + (" ".join(argues_text) if argues_text else "No additional ranked alternatives were returned."),
-            "Concerns / red flags:\nSeek prompt clinical advice for " + ", ".join(red_flags) + ".",
+            + f"Based on {image_count} {image_word}, the combined top visual match is {top['label']}. Scores are averaged visual similarity rankings across the submitted image(s), not diagnosis confidence.{mixed_text}",
+            "Why it may fit:\n"
+            + f"{top['plainEnglish']} Visual features that can support this category include {support_text}.",
+            "Other possibilities:\n"
+            + (
+                " ".join(argues_text)
+                if argues_text
+                else "No additional ranked alternatives were returned."
+            ),
+            "Concerns / red flags:\nSeek prompt clinical advice for "
+            + ", ".join(red_flags)
+            + ".",
             "What to do:\nUse gentle skin care, avoid new irritants or fragranced products, do not squeeze or pick bumps, and monitor whether the area spreads, drains, swells, or the child seems unwell. Contact a pediatrician or clinician when symptoms are severe, worsening, persistent, near the eye, or concerning.",
             "Disclaimer:\n" + DISCLAIMER,
         ]
     )
 
 
-def success_payload(matches: list[dict[str, Any]], selected_model_id: str) -> dict[str, Any]:
+def success_payload(
+    matches: list[dict[str, Any]],
+    selected_model_id: str,
+    image_count: int,
+    per_image_matches: list[dict[str, Any]],
+) -> dict[str, Any]:
     return {
         "ok": True,
         "model": selected_model_id,
+        "imageCount": image_count,
         "topMatches": matches,
-        "reviewText": build_review_text(matches),
+        "perImageMatches": per_image_matches,
+        "reviewText": build_review_text(matches, image_count, per_image_matches),
     }
 
 
@@ -415,28 +678,64 @@ def error_payload(error: str, error_type: str = "runner_failed") -> dict[str, An
 def main() -> int:
     args = parse_args()
     max_matches = clamp_max_matches(args.max_matches)
+    image_paths = args.image or []
 
     try:
         emit_stage("validating_image")
+        if not image_paths:
+            raise ImageDecodeError("At least one image file is required.")
+        if len(image_paths) > MAX_IMAGE_COUNT:
+            raise ImageDecodeError(
+                "No more than 5 image files can be reviewed at once."
+            )
+
         if args.smoke_validation_only:
-            validate_image_signature_for_smoke(args.image)
+            for image_path in image_paths:
+                validate_image_signature_for_smoke(image_path)
+            matches = smoke_matches(max_matches)
+            per_image_matches = smoke_per_image_matches(len(image_paths), max_matches)
             emit_stage("running_classification")
             emit_stage("complete")
-            print(json.dumps(success_payload(smoke_matches(max_matches), "smoke-validation-only"), separators=(",", ":")), flush=True)
+            print(
+                json.dumps(
+                    success_payload(
+                        matches,
+                        "smoke-validation-only",
+                        len(image_paths),
+                        per_image_matches,
+                    ),
+                    separators=(",", ":"),
+                ),
+                flush=True,
+            )
             return 0
 
-        image = load_image(args.image)
-        matches = classify_image(image, max_matches)
+        images = [load_image(image_path) for image_path in image_paths]
+        matches, per_image_matches = classify_images(images, max_matches)
         emit_stage("complete")
-        print(json.dumps(success_payload(matches, model_id()), separators=(",", ":")), flush=True)
+        print(
+            json.dumps(
+                success_payload(matches, model_id(), len(images), per_image_matches),
+                separators=(",", ":"),
+            ),
+            flush=True,
+        )
         return 0
     except ImageDecodeError as exc:
         print(f"Skin review image decode failed: {exc}", file=sys.stderr, flush=True)
-        print(json.dumps(error_payload(str(exc), "image_decode_failed"), separators=(",", ":")), flush=True)
+        print(
+            json.dumps(
+                error_payload(str(exc), "image_decode_failed"), separators=(",", ":")
+            ),
+            flush=True,
+        )
         return 1
     except Exception as exc:  # noqa: BLE001 - strict JSON error for the API route.
         print(f"Skin review runner failed: {exc}", file=sys.stderr, flush=True)
-        print(json.dumps(error_payload(str(exc), "runner_failed"), separators=(",", ":")), flush=True)
+        print(
+            json.dumps(error_payload(str(exc), "runner_failed"), separators=(",", ":")),
+            flush=True,
+        )
         return 1
 
 


### PR DESCRIPTION
### Motivation
- Allow the /skin-review flow to accept 1–5 images so local DermLIP reviews can use multiple views (orientation, close-up, side, other areas, nearby normal skin) for better visual context. 
- Keep processing strictly local, avoid sending images to remote services, and preserve backward compatibility with the single-`image` key. 
- Provide clearer UI guidance, previews, and per-image visibility so reviewers can see combined and per-image results.

### Description
- Frontend: replaced single `File | null` with `File[]` in `SkinReviewTool.tsx`, added `multiple` to the file input, limited selection to 5 files, show selected count, filenames and object-URL previews, added recommended-image helper text, and submit all files under the `images` FormData key while updating labels and button text to “image(s)”.
- API route: updated `app/api/skin-review/analyze/route.ts` to read `formData.getAll("images")` with fallback to legacy `image`, validate each file (file-like, allowed mime, non-empty, <= 10 MB, valid signature), reject zero or >5 images, write each validated upload to `.skin-review-uploads` using unique filenames, collect upload paths, pass all temp paths to the runner, and ensure all temp files are removed in `finally`.
- Runner: updated `scripts/skin_review_runner.py` to accept repeated `--image` args (`action='append'`), smoke-validate each path, load/validate each image, run DermLIP ranking per image, aggregate label scores by averaging across images into combined `topMatches`, produce `perImageMatches` (top N per image), emit strict JSON on stdout for the single result object, and print stage/diagnostic messages to stderr only.
- UX/other: SSE status messages remain available (runner stage lines parsed from stderr), previews use `URL.createObjectURL` and are revoked on unmount, and changes are kept local-only and avoid leaking local paths/secrets.

### Testing
- `python -m py_compile ui/partner-hub/scripts/skin_review_runner.py` — succeeded.
- Smoke runner test: `python ui/partner-hub/scripts/skin_review_runner.py --smoke-validation-only --image /tmp/skin1.png --image /tmp/skin2.png --max-matches 5` — succeeded and produced strict JSON that passed assertions (payload `ok: true`, `imageCount: 2`, `topMatches` length 5, `perImageMatches` length 2); runner stderr emitted `STAGE:` lines demonstrating SSE-stage reporting.
- `npm run lint` was attempted but could not run in this environment because project dependencies are not installed (`next` not found), so lint was blocked.
- `npm ci` was attempted but failed due to a registry access error (npm returned `403 Forbidden` for `react`), so frontend dependency installation and full linting were blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd9e058088330b3e9188d0b1b2817)