### PR TITLE
Add Skin Image Review to Partner Hub navigation

### DIFF
--- a/ui/partner-hub/components/left-nav.tsx
+++ b/ui/partner-hub/components/left-nav.tsx
@@ -14,6 +14,7 @@ export function LeftNav() {
   const toolLinks = [
     { name: "Energy Tool", href: "/tools/energy" },
     { name: "AI Workload Mapper", href: "/tools/workload-mapper" },
+    { name: "Skin Image Review", href: "/skin-review" },
     ...(aiInterviewEnabled ? [{ name: "AI Interview", href: "/tools/interview" }] : []),
   ];
   const links = [


### PR DESCRIPTION
### Motivation
- Expose the new Skin Image Review app in the left sidebar so it appears alongside other tools and is directly navigable from the Partner Hub home page.

### Description
- Inserted `{ name: "Skin Image Review", href: "/skin-review" }` into `toolLinks` in `ui/partner-hub/components/left-nav.tsx` immediately after `AI Workload Mapper`, preserving the existing link pattern and the sidebar's collapse and active-link behavior.

### Testing
- Ran `git diff --check` with no issues; `npm run lint` could not be executed because the `next` binary/dependencies were not available in this environment and `npm ci` failed due to an npm registry `403 Forbidden`, so linting could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffe9eca288833092554ac48fea2949)