### PR TITLE
AI Factory Economics Phase 3: local prompt runner + Ollama streaming proxy

### DIFF
--- a/docs/AI_FACTORY_ECONOMICS_MODULE.md
+++ b/docs/AI_FACTORY_ECONOMICS_MODULE.md
@@ -70,6 +70,60 @@ http://localhost:3000/partner-hub/ai-factory-economics
 
 Use the refresh buttons on the Ollama status and model discovery cards after starting Ollama or pulling a model.
 
+
+## Phase 3 status
+Phase 3 is implemented as a local-only Ollama prompt runner and streaming proxy in Partner Hub. The Phase 1 demo/mock economics dashboard remains visible, while users can now select or manually enter a local Ollama model, enter a prompt, submit it to the local Ollama `/api/generate` endpoint through the Partner Hub proxy, and see streamed response content in the UI.
+
+Phase 3 intentionally does **not** add official TTFT calculation, official tokens/sec calculation, real cost-per-run calculation, GPU telemetry, `nvidia-smi` calls, run history, persistent storage, database migrations, dependencies, cloud services, secrets, prompt persistence, or response persistence. Prompt and response content remain in request/browser memory for the active run only.
+
+Phase 3 files added:
+
+```text
+ui/partner-hub/app/api/ai-factory-economics/run/route.ts
+ui/partner-hub/components/ai-factory-economics/prompt-runner.tsx
+```
+
+Phase 3 files updated:
+
+```text
+ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
+ui/partner-hub/components/ai-factory-economics/model-discovery-panel.tsx
+ui/partner-hub/components/ai-factory-economics/ollama-status-card.tsx
+ui/partner-hub/lib/ai-factory-economics/mock-data.ts
+ui/partner-hub/lib/ai-factory-economics/ollama.ts
+ui/partner-hub/lib/ai-factory-economics/ollama.test.ts
+ui/partner-hub/lib/ai-factory-economics/types.ts
+docs/AI_FACTORY_ECONOMICS_MODULE.md
+ui/partner-hub/docs/ai-factory-economics.md
+```
+
+Phase 3 runtime behavior:
+
+- `AI_FACTORY_OLLAMA_URL` configures the local Ollama base URL and still defaults to `http://127.0.0.1:11434`.
+- `/api/ai-factory-economics/run` accepts `POST` JSON with `model` and `prompt`, validates both fields, rejects empty prompts, rejects missing model names, enforces a prompt length limit, and calls local Ollama only.
+- The run route requests Ollama streaming with `stream: true` and relays response chunks as server-sent events to the browser.
+- Validation and pre-stream Ollama failures return graceful JSON errors without stack traces. Streaming-time failures emit safe stream error events.
+- The prompt runner supports discovered models from Phase 2, manual model entry when discovery is unavailable, idle/running/completed/failed/canceled state, reset/clear, and cancel through `AbortController`.
+- Streamed response content is labeled **Measured** for local runtime availability, not as measured economics.
+- Existing TTFT, tokens/sec, cost/run, and GPU dashboard cards remain **Demo/mock** and are not updated from live prompt runs in Phase 3.
+
+Local Phase 3 test flow:
+
+```bash
+cd ui/partner-hub
+ollama serve
+ollama pull llama3.2:3b
+npm run dev
+```
+
+Then open:
+
+```text
+http://localhost:3000/partner-hub/ai-factory-economics
+```
+
+Select a discovered model or enter one manually, enter a prompt, click **Run local prompt**, and verify the response streams into the prompt runner.
+
 ## Purpose
 The AI Factory Economics module should demonstrate the economics and operational signals of local AI inference using a laptop or workstation as the demo environment. It will combine local Ollama inference timing with local NVIDIA GPU telemetry to help users explain:
 
@@ -336,10 +390,13 @@ Status: **implemented**.
 - Does not execute prompts, stream responses, calculate TTFT, calculate real tokens/sec, call `nvidia-smi`, collect GPU telemetry, persist data, add dependencies, or call cloud services.
 
 ### Phase 3: Prompt runner and streaming proxy
-- Add prompt runner UI.
-- Add server-side run proxy to Ollama.
-- Stream response chunks where practical.
-- Add cancel/stop only if it remains simple and reliable.
+Status: **implemented**.
+
+- Added a prompt runner UI that uses discovered local models when available and supports manual model entry when discovery is unavailable.
+- Added a server-side run proxy to local Ollama at `/api/ai-factory-economics/run`.
+- Streams Ollama response chunks to the browser as server-sent events.
+- Supports cancel/stop through `AbortController` without adding persistence or run history.
+- Keeps official TTFT, tokens/sec, real cost/run, and GPU telemetry out of scope until later phases.
 
 ### Phase 4: TTFT, latency, token estimate, tokens/sec calculations
 - Add server-side run timing.
@@ -396,6 +453,6 @@ Status: **implemented**.
 ## Open questions
 - Future phases can decide whether to add `NEXT_PUBLIC_ENABLE_AI_FACTORY_ECONOMICS`; Phase 1 is visible by default because it is static/mock only.
 - Phase 1 includes home-page and left-nav entries because active Partner Hub tool routes are already discoverable through those surfaces.
-- The current mock selected model is `llama3.1:8b-instruct`; Phase 2 should replace or validate demo model choices through Ollama discovery when connected.
+- The current mock selected model is `llama3.1:8b-instruct`; discovered and manually entered Phase 3 runtime models are displayed separately from the demo/mock dashboard model.
 - The current static energy-rate display assumption is `$0.16/kWh`; future phases should decide whether this becomes user-configurable.
 - Prompt history remains absent in Phase 1; future phases should keep any run-history work in memory first and continue excluding prompt content from stored summaries by default.

