### PR TITLE
Calibrate skin-review visual rankings; add prompt variants, confidence labels, and UI guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ Thumbs.db
 **/__pycache__/
 *.pyc
 
+.skin-review-test-images/
+.skin-review-uploads/

--- a/ui/partner-hub/app/api/skin-review/analyze/route.ts
+++ b/ui/partner-hub/app/api/skin-review/analyze/route.ts
@@ -39,6 +39,7 @@ type SkinReviewMatch = {
   whatSupports: string[];
   whatArguesAgainst: string[];
   redFlags: string[];
+  highConsequence?: boolean;
 };
 
 type PerImageMatches = {
@@ -53,6 +54,13 @@ type RunnerResult = {
   topMatches?: SkinReviewMatch[];
   perImageMatches?: PerImageMatches[];
   reviewText?: string;
+  confidenceLabel?:
+    | "strong visual match"
+    | "moderate visual match"
+    | "weak/mixed visual match";
+  mixedEvidence?: boolean;
+  topMargin?: number;
+  agreementSummary?: string;
   error?: string;
   errorType?:
     | "image_decode_failed"

--- a/ui/partner-hub/components/skin-review/SkinReviewTool.tsx
+++ b/ui/partner-hub/components/skin-review/SkinReviewTool.tsx
@@ -22,6 +22,7 @@ type SkinReviewMatch = {
   whatSupports: string[];
   whatArguesAgainst: string[];
   redFlags: string[];
+  highConsequence?: boolean;
 };
 
 type PerImageMatches = {
@@ -36,6 +37,13 @@ type AnalysisResponse = {
   topMatches?: SkinReviewMatch[];
   perImageMatches?: PerImageMatches[];
   reviewText?: string;
+  confidenceLabel?:
+    | "strong visual match"
+    | "moderate visual match"
+    | "weak/mixed visual match";
+  mixedEvidence?: boolean;
+  topMargin?: number;
+  agreementSummary?: string;
   error?: string;
   runnerStages?: string[];
 };
@@ -85,6 +93,12 @@ const requireReview = (data: AnalysisResponse) => {
     perImageMatches: data.perImageMatches || [],
     reviewText,
     topMatches: data.topMatches,
+    confidenceLabel: data.confidenceLabel || "weak/mixed visual match",
+    mixedEvidence: Boolean(data.mixedEvidence),
+    topMargin: data.topMargin ?? 0,
+    agreementSummary:
+      data.agreementSummary ||
+      "Agreement summary was not returned by the local runner.",
   };
 };
 
@@ -94,8 +108,21 @@ const formatReviewText = (value: string) => {
     return [];
   }
 
+  const sectionHeadings = [
+    "Most likely visual match / combined impression",
+    "Confidence / agreement",
+    "Why it may fit",
+    "Other possibilities",
+    "Concerns / red flags",
+    "What to do",
+    "Disclaimer",
+  ];
+  const sectionHeadingPattern = new RegExp(
+    `\\n(?=(?:${sectionHeadings.join("|")}):)`,
+    "gi",
+  );
   const textWithSectionSpacing = normalized.replace(
-    /\n(?=(?:Plain-English read|Why it may fit|Other possibilities|Concerns \/ red flags|What to do|Disclaimer):)/gi,
+    sectionHeadingPattern,
     "\n\n",
   );
 
@@ -132,6 +159,10 @@ export function SkinReviewTool() {
   const [perImageMatches, setPerImageMatches] = useState<PerImageMatches[]>([]);
   const [imageCount, setImageCount] = useState(0);
   const [model, setModel] = useState("");
+  const [confidenceLabel, setConfidenceLabel] = useState("");
+  const [mixedEvidence, setMixedEvidence] = useState(false);
+  const [agreementSummary, setAgreementSummary] = useState("");
+  const [topMargin, setTopMargin] = useState(0);
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [progressMessages, setProgressMessages] = useState<ProgressMessage[]>(
@@ -184,6 +215,10 @@ export function SkinReviewTool() {
     setPerImageMatches(review.perImageMatches);
     setImageCount(review.imageCount);
     setModel(review.model);
+    setConfidenceLabel(review.confidenceLabel);
+    setMixedEvidence(review.mixedEvidence);
+    setAgreementSummary(review.agreementSummary);
+    setTopMargin(review.topMargin);
   };
 
   const readStreamingResponse = async (response: Response) => {
@@ -247,6 +282,10 @@ export function SkinReviewTool() {
     setPerImageMatches([]);
     setImageCount(0);
     setModel("");
+    setConfidenceLabel("");
+    setMixedEvidence(false);
+    setAgreementSummary("");
+    setTopMargin(0);
 
     if (!images.length) {
       setError(
@@ -418,7 +457,9 @@ export function SkinReviewTool() {
               <p className="rounded-lg bg-muted/50 p-4 text-sm leading-relaxed text-foreground/75">
                 The local review returns combined top ranked visual
                 possibilities, plain-English context, other possibilities, red
-                flags, conservative care guidance, and a bottom disclaimer. It
+                flags, confidence/agreement calibration, conservative care
+                guidance, and a bottom disclaimer. Scores are relative visual
+                similarity rankings rather than diagnosis confidence, and the UI
                 does not show raw prompts or embeddings.
               </p>
             </CardContent>
@@ -488,7 +529,27 @@ export function SkinReviewTool() {
                   processing stays local.
                 </p>
               </CardHeader>
-              <CardContent>
+              <CardContent className="space-y-4">
+                <div className="rounded-xl border border-emerald-200 bg-white/70 p-4 text-sm text-emerald-950 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-50">
+                  <p className="font-semibold capitalize">
+                    Confidence: {confidenceLabel || "visual match"}
+                  </p>
+                  <p className="mt-1 text-emerald-950/75 dark:text-emerald-50/75">
+                    {agreementSummary}
+                  </p>
+                  <p className="mt-1 text-xs text-emerald-950/65 dark:text-emerald-50/65">
+                    Margin over #2: {topMargin.toFixed(4)}. This margin is a
+                    relative ranking gap, not a medical probability.
+                  </p>
+                </div>
+
+                {mixedEvidence || confidenceLabel === "weak/mixed visual match" ? (
+                  <div className="rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm font-medium text-amber-950 dark:border-amber-900/70 dark:bg-amber-950/40 dark:text-amber-50">
+                    The uploaded images do not strongly agree. Treat this as a
+                    weak visual match.
+                  </div>
+                ) : null}
+
                 <ol className="space-y-3">
                   {topMatches.map((match, index) => (
                     <li

--- a/ui/partner-hub/docs/skin-review-local.md
+++ b/ui/partner-hub/docs/skin-review-local.md
@@ -1,8 +1,35 @@
 # Local Skin Image Review
 
-The `/skin-review` page replaces the previous MedGemma image-review flow with a dermatology-specific local ranking workflow. The browser uploads a JPG, PNG, or WebP image to a Next.js API route, the API route writes the file to an ignored temporary folder, and then it calls `scripts/skin_review_runner.py` with `child_process`. Images are not sent to a remote image API by this implementation.
+The `/skin-review` page replaces the previous MedGemma image-review flow with a dermatology-specific local ranking workflow. The browser uploads 1–5 JPG, PNG, or WebP images to a Next.js API route, the API route writes each file to an ignored temporary folder, and then it calls `scripts/skin_review_runner.py` with `child_process`. Images are not sent to a remote image API by this implementation.
 
 The first target model is `redlessone/DermLIP_ViT-B-16`, loaded through `open_clip` as a CLIP-style dermatology vision-language model. It is used for zero-shot visual label ranking against a curated local prompt set. It is not a chat model and does not generate free-form medical judgments.
+
+## Important interpretation limits
+
+DermLIP returns visual similarity between the uploaded image and local dermatology label prompts. The displayed percentages are normalized ranking scores relative to the labels offered to the model; they are **not diagnosis confidence, probabilities of disease, or a substitute for a clinician**. A high score only means that, among the local labels, the image looked most similar to that label's prompt variants.
+
+The runner now uses multiple clinically distinct prompt variants per label and max-pools those variants into one label score before ranking labels. The prompt set includes morphology and distribution concepts such as papules, pustules, vesicles/blisters, crusting/drainage, scaling/dryness, swelling, flat/diffuse rash, localized cheek/forehead/face findings, trunk/widespread patterns, and hands/feet/mouth patterns. Raw prompts are intentionally not exposed in the UI.
+
+## Confidence labels and mixed evidence
+
+Each successful runner response includes:
+
+- `confidenceLabel`: `strong visual match`, `moderate visual match`, or `weak/mixed visual match`.
+- `mixedEvidence`: true when rankings are close, image views disagree, the top condition appears in too few per-image rankings, or a high-consequence label is not strongly supported.
+- `topMargin`: the score gap between the combined #1 and #2 labels.
+- `agreementSummary`: how often the combined #1 appeared as per-image #1 or in each image's top 3.
+
+These fields calibrate the UI language. Strong or moderate results still describe only a visual match, not a diagnosis. Weak/mixed results explicitly say the visual evidence is mixed and avoid leading with a diagnosis-like statement.
+
+## Multi-image aggregation
+
+For each image, the runner encodes the image and compares it with every prompt variant. Prompt variants are collapsed into label scores by max-pooling the best variant for each label, then labels are normalized for display ranking. For multi-image reviews, label scores are averaged across images to create the combined top matches. Per-image top matches remain visible so reviewers can see when submitted views disagree.
+
+## High-consequence labels
+
+Some labels are marked high-consequence because weak visual similarity should not be presented as the main likely impression without stronger support. Examples include herpes simplex / grouped vesicles, cellulitis / spreading bacterial skin infection, impetigo, allergic reaction / urticaria, viral exanthem, and hand-foot-mouth pattern.
+
+When a high-consequence label ranks highly but the confidence label is weak/mixed, the plain-English review treats it as a red-flag concern to check for rather than a likely diagnosis. The combined ranking remains visible for transparency, but the narrative says what findings would make that condition more concerning.
 
 ## Windows setup
 
@@ -70,14 +97,31 @@ A validation-only smoke check is available when you need to confirm local image 
 python scripts/skin_review_runner.py --image path/to/local-image.png --smoke-validation-only
 ```
 
-A full local model run uses:
+A full local model run uses one or more `--image` arguments:
 
 ```bash
-python scripts/skin_review_runner.py --image path/to/local-image.png --max-matches 5
+python scripts/skin_review_runner.py --image path/to/local-image-1.png --image path/to/local-image-2.jpg --max-matches 5
 ```
+
+## Manual validation with private local images
+
+Do not commit private medical images. For local validation, create an ignored folder at the repo root:
+
+```bash
+mkdir -p .skin-review-test-images
+```
+
+Place known private test images in `.skin-review-test-images/` only on your machine. Then run from `ui/partner-hub` using relative paths back to the ignored folder:
+
+```bash
+python scripts/skin_review_runner.py --image ../../.skin-review-test-images/example-1.png --smoke-validation-only
+python scripts/skin_review_runner.py --image ../../.skin-review-test-images/example-1.png --image ../../.skin-review-test-images/example-2.jpg --max-matches 5
+```
+
+Review the combined matches, per-image matches, confidence label, mixed-evidence flag, top margin, agreement summary, and red-flag language. Keep the images private and remove them when no longer needed.
 
 ## Limitations
 
-DermLIP is better aligned to dermatology images than the previous general medical-image flow, but this implementation still requires validation on representative images and clinical review before relying on it. The output is ranked visual similarity to curated text labels, not a confirmed diagnosis. Similar-looking rashes can have different causes, and important context such as age, symptoms, timing, exposures, fever, pain, itch, medications, vaccination status, and whether the child appears ill may not be visible in an image.
+DermLIP is better aligned to dermatology images than the previous general medical-image flow, but this implementation still requires validation on representative images and clinical review before relying on it. Similar-looking rashes can have different causes, and important context such as age, symptoms, timing, exposures, fever, pain, itch, medications, vaccination status, and whether the child appears ill may not be visible in an image.
 
-The UI intentionally presents top possibilities, reasons a category may fit, alternatives, red flags, conservative next steps, and a bottom disclaimer instead of presenting one overconfident diagnosis. A clinician should evaluate symptoms that are severe, worsening, persistent, near the eye, associated with fever or illness, or otherwise concerning.
+The UI intentionally presents top possibilities, confidence/agreement context, reasons a category may fit, alternatives, red flags, conservative next steps, and a bottom disclaimer instead of presenting one overconfident diagnosis. A clinician should evaluate symptoms that are severe, worsening, persistent, near the eye, associated with fever or illness, or otherwise concerning.

--- a/ui/partner-hub/scripts/skin_review_runner.py
+++ b/ui/partner-hub/scripts/skin_review_runner.py
@@ -14,6 +14,8 @@ from typing import Any
 DEFAULT_MODEL_ID = "redlessone/DermLIP_ViT-B-16"
 DEFAULT_MAX_MATCHES = 5
 PER_IMAGE_MATCHES = 3
+STRONG_MARGIN = 0.12
+MODERATE_MARGIN = 0.05
 MAX_IMAGE_COUNT = 5
 MAX_IMAGE_PIXELS = 40_000_000
 GENERAL_RED_FLAGS = [
@@ -37,26 +39,37 @@ DISCLAIMER = (
 class SkinLabel:
     id: str
     label: str
-    prompt: str
+    prompts: tuple[str, ...]
     plain_english: str
     what_supports: tuple[str, ...]
     what_argues_against: tuple[str, ...]
     red_flags: tuple[str, ...]
+    high_consequence: bool = False
 
 
+# Prompts intentionally include multiple morphology/distribution variants per label
+# (papules, pustules, vesicles/blisters, crusting/drainage, scaling/dryness,
+# swelling, flat/diffuse rash, facial vs trunk/widespread vs hands/feet/mouth).
+# During scoring, each prompt variant is encoded, image-to-prompt similarities are
+# computed, and variants are max-pooled into one label score. Max-pooling favors
+# the best clinically distinct variant without displaying raw prompts to users.
 LABELS: tuple[SkinLabel, ...] = (
     SkinLabel(
         id="neonatal_acne",
         label="neonatal acne / baby acne",
-        prompt="a clinical skin image showing neonatal acne or baby acne with small papules or pustules on an infant face",
+        prompts=(
+            "a clinical skin image showing neonatal acne with small red papules on an infant face",
+            "a clinical skin image showing baby acne with small pustules on the cheeks of a newborn",
+            "a close-up infant face photo with scattered acne-like bumps on the cheeks",
+        ),
         plain_english="Common baby acne can look like small red or white bumps on an infant's cheeks, forehead, or face.",
         what_supports=(
             "small facial papules or pustules",
-            "localized infant facial distribution",
-            "no obvious widespread rash pattern",
+            "localized cheek forehead or face distribution",
+            "no obvious widespread trunk rash pattern",
         ),
         what_argues_against=(
-            "honey-colored crusting",
+            "honey-colored crusting or drainage",
             "grouped clear blisters",
             "rapid spreading swelling or warmth",
         ),
@@ -70,7 +83,11 @@ LABELS: tuple[SkinLabel, ...] = (
     SkinLabel(
         id="infantile_acne",
         label="infantile acne",
-        prompt="a clinical skin image showing infantile acne with comedones papules or pustules on a baby's face",
+        prompts=(
+            "a clinical skin image showing infantile acne with comedones papules or pustules on a baby's face",
+            "acne-like inflamed bumps and pustules on the cheeks forehead or chin of an infant",
+            "comedone-like spots with facial papules after the newborn period",
+        ),
         plain_english="Infantile acne can show acne-like bumps on the face after the newborn period.",
         what_supports=(
             "acne-like bumps",
@@ -87,7 +104,11 @@ LABELS: tuple[SkinLabel, ...] = (
     SkinLabel(
         id="milia",
         label="milia",
-        prompt="a clinical skin image showing milia with tiny white bumps on an infant face",
+        prompts=(
+            "a clinical skin image showing milia with tiny white bumps on an infant face",
+            "tiny firm white cyst-like bumps on a newborn nose cheeks or forehead",
+            "uniform pearly white noninflamed papules on an infant face",
+        ),
         plain_english="Milia are tiny white bumps that are common on infant faces and often look uniform and non-inflamed.",
         what_supports=(
             "tiny white bumps",
@@ -100,7 +121,11 @@ LABELS: tuple[SkinLabel, ...] = (
     SkinLabel(
         id="neonatal_cephalic_pustulosis",
         label="neonatal cephalic pustulosis",
-        prompt="a clinical skin image showing neonatal cephalic pustulosis with facial pustules on a newborn scalp or face",
+        prompts=(
+            "a clinical skin image showing neonatal cephalic pustulosis with facial pustules on a newborn scalp or face",
+            "newborn face scalp or neck with many small pustules and acne-like papules",
+            "localized newborn head and neck pustular eruption without honey crusting",
+        ),
         plain_english="This newborn facial or scalp pattern can resemble baby acne with small pustules concentrated on the head or face.",
         what_supports=(
             "newborn face or scalp involvement",
@@ -117,29 +142,32 @@ LABELS: tuple[SkinLabel, ...] = (
     SkinLabel(
         id="irritant_contact_dermatitis",
         label="irritant contact dermatitis",
-        prompt="a clinical skin image showing irritant contact dermatitis with localized redness and irritation",
+        prompts=(
+            "localized red irritated skin from rubbing saliva wipes detergent or skin products",
+            "patchy irritated redness without blisters or honey crusting",
+            "rough dry red localized rash in an area exposed to friction moisture or products",
+        ),
         plain_english="Irritation from saliva, rubbing, wipes, products, or fabrics can cause localized redness and roughness.",
         what_supports=(
             "localized redness",
-            "area exposed to rubbing or products",
-            "irritated rather than blistering pattern",
+            "area exposed to rubbing saliva wipes products or fabrics",
+            "irritated rough skin without blister clusters",
         ),
         what_argues_against=(
             "rapidly spreading warmth",
             "fever",
             "thick yellow crusting",
         ),
-        red_flags=(
-            "skin breakdown",
-            "drainage",
-            "rapid spread",
-            "swelling near the eye",
-        ),
+        red_flags=("skin breakdown", "drainage", "rapid spread", "swelling near the eye"),
     ),
     SkinLabel(
         id="atopic_dermatitis",
         label="atopic dermatitis / eczema",
-        prompt="a clinical skin image showing atopic dermatitis or eczema with dry red scaly itchy patches",
+        prompts=(
+            "a clinical skin image showing atopic dermatitis or eczema with dry red scaly itchy patches",
+            "rough scaling dryness and patchy redness on infant cheeks folds or body",
+            "chronic itchy-looking inflamed skin plaques with scale and dryness",
+        ),
         plain_english="Eczema often appears as dry, itchy, red, rough, or scaly patches that may come and go.",
         what_supports=(
             "dry or scaly patches",
@@ -156,219 +184,157 @@ LABELS: tuple[SkinLabel, ...] = (
     SkinLabel(
         id="seborrheic_dermatitis",
         label="seborrheic dermatitis / cradle cap",
-        prompt="a clinical skin image showing seborrheic dermatitis or cradle cap with greasy scale and redness on infant scalp face or folds",
+        prompts=(
+            "a clinical skin image showing seborrheic dermatitis or cradle cap with greasy scale and redness on infant scalp face or folds",
+            "greasy yellow-white scale on scalp eyebrows forehead ears or skin folds of a baby",
+            "flaky scaling cradle cap pattern with mild redness on infant head or face",
+        ),
         plain_english="Cradle cap and seborrheic dermatitis can cause greasy scale with redness on the scalp, eyebrows, face, or skin folds.",
         what_supports=(
             "greasy yellow-white scale",
             "scalp eyebrow or fold involvement",
             "mild redness under scale",
         ),
-        what_argues_against=(
-            "clear grouped blisters",
-            "rapid spread",
-            "marked swelling",
-        ),
+        what_argues_against=("clear grouped blisters", "rapid spread", "marked swelling"),
         red_flags=("oozing", "bad smell", "fever", "baby acting ill"),
     ),
     SkinLabel(
         id="miliaria",
         label="heat rash / miliaria",
-        prompt="a clinical skin image showing heat rash or miliaria with tiny red bumps in warm occluded skin areas",
+        prompts=(
+            "a clinical skin image showing heat rash or miliaria with tiny red bumps in warm occluded skin areas",
+            "many tiny red papules or vesicles on neck folds trunk or covered sweaty skin",
+            "fine prickly heat rash bumps in areas of heat sweating or occlusion",
+        ),
         plain_english="Heat rash can show many tiny bumps in warm, sweaty, or covered areas.",
-        what_supports=(
-            "many tiny bumps",
-            "warm or occluded area",
-            "recent heat or sweating context",
-        ),
-        what_argues_against=(
-            "yellow crusting",
-            "localized eye swelling",
-            "grouped blisters",
-        ),
+        what_supports=("many tiny bumps", "warm or occluded area", "recent heat or sweating context"),
+        what_argues_against=("yellow crusting", "localized eye swelling", "grouped blisters"),
         red_flags=("fever", "rapid spread", "painful swelling", "baby acting ill"),
     ),
     SkinLabel(
         id="impetigo",
         label="impetigo",
-        prompt="a clinical skin image showing impetigo with yellow crusting or drainage",
+        prompts=(
+            "honey-colored crusting or oozing superficial skin infection",
+            "yellow crusted sores around the mouth nose or irritated skin",
+            "drainage weeping erosions and golden crust on superficial skin lesions",
+        ),
         plain_english="Impetigo is a contagious superficial skin infection that often has honey-yellow crusting, oozing, or drainage.",
-        what_supports=(
-            "honey-colored crust",
-            "oozing or drainage",
-            "sores around nose mouth or irritated skin",
-        ),
-        what_argues_against=(
-            "only dry non-crusted bumps",
-            "uniform tiny white bumps",
-            "no drainage or crust",
-        ),
-        red_flags=(
-            "spreading redness",
-            "fever",
-            "swelling near the eye",
-            "baby acting ill",
-        ),
+        what_supports=("honey-colored crust", "oozing or drainage", "sores around nose mouth or irritated skin"),
+        what_argues_against=("only dry non-crusted bumps", "uniform tiny white bumps", "no drainage or crust"),
+        red_flags=("spreading redness", "fever", "swelling near the eye", "baby acting ill"),
+        high_consequence=True,
     ),
     SkinLabel(
         id="folliculitis",
         label="folliculitis",
-        prompt="a clinical skin image showing folliculitis with small pustules centered around hair follicles",
+        prompts=(
+            "a clinical skin image showing folliculitis with small pustules centered around hair follicles",
+            "multiple small inflamed follicle-centered bumps or pustules on hair-bearing skin",
+            "scattered pustules around hair follicles without diffuse flat rash",
+        ),
         plain_english="Folliculitis can look like small inflamed bumps or pustules centered on hair follicles.",
-        what_supports=(
-            "pustules around follicles",
-            "hair-bearing area",
-            "similar small inflamed bumps",
-        ),
-        what_argues_against=(
-            "flat diffuse rash",
-            "greasy scale",
-            "grouped clear blisters",
-        ),
+        what_supports=("pustules around follicles", "hair-bearing area", "similar small inflamed bumps"),
+        what_argues_against=("flat diffuse rash", "greasy scale", "grouped clear blisters"),
         red_flags=("painful boil", "spreading redness", "fever"),
     ),
     SkinLabel(
         id="viral_exanthem",
         label="viral exanthem",
-        prompt="a clinical skin image showing viral exanthem with widespread red macules or papules on the body",
+        prompts=(
+            "widespread red macules or papules on trunk and body with viral illness",
+            "flat or slightly raised diffuse red rash over the trunk and body",
+            "many similar red spots on widespread skin distribution with fever or viral symptoms",
+        ),
         plain_english="A viral rash is usually considered when there is a more widespread pattern or illness symptoms along with the rash.",
-        what_supports=(
-            "widespread trunk or body rash",
-            "many similar red spots",
-            "fever or viral symptoms if present",
-        ),
-        what_argues_against=(
-            "single localized face patch",
-            "only a few infant facial bumps",
-            "yellow crusting",
-        ),
-        red_flags=(
-            "fever in a young infant",
-            "breathing trouble",
-            "lethargy",
-            "non-blanching purple spots",
-        ),
+        what_supports=("widespread trunk or body rash", "many similar red spots", "fever or viral symptoms if present"),
+        what_argues_against=("single localized face patch", "only a few infant facial bumps", "yellow crusting"),
+        red_flags=("fever in a young infant", "breathing trouble", "lethargy", "non-blanching purple spots"),
+        high_consequence=True,
     ),
     SkinLabel(
         id="hand_foot_mouth",
         label="hand-foot-mouth pattern",
-        prompt="a clinical skin image showing hand foot and mouth disease pattern with vesicles on hands feet or around the mouth",
+        prompts=(
+            "vesicles or spots involving hands feet mouth or diaper area",
+            "a clinical skin image showing hand foot and mouth disease pattern with vesicles on hands feet or around the mouth",
+            "small blisters erosions or red spots on palms soles mouth area or diaper area",
+        ),
         plain_english="Hand-foot-mouth pattern is more likely when spots or blisters involve the hands, feet, mouth, or diaper area with illness symptoms.",
-        what_supports=(
-            "hands feet or mouth involvement",
-            "small blisters or erosions",
-            "compatible distribution",
-        ),
-        what_argues_against=(
-            "only localized cheek bumps",
-            "no hand foot or mouth distribution",
-            "greasy scale",
-        ),
-        red_flags=(
-            "dehydration",
-            "breathing trouble",
-            "lethargy",
-            "fever in a young infant",
-        ),
+        what_supports=("hands feet or mouth involvement", "small blisters or erosions", "compatible distribution"),
+        what_argues_against=("only localized cheek bumps", "no hand foot or mouth distribution", "greasy scale"),
+        red_flags=("dehydration", "breathing trouble", "lethargy", "fever in a young infant"),
+        high_consequence=True,
     ),
     SkinLabel(
         id="herpes_simplex_grouped_vesicles",
         label="herpes simplex / grouped vesicles",
-        prompt="a clinical skin image showing grouped vesicles consistent with herpes simplex",
+        prompts=(
+            "grouped clear fluid-filled vesicles on red skin",
+            "clustered blisters with erosions or crusting near the mouth or eye",
+            "localized painful-looking grouped vesicles or punched-out erosions on infant skin",
+        ),
         plain_english="Grouped clear blisters, especially near the eye or in a young infant, need prompt clinician review.",
-        what_supports=(
-            "clustered clear blisters",
-            "erosions after blisters",
-            "localized painful-looking grouped lesions",
-        ),
-        what_argues_against=(
-            "solid acne-like papules",
-            "tiny uniform white bumps",
-            "dry scale without blisters",
-        ),
-        red_flags=(
-            "grouped clear blisters",
-            "eye-area involvement",
-            "fever",
-            "poor feeding",
-            "lethargy",
-        ),
+        what_supports=("clustered clear blisters", "erosions after blisters", "localized painful-looking grouped lesions"),
+        what_argues_against=("solid acne-like papules", "tiny uniform white bumps", "dry scale without blisters"),
+        red_flags=("grouped clear blisters", "eye-area involvement", "fever", "poor feeding", "lethargy"),
+        high_consequence=True,
     ),
     SkinLabel(
         id="cellulitis_spreading_bacterial_infection",
         label="cellulitis / spreading bacterial skin infection",
-        prompt="a clinical skin image showing cellulitis with spreading redness and swelling",
+        prompts=(
+            "spreading redness swelling warmth and tenderness suggesting bacterial skin infection",
+            "a clinical skin image showing cellulitis with expanding red swollen skin",
+            "diffuse hot tender swollen red skin area rather than tiny stable bumps",
+        ),
         plain_english="Cellulitis is a deeper spreading infection pattern with expanding redness, warmth, swelling, pain, or fever.",
-        what_supports=(
-            "spreading redness",
-            "swelling",
-            "warmth or tenderness if present",
-        ),
-        what_argues_against=(
-            "stable tiny bumps",
-            "no swelling",
-            "dry scaly patch only",
-        ),
-        red_flags=(
-            "rapidly spreading redness",
-            "fever",
-            "swelling near the eye",
-            "baby acting ill",
-        ),
+        what_supports=("spreading redness", "swelling", "warmth or tenderness if present"),
+        what_argues_against=("stable tiny bumps", "no swelling", "dry scaly patch only"),
+        red_flags=("rapidly spreading redness", "fever", "swelling near the eye", "baby acting ill"),
+        high_consequence=True,
     ),
     SkinLabel(
         id="urticaria_allergic_reaction",
         label="allergic reaction / urticaria",
-        prompt="a clinical skin image showing allergic reaction or urticaria with raised wheals or hives",
+        prompts=(
+            "a clinical skin image showing allergic reaction or urticaria with raised wheals or hives",
+            "raised swollen welts hives or wheals with itching on the skin",
+            "transient-looking puffy red plaques with face or lip swelling concern",
+        ),
         plain_english="Hives are raised welts that often move around and can occur with allergic reactions or viral illnesses.",
-        what_supports=(
-            "raised welts",
-            "changing or migrating spots",
-            "itchy-looking swelling",
-        ),
+        what_supports=("raised welts", "changing or migrating spots", "itchy-looking swelling"),
         what_argues_against=("fixed pustules", "yellow crusting", "tiny white bumps"),
-        red_flags=(
-            "breathing trouble",
-            "face or lip swelling",
-            "vomiting with hives",
-            "baby acting ill",
-        ),
+        red_flags=("breathing trouble", "face or lip swelling", "vomiting with hives", "baby acting ill"),
+        high_consequence=True,
     ),
     SkinLabel(
         id="insect_bites",
         label="insect bites",
-        prompt="a clinical skin image showing insect bites with discrete itchy red papules possibly with central puncta",
+        prompts=(
+            "a clinical skin image showing insect bites with discrete itchy red papules possibly with central puncta",
+            "separate red bumps on exposed skin with a central dot or punctum",
+            "clustered but discrete itchy papules on arms legs face or other exposed areas",
+        ),
         plain_english="Bites often appear as separate itchy red bumps and may have a central dot or occur in exposed areas.",
-        what_supports=(
-            "discrete separated bumps",
-            "central punctum if visible",
-            "exposed skin distribution",
-        ),
-        what_argues_against=(
-            "widespread viral pattern",
-            "greasy scale",
-            "uniform tiny white facial bumps",
-        ),
+        what_supports=("discrete separated bumps", "central punctum if visible", "exposed skin distribution"),
+        what_argues_against=("widespread viral pattern", "greasy scale", "uniform tiny white facial bumps"),
         red_flags=("rapid swelling", "spreading redness", "drainage", "fever"),
     ),
     SkinLabel(
         id="nonspecific_unclear_rash",
         label="nonspecific rash / unclear",
-        prompt="a clinical skin image showing a nonspecific unclear rash without a definitive visual pattern",
+        prompts=(
+            "a clinical skin image showing a nonspecific unclear rash without a definitive visual pattern",
+            "subtle mixed skin findings that do not clearly match one dermatology pattern",
+            "low detail or ambiguous rash image without clear papules pustules vesicles scale crusting or distribution",
+        ),
         plain_english="Some images do not have enough distinctive visual information for a confident visual category.",
-        what_supports=(
-            "mixed or subtle findings",
-            "limited image context",
-            "no single distinctive pattern",
-        ),
-        what_argues_against=(
-            "classic honey crust",
-            "classic grouped blisters",
-            "classic tiny white milia",
-        ),
+        what_supports=("mixed or subtle findings", "limited image context", "no single distinctive pattern"),
+        what_argues_against=("classic honey crust", "classic grouped blisters", "classic tiny white milia"),
         red_flags=tuple(GENERAL_RED_FLAGS),
     ),
 )
-
 
 class ImageDecodeError(Exception):
     """Raised when PIL cannot safely decode the uploaded image."""
@@ -509,6 +475,7 @@ def match_from_score(index: int, score: float) -> dict[str, Any]:
         "whatSupports": list(label.what_supports),
         "whatArguesAgainst": list(label.what_argues_against),
         "redFlags": list(dict.fromkeys([*label.red_flags, *GENERAL_RED_FLAGS])),
+        "highConsequence": label.high_consequence,
     }
 
 
@@ -550,7 +517,12 @@ def classify_images(
     model.eval()
 
     emit_stage("running_classification")
-    prompts = [label.prompt for label in LABELS]
+    prompts = [prompt for label in LABELS for prompt in label.prompts]
+    prompt_label_indices = [
+        label_index
+        for label_index, label in enumerate(LABELS)
+        for _prompt in label.prompts
+    ]
     all_scores: list[list[float]] = []
 
     with torch.no_grad():
@@ -562,9 +534,24 @@ def classify_images(
             image_tensor = preprocess(image).unsqueeze(0).to(device)
             image_features = model.encode_image(image_tensor)
             image_features = image_features / image_features.norm(dim=-1, keepdim=True)
-            similarities = (100.0 * image_features @ text_features.T).softmax(dim=-1)[0]
+            prompt_logits = (100.0 * image_features @ text_features.T)[0]
+
+            # Collapse clinically distinct prompt variants into one score per label
+            # by max-pooling the raw similarities, then softmax across labels for
+            # display ranking. These normalized values are relative visual
+            # similarities, not diagnosis probabilities.
+            label_logits = []
+            for label_index in range(len(LABELS)):
+                variant_indices = [
+                    prompt_index
+                    for prompt_index, prompt_label_index in enumerate(prompt_label_indices)
+                    if prompt_label_index == label_index
+                ]
+                label_logits.append(prompt_logits[variant_indices].max())
+
+            label_scores = torch.stack(label_logits).softmax(dim=-1)
             all_scores.append(
-                [float(score) for score in similarities.detach().cpu().tolist()]
+                [float(score) for score in label_scores.detach().cpu().tolist()]
             )
 
     average_scores = [
@@ -599,56 +586,153 @@ def smoke_per_image_matches(image_count: int, max_matches: int) -> list[dict[str
     ]
 
 
-def has_mixed_per_image_evidence(per_image_matches: list[dict[str, Any]]) -> bool:
+def per_image_agreement(
+    top_id: str, per_image_matches: list[dict[str, Any]]
+) -> tuple[int, int]:
+    top1_count = 0
+    top3_count = 0
+    for image_result in per_image_matches:
+        image_matches = image_result.get("topMatches", [])
+        ids = [match.get("id") for match in image_matches]
+        if ids[:1] == [top_id]:
+            top1_count += 1
+        if top_id in ids[:PER_IMAGE_MATCHES]:
+            top3_count += 1
+    return top1_count, top3_count
+
+
+def calibration_summary(
+    matches: list[dict[str, Any]], per_image_matches: list[dict[str, Any]]
+) -> dict[str, Any]:
+    top = matches[0]
+    second_score = float(matches[1]["score"]) if len(matches) > 1 else 0.0
+    top_margin = round(max(0.0, float(top["score"]) - second_score), 4)
+    image_count = max(1, len(per_image_matches))
+    top1_count, top3_count = per_image_agreement(top["id"], per_image_matches)
+    most_images_threshold = image_count if image_count <= 2 else image_count - 1
+    half_images_threshold = (image_count + 1) // 2
     top_labels = {
         image_result["topMatches"][0]["id"]
         for image_result in per_image_matches
         if image_result.get("topMatches")
     }
-    return len(top_labels) > 1
+
+    # Simple calibration constants for relative visual-similarity output:
+    # strong requires the combined #1 to appear in the top 3 for most/all images
+    # and clear separation from #2; moderate requires at least half agreement and
+    # non-tiny separation. High-consequence labels are downgraded unless strongly
+    # supported because weak CLIP-style similarity should not read like a diagnosis.
+    strong_agreement = top3_count >= most_images_threshold and top_margin >= STRONG_MARGIN
+    moderate_agreement = top3_count >= half_images_threshold and top_margin >= MODERATE_MARGIN
+    weak_reasons = [
+        top_margin < MODERATE_MARGIN,
+        top3_count < half_images_threshold,
+        image_count > 1 and top1_count <= 1,
+        len(top_labels) > 1 and top3_count < most_images_threshold,
+        bool(top.get("highConsequence")) and not strong_agreement,
+    ]
+
+    if strong_agreement:
+        confidence_label = "strong visual match"
+    elif moderate_agreement and not (
+        bool(top.get("highConsequence")) and top3_count < most_images_threshold
+    ):
+        confidence_label = "moderate visual match"
+    else:
+        confidence_label = "weak/mixed visual match"
+
+    mixed_evidence = confidence_label == "weak/mixed visual match" or any(weak_reasons)
+    image_word = "image" if image_count == 1 else "images"
+    agreement_summary = (
+        f"Combined #1 appeared as the per-image #1 in {top1_count}/{image_count} "
+        f"{image_word} and within the per-image top 3 in {top3_count}/{image_count}; "
+        f"margin over #2 was {top_margin:.4f}."
+    )
+
+    return {
+        "confidenceLabel": confidence_label,
+        "mixedEvidence": mixed_evidence,
+        "topMargin": top_margin,
+        "agreementSummary": agreement_summary,
+    }
+
+
+def high_consequence_concerns(matches: list[dict[str, Any]]) -> list[str]:
+    concerns = []
+    for match in matches:
+        if match.get("highConsequence"):
+            supports = ", ".join(match["whatSupports"][:2])
+            concerns.append(
+                f"This would be more concerning for {match['label']} if there are {supports}."
+            )
+    return concerns
 
 
 def build_review_text(
     matches: list[dict[str, Any]],
     image_count: int,
     per_image_matches: list[dict[str, Any]],
+    calibration: dict[str, Any],
 ) -> str:
     top = matches[0]
     alternatives = matches[1:4]
+    confidence_label = calibration["confidenceLabel"]
+    mixed_evidence = bool(calibration["mixedEvidence"])
     support_text = "; ".join(top["whatSupports"][:3])
-    argues_text = []
-    for match in alternatives:
-        argues_text.append(
-            f"{match['label']} would be more likely with {', '.join(match['whatSupports'][:2])}."
-        )
-    red_flags = list(dict.fromkeys([*top.get("redFlags", []), *GENERAL_RED_FLAGS]))
-    mixed_evidence = has_mixed_per_image_evidence(per_image_matches)
-    image_word = "image" if image_count == 1 else "images"
-    mixed_text = (
-        " The per-image top labels differ, so the visual evidence is mixed/inconsistent across the submitted views."
-        if mixed_evidence
-        else ""
+    high_consequence_weak = (
+        bool(top.get("highConsequence"))
+        and confidence_label != "strong visual match"
     )
+    image_word = "image" if image_count == 1 else "images"
+
+    if mixed_evidence:
+        impression = (
+            f"The visual evidence is mixed. Based on {image_count} {image_word}, "
+            f"{top['label']} is the highest relative visual-similarity ranking, "
+            "but this is a weak visual match rather than a diagnosis-like conclusion."
+        )
+    elif high_consequence_weak:
+        impression = (
+            f"Based on {image_count} {image_word}, {top['label']} ranked highest, "
+            "but because this category can be higher consequence and is not strongly supported, "
+            "treat it as a concern to check for rather than the main likely impression."
+        )
+    else:
+        impression = (
+            f"Based on {image_count} {image_word}, the combined top visual match is "
+            f"{top['label']}. This is a {confidence_label}, not a confirmed diagnosis."
+        )
+
+    alternative_text = " ".join(
+        f"{match['label']} would be more likely with {', '.join(match['whatSupports'][:2])}."
+        for match in alternatives
+    ) or "No additional ranked alternatives were returned."
+
+    concern_texts = high_consequence_concerns(
+        matches[:4] if mixed_evidence else alternatives
+    )
+    red_flags = list(dict.fromkeys([*top.get("redFlags", []), *GENERAL_RED_FLAGS]))
+    if concern_texts:
+        concerns = (
+            " ".join(concern_texts)
+            + " Seek prompt clinical advice for "
+            + ", ".join(red_flags)
+            + "."
+        )
+    else:
+        concerns = "Seek prompt clinical advice for " + ", ".join(red_flags) + "."
 
     return "\n\n".join(
         [
-            "Most likely matches:\n"
-            + "\n".join(
-                f"- {match['label']} ({match['percent']:.1f}%)" for match in matches
-            ),
-            "Plain-English read:\n"
-            + f"Based on {image_count} {image_word}, the combined top visual match is {top['label']}. Scores are averaged visual similarity rankings across the submitted image(s), not diagnosis confidence.{mixed_text}",
+            "Most likely visual match / combined impression:\n"
+            + impression
+            + " Scores are relative visual-similarity rankings against curated local labels, not diagnosis confidence.",
+            "Confidence / agreement:\n"
+            + f"{confidence_label}. {calibration['agreementSummary']}",
             "Why it may fit:\n"
             + f"{top['plainEnglish']} Visual features that can support this category include {support_text}.",
-            "Other possibilities:\n"
-            + (
-                " ".join(argues_text)
-                if argues_text
-                else "No additional ranked alternatives were returned."
-            ),
-            "Concerns / red flags:\nSeek prompt clinical advice for "
-            + ", ".join(red_flags)
-            + ".",
+            "Other possibilities:\n" + alternative_text,
+            "Concerns / red flags:\n" + concerns,
             "What to do:\nUse gentle skin care, avoid new irritants or fragranced products, do not squeeze or pick bumps, and monitor whether the area spreads, drains, swells, or the child seems unwell. Contact a pediatrician or clinician when symptoms are severe, worsening, persistent, near the eye, or concerning.",
             "Disclaimer:\n" + DISCLAIMER,
         ]
@@ -661,13 +745,20 @@ def success_payload(
     image_count: int,
     per_image_matches: list[dict[str, Any]],
 ) -> dict[str, Any]:
+    calibration = calibration_summary(matches, per_image_matches)
     return {
         "ok": True,
         "model": selected_model_id,
         "imageCount": image_count,
         "topMatches": matches,
         "perImageMatches": per_image_matches,
-        "reviewText": build_review_text(matches, image_count, per_image_matches),
+        "confidenceLabel": calibration["confidenceLabel"],
+        "mixedEvidence": calibration["mixedEvidence"],
+        "topMargin": calibration["topMargin"],
+        "agreementSummary": calibration["agreementSummary"],
+        "reviewText": build_review_text(
+            matches, image_count, per_image_matches, calibration
+        ),
     }
 
 


### PR DESCRIPTION
### Motivation
- Reduce misleading interpretation of CLIP-style similarity scores by making the runner and UI explicitly present visual-match confidence and agreement instead of implying diagnostic certainty. 
- Improve label coverage and robustness by adding multiple clinically distinct prompt variants (morphology and distribution) per condition so visual variants are better captured. 
- Treat higher-risk conditions conservatively by downgrading diagnostic language when visual evidence is weak or images disagree.

### Description
- Extend `SkinLabel` in `ui/partner-hub/scripts/skin_review_runner.py` to include `prompts: tuple[str, ...]`, `high_consequence: bool`, and richer `what_supports`/`what_argues_against` entries and add multiple prompt variants for each condition. 
- Change scoring to encode all prompt variants, collapse variant scores into one label score via max-pooling, softmax across labels, then average label scores across multiple images to produce combined matches while preserving per-image top matches. 
- Add calibration and output fields: `confidenceLabel`, `mixedEvidence`, `topMargin`, and `agreementSummary`, plus conservative red-flag wording and adjusted `build_review_text` that frames results as visual matches not diagnoses. 
- Surface new fields in the API types (`app/api/skin-review/analyze/route.ts`) and show `confidenceLabel` / `agreementSummary` / weak-evidence warning in the UI (`components/skin-review/SkinReviewTool.tsx`), and update docs (`docs/skin-review-local.md`) and `.gitignore` for local test images and temp uploads. 

### Testing
- Ran `python -m py_compile ui/partner-hub/scripts/skin_review_runner.py` to validate Python syntax and it succeeded. 
- Executed smoke validation with `python ui/partner-hub/scripts/skin_review_runner.py --image /tmp/skin-test.png --smoke-validation-only` and validated the JSON output (presence of `topMatches`, `perImageMatches`, `confidenceLabel`, `mixedEvidence`, `topMargin`, and `agreementSummary`), which succeeded. 
- Performed `git diff --check` style checks and local static updates (no errors). 
- UI linting (`cd ui/partner-hub && npm run lint`) could not be completed in this environment because `next` is unavailable and `npm install` failed due to registry `403 Forbidden`, so dependency installation and full `next` linting are blocked in CI here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffdca905ac833097d8d6327313eb0e)