--- a/ui/partner-hub/app/api/ai-factory-economics/run/route.ts
+++ b/ui/partner-hub/app/api/ai-factory-economics/run/route.ts
@@ -1,0 +1,181 @@
+import { NextResponse } from "next/server";
+
+import {
+  AI_FACTORY_OLLAMA_RUN_TIMEOUT_MS,
+  getAiFactoryOllamaBaseUrl,
+  normalizeOllamaGenerateChunk,
+  openOllamaRunStream,
+  toSafeOllamaError,
+  validateAiFactoryRunRequest,
+} from "@/lib/ai-factory-economics/ollama";
+import type { AiFactorySafeError } from "@/lib/ai-factory-economics/types";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function jsonError(error: AiFactorySafeError, status: number) {
+  return NextResponse.json(
+    { ok: false, error },
+    {
+      status,
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}
+
+function encodeSse(event: string, data: unknown) {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(
+      {
+        code: "INVALID_JSON",
+        message: "Request body must be valid JSON with model and prompt fields.",
+      },
+      400,
+    );
+  }
+
+  const validation = validateAiFactoryRunRequest(body);
+  if (!validation.ok) {
+    return jsonError(validation.error, validation.status);
+  }
+
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => abortController.abort(), AI_FACTORY_OLLAMA_RUN_TIMEOUT_MS);
+  const relayClientAbort = () => abortController.abort();
+  request.signal.addEventListener("abort", relayClientAbort, { once: true });
+
+  let upstream: Response;
+  try {
+    upstream = await openOllamaRunStream(validation.request, fetch, abortController.signal);
+  } catch (error) {
+    clearTimeout(timeout);
+    request.signal.removeEventListener("abort", relayClientAbort);
+    const safeError = toSafeOllamaError(error, "Could not start the local Ollama prompt run.");
+    return jsonError(safeError, safeError.code === "OLLAMA_TIMEOUT" ? 504 : 502);
+  }
+
+  const upstreamBody = upstream.body;
+  if (!upstreamBody) {
+    clearTimeout(timeout);
+    request.signal.removeEventListener("abort", relayClientAbort);
+    return jsonError(
+      {
+        code: "OLLAMA_BAD_RESPONSE",
+        message: "Local Ollama did not return a readable streaming response.",
+      },
+      502,
+    );
+  }
+
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const reader = upstreamBody.getReader();
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send = (event: string, data: unknown) => {
+        controller.enqueue(encoder.encode(encodeSse(event, data)));
+      };
+
+      send("meta", {
+        ok: true,
+        phase: "Phase 3",
+        model: validation.request.model,
+        baseUrl: getAiFactoryOllamaBaseUrl(),
+        classification: "Measured",
+        economicsClassification: "Demo/mock",
+        message: "Streaming response content is measured from local Ollama; official TTFT, tokens/sec, and cost are not calculated in Phase 3.",
+      });
+
+      let buffer = "";
+
+      try {
+        while (true) {
+          const { value, done } = await reader.read();
+          buffer += decoder.decode(value, { stream: !done });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() || "";
+
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed) {
+              continue;
+            }
+
+            const chunk = normalizeOllamaGenerateChunk(trimmed);
+            if (!chunk) {
+              send("error", {
+                code: "OLLAMA_BAD_RESPONSE",
+                message: "Local Ollama returned an unexpected streaming chunk.",
+              });
+              continue;
+            }
+
+            if (chunk.response) {
+              send("chunk", {
+                response: chunk.response,
+                done: false,
+                classification: "Measured",
+              });
+            }
+
+            if (chunk.done) {
+              send("done", {
+                ok: true,
+                status: "completed",
+                classification: "Measured",
+                message: "Prompt run completed. Official TTFT, tokens/sec, cost, and GPU telemetry remain unavailable in Phase 3.",
+              });
+            }
+          }
+
+          if (done) {
+            if (buffer.trim()) {
+              const chunk = normalizeOllamaGenerateChunk(buffer.trim());
+              if (chunk?.response) {
+                send("chunk", {
+                  response: chunk.response,
+                  done: chunk.done,
+                  classification: "Measured",
+                });
+              }
+            }
+            break;
+          }
+        }
+      } catch (error) {
+        const safeError = toSafeOllamaError(error, "The local Ollama prompt run failed while streaming.");
+        send("error", safeError);
+      } finally {
+        clearTimeout(timeout);
+        request.signal.removeEventListener("abort", relayClientAbort);
+        controller.close();
+      }
+    },
+    async cancel() {
+      clearTimeout(timeout);
+      request.signal.removeEventListener("abort", relayClientAbort);
+      abortController.abort();
+      await reader.cancel().catch(() => undefined);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
+++ b/ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
@@ -7,6 +7,7 @@ import { MetricCard } from "./metric-card";
 import { ModelDiscoveryPanel } from "./model-discovery-panel";
 import { OllamaStatusCard } from "./ollama-status-card";
 import { PhaseStatusPanel } from "./phase-status-panel";
+import { PromptRunner } from "./prompt-runner";
 import { ReadinessPanel } from "./readiness-panel";
 
 export function AiFactoryEconomicsTool() {
@@ -19,7 +20,7 @@ export function AiFactoryEconomicsTool() {
         <div className="relative grid gap-8 lg:grid-cols-[1.25fr_0.75fr] lg:items-end">
           <div className="space-y-5">
             <div className="inline-flex rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-white/80">
-              Local-only Phase 2
+              Local-only Phase 3
             </div>
             <div className="space-y-3">
               <h1 className="text-3xl font-semibold tracking-tight md:text-5xl">AI Factory Economics</h1>
@@ -34,12 +35,12 @@ export function AiFactoryEconomicsTool() {
               <div className="rounded-2xl border border-white/15 bg-white/10 p-4 backdrop-blur">
                 <Gauge className="mb-3 h-5 w-5 text-blue-200" aria-hidden />
                 <p className="font-semibold">Demo metrics remain</p>
-                <p className="mt-1 text-white/65">Dashboard economics remain demo/mock while health/models are measured locally.</p>
+                <p className="mt-1 text-white/65">Dashboard economics remain demo/mock while prompt streaming is measured locally.</p>
               </div>
               <div className="rounded-2xl border border-white/15 bg-white/10 p-4 backdrop-blur">
                 <Cpu className="mb-3 h-5 w-5 text-amber-200" aria-hidden />
-                <p className="font-semibold">Prompt runs later</p>
-                <p className="mt-1 text-white/65">No prompt execution, streaming, TTFT, or GPU telemetry is added in Phase 2.</p>
+                <p className="font-semibold">Prompt runs locally</p>
+                <p className="mt-1 text-white/65">Prompt streaming is live/local; TTFT, tokens/sec, cost, and GPU telemetry are not calculated yet.</p>
               </div>
             </div>
           </div>
@@ -52,7 +53,7 @@ export function AiFactoryEconomicsTool() {
             </CardHeader>
             <CardContent className="space-y-3 text-sm leading-relaxed text-white/75">
               <p>This is a local demo module. No cloud services, accounts, secrets, or external APIs are required.</p>
-              <p>Phase 2 adds local Ollama health and model discovery only. Demo/mock dashboard values remain visible, and NVIDIA telemetry is still not connected.</p>
+              <p>Phase 3 adds a local Ollama prompt runner and streaming proxy. Demo/mock dashboard economics remain visible, and NVIDIA telemetry is still not connected.</p>
             </CardContent>
           </Card>
         </div>
@@ -70,6 +71,8 @@ export function AiFactoryEconomicsTool() {
         <OllamaStatusCard />
         <ModelDiscoveryPanel />
       </section>
+
+      <PromptRunner />
 
       <section className="grid gap-4 lg:grid-cols-2">
         <ReadinessPanel items={dashboard.readiness} />

--- a/ui/partner-hub/components/ai-factory-economics/ollama-status-card.tsx
+++ b/ui/partner-hub/components/ai-factory-economics/ollama-status-card.tsx
@@ -79,13 +79,13 @@ export function OllamaStatusCard() {
           </div>
           <div className="rounded-xl border border-border/60 bg-background p-3">
             <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">NVIDIA telemetry</p>
-            <p className="mt-1 font-semibold text-foreground">Not connected in Phase 2</p>
+            <p className="mt-1 font-semibold text-foreground">Not connected in Phase 3</p>
           </div>
         </div>
 
         <p>
-          Phase 2 checks only health and local model discovery. It does not execute prompts, stream responses, calculate TTFT,
-          calculate tokens/sec from real runs, or collect GPU telemetry.
+          Phase 3 checks health, discovers local models, and can stream prompt responses. It does not calculate official TTFT,
+          calculate tokens/sec from real runs, estimate cost per run, or collect GPU telemetry.
         </p>
 
         <button

--- a/ui/partner-hub/components/ai-factory-economics/prompt-runner.tsx
+++ b/ui/partner-hub/components/ai-factory-economics/prompt-runner.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import { Play, RefreshCw, RotateCcw, Square, Terminal } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { withBasePath } from "@/lib/basePath";
+import type {
+  AiFactoryModelDiscoveryResult,
+  AiFactoryRunStatus,
+  AiFactorySafeError,
+} from "@/lib/ai-factory-economics/types";
+import { MetricLabel } from "./metric-label";
+
+const promptMaxLength = 4_000;
+
+type SseEvent = {
+  event: string;
+  data: Record<string, unknown>;
+};
+
+function parseSseEvents(input: string): SseEvent[] {
+  return input
+    .split("\n\n")
+    .map((block) => block.trim())
+    .filter(Boolean)
+    .map((block) => {
+      const eventLine = block.split("\n").find((line) => line.startsWith("event:"));
+      const dataLine = block.split("\n").find((line) => line.startsWith("data:"));
+      const event = eventLine?.replace(/^event:\s*/, "") || "message";
+      const rawData = dataLine?.replace(/^data:\s*/, "") || "{}";
+
+      try {
+        return { event, data: JSON.parse(rawData) as Record<string, unknown> };
+      } catch {
+        return { event: "error", data: { message: "The local stream returned an unreadable event." } };
+      }
+    });
+}
+
+function formatRunError(error: unknown) {
+  const safeError = error as Partial<AiFactorySafeError> | null;
+  if (safeError?.message) {
+    return safeError.detail ? `${safeError.message} ${safeError.detail}` : safeError.message;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "The local prompt run failed.";
+}
+
+export function PromptRunner() {
+  const [models, setModels] = useState<string[]>([]);
+  const [modelDiscoveryError, setModelDiscoveryError] = useState("");
+  const [model, setModel] = useState("");
+  const [manualModel, setManualModel] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [output, setOutput] = useState("");
+  const [status, setStatus] = useState<AiFactoryRunStatus>("idle");
+  const [error, setError] = useState("");
+  const abortRef = useRef<AbortController | null>(null);
+
+  const selectedModel = model === "__manual__" ? manualModel.trim() : model.trim();
+  const canRun = status !== "running" && selectedModel.length > 0 && prompt.trim().length > 0;
+
+  const loadModels = useCallback(async () => {
+    setModelDiscoveryError("");
+
+    try {
+      const response = await fetch(withBasePath("/api/ai-factory-economics/models"), { cache: "no-store" });
+      const data = (await response.json()) as AiFactoryModelDiscoveryResult;
+      if (data.ok && data.models.length > 0) {
+        setModels(data.models);
+        setModel((current) => current || data.models[0]);
+        return;
+      }
+
+      setModels([]);
+      setModel((current) => current || "__manual__");
+      setModelDiscoveryError(data.ok ? "No local models were discovered. Enter a model manually after pulling it with Ollama." : data.error.message);
+    } catch {
+      setModels([]);
+      setModel((current) => current || "__manual__");
+      setModelDiscoveryError("Could not load local model discovery. Enter a local Ollama model manually.");
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadModels();
+  }, [loadModels]);
+
+  const reset = () => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setStatus("idle");
+    setError("");
+    setOutput("");
+    setPrompt("");
+  };
+
+  const cancel = () => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setStatus("canceled");
+    setError("Prompt run canceled locally. Ollama may need a moment to stop the in-flight generation.");
+  };
+
+  const runPrompt = async () => {
+    if (!selectedModel) {
+      setStatus("failed");
+      setError("Choose or enter a local Ollama model before running a prompt.");
+      return;
+    }
+
+    const trimmedPrompt = prompt.trim();
+    if (!trimmedPrompt) {
+      setStatus("failed");
+      setError("Enter a prompt before running the local model.");
+      return;
+    }
+
+    if (trimmedPrompt.length > promptMaxLength) {
+      setStatus("failed");
+      setError(`Prompts must be ${promptMaxLength.toLocaleString()} characters or fewer for Phase 3.`);
+      return;
+    }
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setStatus("running");
+    setError("");
+    setOutput("");
+
+    try {
+      const response = await fetch(withBasePath("/api/ai-factory-economics/run"), {
+        method: "POST",
+        headers: {
+          Accept: "text/event-stream",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ model: selectedModel, prompt: trimmedPrompt }),
+        cache: "no-store",
+        signal: controller.signal,
+      });
+
+      if (!response.ok || !response.body) {
+        const data = (await response.json().catch(() => null)) as { error?: AiFactorySafeError } | null;
+        throw new Error(formatRunError(data?.error));
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let completed = false;
+
+      while (true) {
+        const { value, done } = await reader.read();
+        buffer += decoder.decode(value, { stream: !done });
+        const eventBlocks = buffer.split("\n\n");
+        buffer = eventBlocks.pop() || "";
+
+        for (const event of parseSseEvents(eventBlocks.join("\n\n"))) {
+          if (event.event === "chunk") {
+            setOutput((current) => `${current}${typeof event.data.response === "string" ? event.data.response : ""}`);
+          }
+
+          if (event.event === "done") {
+            completed = true;
+          }
+
+          if (event.event === "error") {
+            throw new Error(formatRunError(event.data));
+          }
+        }
+
+        if (done) {
+          if (buffer.trim()) {
+            for (const event of parseSseEvents(buffer)) {
+              if (event.event === "chunk") {
+                setOutput((current) => `${current}${typeof event.data.response === "string" ? event.data.response : ""}`);
+              }
+              if (event.event === "done") {
+                completed = true;
+              }
+            }
+          }
+          break;
+        }
+      }
+
+      setStatus("completed");
+    } catch (runError) {
+      if (controller.signal.aborted) {
+        setStatus("canceled");
+        setError("Prompt run canceled locally. No prompt or response content was persisted by the app.");
+      } else {
+        setStatus("failed");
+        setError(formatRunError(runError));
+      }
+    } finally {
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+      }
+    }
+  };
+
+  return (
+    <Card className="border-border/70">
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground/50">Measured local runtime availability</p>
+            <CardTitle className="mt-1 flex items-center gap-2 text-xl">
+              <Terminal className="h-5 w-5 text-primary" aria-hidden />
+              Phase 3 prompt runner
+            </CardTitle>
+          </div>
+          <MetricLabel classification="Measured" />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-5 text-sm leading-relaxed text-foreground/70">
+        <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-amber-800 dark:text-amber-200">
+          <p className="font-semibold">Phase 3 boundary</p>
+          <p className="mt-1">
+            This runner sends prompts only to local Ollama and streams the response back into this browser session. It does not
+            calculate official TTFT, tokens/sec, cost per run, or GPU telemetry yet. Prompt and response content are not persisted
+            by the app.
+          </p>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-[0.8fr_1.2fr]">
+          <div className="space-y-2">
+            <label className="text-xs font-semibold uppercase tracking-wide text-foreground/60" htmlFor="ai-factory-model">
+              Local model
+            </label>
+            <select
+              id="ai-factory-model"
+              value={model}
+              onChange={(event) => setModel(event.target.value)}
+              className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground"
+              disabled={status === "running"}
+            >
+              {models.map((name) => (
+                <option key={name} value={name}>
+                  {name}
+                </option>
+              ))}
+              <option value="__manual__">Enter model manually…</option>
+            </select>
+            {model === "__manual__" ? (
+              <input
+                type="text"
+                value={manualModel}
+                onChange={(event) => setManualModel(event.target.value)}
+                placeholder="llama3.2:3b"
+                className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground"
+                disabled={status === "running"}
+              />
+            ) : null}
+            {modelDiscoveryError ? <p className="text-xs text-amber-700 dark:text-amber-300">{modelDiscoveryError}</p> : null}
+            <button
+              type="button"
+              onClick={() => void loadModels()}
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={status === "running"}
+            >
+              <RefreshCw className="h-3.5 w-3.5" aria-hidden />
+              Refresh models
+            </button>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-xs font-semibold uppercase tracking-wide text-foreground/60" htmlFor="ai-factory-prompt">
+              Prompt
+            </label>
+            <textarea
+              id="ai-factory-prompt"
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              placeholder="Ask a short local inference question…"
+              className="min-h-36 w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground"
+              disabled={status === "running"}
+              maxLength={promptMaxLength}
+            />
+            <p className="text-xs text-foreground/50">
+              {prompt.length.toLocaleString()} / {promptMaxLength.toLocaleString()} characters. Content stays in request/browser
+              memory only and is not saved by Partner Hub.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={() => void runPrompt()}
+            className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-xs font-semibold text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={!canRun}
+          >
+            <Play className="h-3.5 w-3.5" aria-hidden />
+            Run local prompt
+          </button>
+          {status === "running" ? (
+            <button
+              type="button"
+              onClick={cancel}
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-4 py-2 text-xs font-semibold text-foreground transition hover:bg-muted"
+            >
+              <Square className="h-3.5 w-3.5" aria-hidden />
+              Cancel
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={reset}
+            className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-4 py-2 text-xs font-semibold text-foreground transition hover:bg-muted"
+          >
+            <RotateCcw className="h-3.5 w-3.5" aria-hidden />
+            Reset / clear
+          </button>
+          <span className="rounded-full border border-border bg-muted/40 px-3 py-1 text-xs font-semibold text-foreground">
+            Status: {status}
+          </span>
+        </div>
+
+        {error ? <p className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-amber-800 dark:text-amber-200">{error}</p> : null}
+
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">Generated response</p>
+            <MetricLabel classification="Measured" />
+            <span className="text-xs text-foreground/50">Runtime response content only; measured economics are not calculated yet.</span>
+          </div>
+          <pre className="min-h-40 whitespace-pre-wrap rounded-xl border border-border bg-muted/30 p-4 text-sm text-foreground">
+            {output || "Local Ollama response stream will appear here."}
+          </pre>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui/partner-hub/docs/ai-factory-economics.md
+++ b/ui/partner-hub/docs/ai-factory-economics.md
@@ -12,34 +12,34 @@ This pointer exists so the module is discoverable from the existing Partner Hub 
 
 ## Current status
 
-- Phase 2 is implemented as local-only Ollama health and model discovery.
+- Phase 3 is implemented as a local-only Ollama prompt runner and streaming proxy.
 - The page is available at `/ai-factory-economics`; with the default Partner Hub base path, open `http://localhost:3000/partner-hub/ai-factory-economics`.
-- The feature keeps the Phase 1 demo/mock dashboard values visible.
-- The page now shows measured local Ollama readiness and measured discovered local model names when Ollama is available.
-- The page still renders gracefully when Ollama is not running or when `/api/tags` fails.
-- NVIDIA telemetry is explicitly shown as not connected in Phase 2.
-- Phase 2 still does not run prompts, stream responses, calculate TTFT, calculate tokens/sec from real runs, call `nvidia-smi`, collect GPU telemetry, persist prompt content, or store run history.
+- The feature keeps the Phase 1 demo/mock dashboard economics visible.
+- The page shows measured local Ollama readiness and measured discovered local model names when Ollama is available.
+- The Phase 3 prompt runner lets a user choose a discovered model or enter a model manually, enter a prompt, submit it to local Ollama, and stream the response into the browser.
+- The page still renders gracefully when Ollama is not running, when `/api/tags` fails, or when the run endpoint cannot reach local Ollama.
+- NVIDIA telemetry is explicitly shown as not connected in Phase 3.
+- Phase 3 still does not calculate official TTFT, calculate tokens/sec from real runs, calculate cost per run from real runs, call `nvidia-smi`, collect GPU telemetry, persist prompt content, persist response content, add run history, add dependencies, add database migrations, or call cloud services.
 
-## Files added or updated in Phase 2
+## Files added or updated in Phase 3
 
 Added:
 
 ```text
-ui/partner-hub/app/api/ai-factory-economics/health/route.ts
-ui/partner-hub/app/api/ai-factory-economics/models/route.ts
-ui/partner-hub/components/ai-factory-economics/ollama-status-card.tsx
-ui/partner-hub/components/ai-factory-economics/model-discovery-panel.tsx
-ui/partner-hub/lib/ai-factory-economics/ollama.ts
-ui/partner-hub/lib/ai-factory-economics/ollama.test.ts
+ui/partner-hub/app/api/ai-factory-economics/run/route.ts
+ui/partner-hub/components/ai-factory-economics/prompt-runner.tsx
 ```
 
 Updated:
 
 ```text
 ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
+ui/partner-hub/components/ai-factory-economics/model-discovery-panel.tsx
+ui/partner-hub/components/ai-factory-economics/ollama-status-card.tsx
 ui/partner-hub/lib/ai-factory-economics/mock-data.ts
+ui/partner-hub/lib/ai-factory-economics/ollama.ts
+ui/partner-hub/lib/ai-factory-economics/ollama.test.ts
 ui/partner-hub/lib/ai-factory-economics/types.ts
-ui/partner-hub/package.json (test/typecheck script maintenance and AI Factory helper test inclusion)
 docs/AI_FACTORY_ECONOMICS_MODULE.md
 ui/partner-hub/docs/ai-factory-economics.md
 ```
@@ -74,7 +74,7 @@ http://localhost:3000/partner-hub/ai-factory-economics
 
 If `NEXT_PUBLIC_BASE_PATH` is changed, keep using the same internal route (`/ai-factory-economics`) under that configured base path.
 
-To test with local Ollama:
+To test Phase 3 with local Ollama:
 
 ```bash
 ollama serve
@@ -82,13 +82,24 @@ ollama pull llama3.2:3b
 npm run dev
 ```
 
-Then open:
+Then:
 
-```text
-http://localhost:3000/partner-hub/ai-factory-economics
+1. Open `http://localhost:3000/partner-hub/ai-factory-economics`.
+2. Verify the Ollama status card reports the configured local URL.
+3. Select a discovered model in the Phase 3 prompt runner, or choose manual entry and enter a local model name such as `llama3.2:3b`.
+4. Enter a prompt.
+5. Click **Run local prompt**.
+6. Verify the generated response streams into the response panel.
+7. Optionally click **Cancel** during a run to abort the browser request with `AbortController`.
+8. Click **Reset / clear** to clear in-memory prompt and response UI state.
+
+Verification commands from `ui/partner-hub`:
+
+```bash
+npm run typecheck
+npm test
+npm run lint
 ```
-
-Use the status refresh buttons after starting Ollama or pulling a model.
 
 ## Graceful fallback behavior
 
@@ -98,27 +109,33 @@ If Ollama is not running, the page should show an “Ollama unavailable” state
 - Pull a model with `ollama pull <model>`.
 - Refresh the page/status.
 
-If `/api/tags` returns no models, the model discovery card shows setup guidance while the demo/mock dashboard remains visible.
+If `/api/tags` returns no models, the model discovery card and prompt runner show setup guidance while the demo/mock dashboard remains visible. The prompt runner still allows manual model entry so users can run a model immediately after pulling it.
+
+If `/api/ai-factory-economics/run` receives invalid input, it returns graceful JSON validation errors without stack traces. If local Ollama is unavailable, the route returns a safe JSON error before streaming begins. If an upstream streaming error occurs after streaming begins, the route emits a safe stream error event.
 
 ## Metric labeling rules
 
 - Live Ollama health is labeled **Measured**.
 - Discovered local Ollama models are labeled **Measured**.
+- Prompt run status and streamed response content are labeled **Measured** for runtime availability only.
+- Generated response content is not labeled as measured economics.
 - Demo dashboard economics remain labeled **Demo/mock**.
 - Static assumptions such as demo mode and energy rate remain labeled **Configured**.
 
-## Phase 2 guardrails
+## Phase 3 guardrails
 
-Phase 2 intentionally does **not** add:
+Phase 3 intentionally does **not** add:
 
-- Prompt execution.
-- Streaming.
-- TTFT calculation.
-- Real tokens/sec calculation.
+- Official TTFT calculation.
+- Official tokens/sec calculation.
+- Real cost-per-run calculation.
 - `nvidia-smi` calls.
 - GPU telemetry.
 - Run history.
 - Persistent storage.
+- Prompt or response content persistence.
 - Database migrations.
 - New dependencies.
 - Cloud services, secrets, or API keys.
+
+Prompt and response content remain in request/browser memory for the active run only. Partner Hub does not save prompt content, response content, or run history in Phase 3.

--- a/ui/partner-hub/lib/ai-factory-economics/mock-data.ts
+++ b/ui/partner-hub/lib/ai-factory-economics/mock-data.ts
@@ -3,14 +3,14 @@ import type { AiFactoryEconomicsMockDashboard } from "./types";
 export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard = {
   scenarioName: "Local workstation inference economics demo",
   summary:
-    "A Phase 2 dashboard that keeps demo/mock economics visible while checking local Ollama health and model discovery without running prompts.",
+    "A Phase 3 dashboard that keeps demo/mock economics visible while running local Ollama prompts through a streaming proxy.",
   assumptions: [
     {
       id: "energy-rate",
       label: "Energy rate assumption",
       value: "$0.16/kWh",
       classification: "Configured",
-      description: "Static display assumption only; not used by a live collector in Phase 2.",
+      description: "Static display assumption only; not used by a live collector in Phase 3.",
       tone: "info",
     },
     {
@@ -18,7 +18,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard = 
       label: "Demo mode",
       value: "On",
       classification: "Configured",
-      description: "Phase 2 renders with demo/mock metrics plus optional local Ollama health and model discovery.",
+      description: "Phase 3 renders demo/mock economics plus optional local Ollama health, model discovery, and prompt streaming.",
       tone: "good",
     },
   ],
@@ -28,7 +28,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard = 
       label: "Selected model",
       value: "llama3.1:8b-instruct",
       classification: "Demo/mock",
-      description: "Placeholder model name for demo fallback; discovered local Ollama models are shown separately as Measured in Phase 2.",
+      description: "Placeholder model name for demo fallback; discovered local Ollama models and prompt streams are shown separately as Measured in Phase 3.",
       tone: "info",
     },
     {
@@ -36,7 +36,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard = 
       label: "Time to first token",
       value: "420 ms",
       classification: "Demo/mock",
-      description: "Mock first-token timing for the dashboard shell; Phase 2 does not stream responses or calculate TTFT.",
+      description: "Mock first-token timing for the dashboard shell; Phase 3 streams responses but does not calculate official TTFT.",
       tone: "good",
     },
     {
@@ -44,7 +44,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard = 
       label: "Total latency",
       value: "2.8 s",
       classification: "Demo/mock",
-      description: "Mock end-to-end run duration; no real prompt execution happens in Phase 2.",
+      description: "Mock end-to-end economics placeholder; Phase 3 does not calculate official total latency metrics from runs.",
       tone: "good",
     },
     {
@@ -60,7 +60,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard = 
       label: "GPU utilization",
       value: "68%",
       classification: "Demo/mock",
-      description: "Mock GPU utilization; Phase 2 does not call nvidia-smi or sample hardware telemetry.",
+      description: "Mock GPU utilization; Phase 3 does not call nvidia-smi or sample hardware telemetry.",
       tone: "info",
     },
     {
@@ -76,7 +76,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard = 
       label: "GPU watts",
       value: "146 W",
       classification: "Demo/mock",
-      description: "Mock power draw; no local process or hardware probe is used in Phase 2.",
+      description: "Mock power draw; no local process or hardware probe is used in Phase 3.",
       tone: "warning",
     },
     {
@@ -100,7 +100,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard = 
       label: "Estimated cost per run",
       value: "$0.000018",
       classification: "Demo/mock",
-      description: "Mock economics preview using a static energy-rate assumption; no persisted cost model exists in Phase 2.",
+      description: "Mock economics preview using a static energy-rate assumption; no persisted cost model exists in Phase 3.",
       tone: "good",
     },
   ],
@@ -109,19 +109,19 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard = 
       title: "Ollama",
       status: "Checked",
       classification: "Measured",
-      description: "Phase 2 checks local Ollama health and /api/tags model discovery with graceful fallback when unavailable.",
+      description: "Phase 3 checks local Ollama health, discovers /api/tags models, and runs local prompt streams with graceful fallback when unavailable.",
     },
     {
       title: "NVIDIA telemetry",
       status: "Planned",
       classification: "Demo/mock",
-      description: "Planned for Phase 5; Phase 2 does not call nvidia-smi.",
+      description: "Planned for Phase 5; Phase 3 does not call nvidia-smi.",
     },
     {
       title: "Run history",
       status: "Not persistent",
       classification: "Demo/mock",
-      description: "Planned as in-memory summaries first; no database or persistent storage is added in Phase 2.",
+      description: "Planned as in-memory summaries first; no database or persistent storage is added in Phase 3.",
     },
   ],
   phases: [
@@ -132,17 +132,17 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard = 
       description: "Dashboard shell, local-only copy, mock metrics, readiness guidance, and documentation updates.",
     },
     {
-      phase: "Phase 2",
+      phase: "Phase 3",
       title: "Ollama health/model discovery",
-      status: "Active",
+      status: "Complete",
       description: "Local health checks and model list discovery while retaining demo fallback behavior.",
-      active: true,
     },
     {
       phase: "Phase 3",
       title: "Prompt runner",
-      status: "Later",
-      description: "Introduce prompt execution and latency timing without persisting prompt content.",
+      status: "Active",
+      description: "Run local Ollama prompts and stream responses without persisting prompt or response content; official metrics wait for Phase 4.",
+      active: true,
     },
     {
       phase: "Phase 5",

--- a/ui/partner-hub/lib/ai-factory-economics/ollama.test.ts
+++ b/ui/partner-hub/lib/ai-factory-economics/ollama.test.ts
@@ -3,9 +3,14 @@ import test from "node:test";
 
 import {
   AI_FACTORY_DEFAULT_OLLAMA_URL,
+  AI_FACTORY_MODEL_MAX_LENGTH,
+  AI_FACTORY_PROMPT_MAX_LENGTH,
+  buildOllamaRunPayload,
   getAiFactoryOllamaBaseUrl,
   normalizeOllamaModelNames,
   toSafeOllamaError,
+  validateAiFactoryRunRequest,
+  normalizeOllamaGenerateChunk,
 } from "./ollama";
 
 test("getAiFactoryOllamaBaseUrl defaults and removes trailing slashes", () => {
@@ -48,4 +53,63 @@ test("toSafeOllamaError shapes safe UI errors without stack traces", () => {
   assert.equal(unavailable.message, "Local Ollama is unavailable.");
   assert.equal(unavailable.detail, "connect ECONNREFUSED 127.0.0.1:11434");
   assert.equal("stack" in unavailable, false);
+});
+
+
+test("validateAiFactoryRunRequest accepts trimmed model and prompt", () => {
+  const result = validateAiFactoryRunRequest({ model: " llama3.2:3b ", prompt: " hello local model " });
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.deepEqual(result.request, { model: "llama3.2:3b", prompt: "hello local model" });
+    assert.deepEqual(buildOllamaRunPayload(result.request), {
+      model: "llama3.2:3b",
+      prompt: "hello local model",
+      stream: true,
+    });
+  }
+});
+
+test("validateAiFactoryRunRequest rejects missing or invalid model names", () => {
+  const missing = validateAiFactoryRunRequest({ model: " ", prompt: "hello" });
+  assert.equal(missing.ok, false);
+  if (!missing.ok) {
+    assert.equal(missing.status, 400);
+    assert.equal(missing.error.code, "MODEL_REQUIRED");
+  }
+
+  const tooLong = validateAiFactoryRunRequest({ model: "a".repeat(AI_FACTORY_MODEL_MAX_LENGTH + 1), prompt: "hello" });
+  assert.equal(tooLong.ok, false);
+  if (!tooLong.ok) {
+    assert.equal(tooLong.status, 400);
+    assert.equal(tooLong.error.code, "MODEL_TOO_LONG");
+  }
+
+  const controlCharacter = validateAiFactoryRunRequest({ model: "llama\n3", prompt: "hello" });
+  assert.equal(controlCharacter.ok, false);
+  if (!controlCharacter.ok) {
+    assert.equal(controlCharacter.error.code, "MODEL_INVALID");
+  }
+});
+
+test("validateAiFactoryRunRequest rejects empty prompts and enforces length limit", () => {
+  const empty = validateAiFactoryRunRequest({ model: "llama3.2:3b", prompt: "   " });
+  assert.equal(empty.ok, false);
+  if (!empty.ok) {
+    assert.equal(empty.status, 400);
+    assert.equal(empty.error.code, "PROMPT_REQUIRED");
+  }
+
+  const tooLong = validateAiFactoryRunRequest({ model: "llama3.2:3b", prompt: "x".repeat(AI_FACTORY_PROMPT_MAX_LENGTH + 1) });
+  assert.equal(tooLong.ok, false);
+  if (!tooLong.ok) {
+    assert.equal(tooLong.status, 413);
+    assert.equal(tooLong.error.code, "PROMPT_TOO_LONG");
+  }
+});
+
+test("normalizeOllamaGenerateChunk parses safe streaming chunks", () => {
+  assert.deepEqual(normalizeOllamaGenerateChunk('{"response":"hi","done":false}'), { response: "hi", done: false });
+  assert.deepEqual(normalizeOllamaGenerateChunk('{"response":"","done":true}'), { response: "", done: true });
+  assert.equal(normalizeOllamaGenerateChunk('not json'), null);
 });

--- a/ui/partner-hub/lib/ai-factory-economics/ollama.ts
+++ b/ui/partner-hub/lib/ai-factory-economics/ollama.ts
@@ -1,11 +1,16 @@
 import type {
   AiFactoryHealthStatus,
   AiFactoryModelDiscoveryResult,
+  AiFactoryRunRequest,
+  AiFactoryRunValidationResult,
   AiFactorySafeError,
 } from "./types";
 
 export const AI_FACTORY_DEFAULT_OLLAMA_URL = "http://127.0.0.1:11434";
 export const AI_FACTORY_OLLAMA_TIMEOUT_MS = 2_000;
+export const AI_FACTORY_OLLAMA_RUN_TIMEOUT_MS = 120_000;
+export const AI_FACTORY_PROMPT_MAX_LENGTH = 4_000;
+export const AI_FACTORY_MODEL_MAX_LENGTH = 120;
 
 type FetchLike = typeof fetch;
 
@@ -16,6 +21,11 @@ type OllamaModelEntry = {
 
 type OllamaTagsResponse = {
   models?: unknown;
+};
+
+type OllamaGenerateChunk = {
+  response?: unknown;
+  done?: unknown;
 };
 
 export function getAiFactoryOllamaBaseUrl(value = process.env.AI_FACTORY_OLLAMA_URL) {
@@ -92,7 +102,7 @@ export async function getOllamaHealth(fetcher: FetchLike = fetch): Promise<AiFac
 
     return {
       ok: true,
-      phase: "Phase 2",
+      phase: "Phase 3",
       ollama: {
         status: "available",
         reachable: true,
@@ -105,15 +115,15 @@ export async function getOllamaHealth(fetcher: FetchLike = fetch): Promise<AiFac
       nvidiaTelemetry: {
         status: "not_connected",
         classification: "Demo/mock",
-        message: "NVIDIA telemetry is not connected in Phase 2.",
+        message: "NVIDIA telemetry is not connected in Phase 3.",
       },
-      promptExecution: "not_enabled",
-      streaming: "not_enabled",
+      promptExecution: "enabled",
+      streaming: "enabled",
     };
   } catch (error) {
     return {
       ok: false,
-      phase: "Phase 2",
+      phase: "Phase 3",
       ollama: {
         status: "unavailable",
         reachable: false,
@@ -127,10 +137,10 @@ export async function getOllamaHealth(fetcher: FetchLike = fetch): Promise<AiFac
       nvidiaTelemetry: {
         status: "not_connected",
         classification: "Demo/mock",
-        message: "NVIDIA telemetry is not connected in Phase 2.",
+        message: "NVIDIA telemetry is not connected in Phase 3.",
       },
-      promptExecution: "not_enabled",
-      streaming: "not_enabled",
+      promptExecution: "enabled",
+      streaming: "enabled",
     };
   }
 }
@@ -144,7 +154,7 @@ export async function discoverOllamaModels(fetcher: FetchLike = fetch): Promise<
 
     return {
       ok: true,
-      phase: "Phase 2",
+      phase: "Phase 3",
       baseUrl,
       timeoutMs: AI_FACTORY_OLLAMA_TIMEOUT_MS,
       classification: "Measured",
@@ -154,7 +164,7 @@ export async function discoverOllamaModels(fetcher: FetchLike = fetch): Promise<
   } catch (error) {
     return {
       ok: false,
-      phase: "Phase 2",
+      phase: "Phase 3",
       baseUrl,
       timeoutMs: AI_FACTORY_OLLAMA_TIMEOUT_MS,
       classification: "Measured",
@@ -163,4 +173,118 @@ export async function discoverOllamaModels(fetcher: FetchLike = fetch): Promise<
       error: toSafeOllamaError(error, "Could not discover local Ollama models."),
     };
   }
+}
+
+export function validateAiFactoryRunRequest(input: unknown): AiFactoryRunValidationResult {
+  const body = input as Partial<Record<keyof AiFactoryRunRequest, unknown>> | null;
+  const model = typeof body?.model === "string" ? body.model.trim() : "";
+  const prompt = typeof body?.prompt === "string" ? body.prompt.trim() : "";
+
+  if (!model) {
+    return {
+      ok: false,
+      status: 400,
+      error: {
+        code: "MODEL_REQUIRED",
+        message: "Choose or enter a local Ollama model before running a prompt.",
+      },
+    };
+  }
+
+  if (model.length > AI_FACTORY_MODEL_MAX_LENGTH) {
+    return {
+      ok: false,
+      status: 400,
+      error: {
+        code: "MODEL_TOO_LONG",
+        message: `Model names must be ${AI_FACTORY_MODEL_MAX_LENGTH} characters or fewer.`,
+      },
+    };
+  }
+
+  if (/\p{C}/u.test(model)) {
+    return {
+      ok: false,
+      status: 400,
+      error: {
+        code: "MODEL_INVALID",
+        message: "Model names cannot include control characters.",
+      },
+    };
+  }
+
+  if (!prompt) {
+    return {
+      ok: false,
+      status: 400,
+      error: {
+        code: "PROMPT_REQUIRED",
+        message: "Enter a prompt before running the local model.",
+      },
+    };
+  }
+
+  if (prompt.length > AI_FACTORY_PROMPT_MAX_LENGTH) {
+    return {
+      ok: false,
+      status: 413,
+      error: {
+        code: "PROMPT_TOO_LONG",
+        message: `Prompts must be ${AI_FACTORY_PROMPT_MAX_LENGTH.toLocaleString()} characters or fewer for this local demo phase.`,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    request: { model, prompt },
+  };
+}
+
+export function buildOllamaRunPayload(request: AiFactoryRunRequest) {
+  return {
+    model: request.model,
+    prompt: request.prompt,
+    stream: true,
+  };
+}
+
+export function normalizeOllamaGenerateChunk(line: string) {
+  try {
+    const parsed = JSON.parse(line) as OllamaGenerateChunk;
+    return {
+      response: typeof parsed.response === "string" ? parsed.response : "",
+      done: parsed.done === true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function openOllamaRunStream(
+  request: AiFactoryRunRequest,
+  fetcher: FetchLike = fetch,
+  signal?: AbortSignal,
+) {
+  const baseUrl = getAiFactoryOllamaBaseUrl();
+  const response = await fetcher(`${baseUrl}/api/generate`, {
+    method: "POST",
+    headers: {
+      Accept: "application/x-ndjson, application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(buildOllamaRunPayload(request)),
+    signal,
+  });
+
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error(`Ollama returned HTTP ${response.status}.`);
+  }
+
+  if (!response.body) {
+    throw new Error("Ollama did not return a streaming response body.");
+  }
+
+  return response;
 }

--- a/ui/partner-hub/lib/ai-factory-economics/types.ts
+++ b/ui/partner-hub/lib/ai-factory-economics/types.ts
@@ -63,17 +63,17 @@ export type AiFactoryNvidiaTelemetryStatus = {
 
 export type AiFactoryHealthStatus = {
   ok: boolean;
-  phase: "Phase 2";
+  phase: "Phase 3";
   ollama: OllamaAvailability;
   demoModeAvailable: boolean;
   nvidiaTelemetry: AiFactoryNvidiaTelemetryStatus;
-  promptExecution: "not_enabled";
-  streaming: "not_enabled";
+  promptExecution: "enabled";
+  streaming: "enabled";
 };
 
 export type AiFactoryModelDiscoverySuccess = {
   ok: true;
-  phase: "Phase 2";
+  phase: "Phase 3";
   baseUrl: string;
   timeoutMs: number;
   classification: "Measured";
@@ -83,7 +83,7 @@ export type AiFactoryModelDiscoverySuccess = {
 
 export type AiFactoryModelDiscoveryFailure = {
   ok: false;
-  phase: "Phase 2";
+  phase: "Phase 3";
   baseUrl: string;
   timeoutMs: number;
   classification: "Measured";
@@ -93,3 +93,45 @@ export type AiFactoryModelDiscoveryFailure = {
 };
 
 export type AiFactoryModelDiscoveryResult = AiFactoryModelDiscoverySuccess | AiFactoryModelDiscoveryFailure;
+
+export type AiFactoryRunStatus = "idle" | "running" | "completed" | "failed" | "canceled";
+
+export type AiFactoryRunRequest = {
+  model: string;
+  prompt: string;
+};
+
+export type AiFactoryRunValidationSuccess = {
+  ok: true;
+  request: AiFactoryRunRequest;
+};
+
+export type AiFactoryRunValidationFailure = {
+  ok: false;
+  error: AiFactorySafeError;
+  status: number;
+};
+
+export type AiFactoryRunValidationResult = AiFactoryRunValidationSuccess | AiFactoryRunValidationFailure;
+
+export type AiFactoryRunErrorCode =
+  | "INVALID_JSON"
+  | "MODEL_REQUIRED"
+  | "MODEL_TOO_LONG"
+  | "MODEL_INVALID"
+  | "PROMPT_REQUIRED"
+  | "PROMPT_TOO_LONG"
+  | "OLLAMA_TIMEOUT"
+  | "OLLAMA_UNAVAILABLE"
+  | "OLLAMA_BAD_RESPONSE";
+
+export type AiFactoryRunError = AiFactorySafeError & {
+  code: AiFactoryRunErrorCode;
+};
+
+export type AiFactoryRunStreamEvent = "meta" | "chunk" | "done" | "error";
+
+export type AiFactoryRunStreamChunk = {
+  response: string;
+  done: boolean;
+};


### PR DESCRIPTION
### Motivation
- Enable Phase 3 capabilities: let Partner Hub run short, safe local prompts against a local Ollama model and stream the response back into the browser while preserving the Phase 3 guardrails. 
- Keep demo/mock economics visible and clearly labeled while adding measured local prompt streaming without calculating TTFT/tokens/sec/cost or adding GPU telemetry or persistence. 

### Description
- Added a local-only run API route that validates request JSON, enforces model and prompt length limits, proxies to local Ollama with `stream: true`, and relays chunks as server-sent events; see `ui/partner-hub/app/api/ai-factory-economics/run/route.ts`. 
- Extended the feature-scoped helper with run request validation, safe request shaping, streaming helper, and chunk normalization; see `ui/partner-hub/lib/ai-factory-economics/ollama.ts` and typed shapes in `ui/partner-hub/lib/ai-factory-economics/types.ts`. 
- Added a client-side Phase 3 prompt runner component supporting discovered-model selection or manual model entry, prompt entry, streamed output display, run status (idle/running/completed/failed/canceled), reset, and cancellation via `AbortController`; see `ui/partner-hub/components/ai-factory-economics/prompt-runner.tsx`. 
- Integrated the prompt runner into the feature shell and updated copy/docs to clearly mark measured vs demo/mock boundaries; updated files include `ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx`, `ui/partner-hub/components/ai-factory-economics/ollama-status-card.tsx`, `ui/partner-hub/lib/ai-factory-economics/mock-data.ts`, `ui/partner-hub/lib/ai-factory-economics/ollama.test.ts`, `ui/partner-hub/docs/ai-factory-economics.md`, and `docs/AI_FACTORY_ECONOMICS_MODULE.md`. 

### Testing
- Ran `cd ui/partner-hub && npm run typecheck` which failed due to missing local `node_modules` and global TypeScript environment reporting many missing dependency/type declarations (environment blocked local typecheck). 
- Ran `cd ui/partner-hub && npm test` which failed for the same reason and because the CI-like `tsc` test invocation is blocked without installed dependencies and the registry returned a `403` while attempting `npm install`. 
- Ran `cd ui/partner-hub && npm run lint` which failed because `next` is not installed in the environment. 
- Performed repository-local safety checks that succeeded: `git diff --check` (no trailing/merge markers), verified no touched file exceeds 800 lines (`wc -l` on modified files), confirmed no `nvidia-smi` calls or persistence APIs were added via `rg` searches, and confirmed Phase 3 did not introduce TTFT/tokens/sec/cost/GPU telemetry calculations (matches are only docs/mock text). 

Notes: automated test/typecheck execution is blocked in this environment because `npm install` cannot complete due to registry/access constraints; the added unit tests live at `ui/partner-hub/lib/ai-factory-economics/ollama.test.ts` and will run normally once dependencies are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21d9bcc3e08330a3b1763c9e8485ce)