### PR TITLE
Finalize AI Factory Economics — Phase 8 docs, hardening, and small safety fixes

### DIFF
--- a/docs/AI_FACTORY_ECONOMICS_MODULE.md
+++ b/docs/AI_FACTORY_ECONOMICS_MODULE.md
@@ -1,752 +1,155 @@
-# AI Factory Economics Module Plan
+# AI Factory Economics Module
 
-## Phase 1 status
+## Final Phase 8 status
 
-Phase 1 is implemented as a local-only static/mock feature shell in Partner Hub. The route, mock dashboard UI, feature-scoped components, feature-scoped mock data/types, navigation links, and documentation updates have been added without API routes, Ollama calls, NVIDIA telemetry calls, dependencies, migrations, database changes, prompt execution, or persistent storage.
+Phase 8 is implemented as the final hardening, validation, cleanup, and documentation pass for the local-only AI Factory Economics module in Partner Hub. The module remains a local education/demo experience: it can show the original demo/mock dashboard, check a local Ollama service, discover local models, stream local prompt runs, measure runtime timing, estimate token counts, derive throughput and model comparison summaries, take optional NVIDIA `nvidia-smi` snapshots, and present executive scorecards/recommendations with explicit caveats.
 
-Phase 0 remains the source architecture plan for future phases. Phase 1 intentionally renders demo/mock values only, with visible metric classification labels on every dashboard metric.
+Phase 8 does **not** add major features, run persistence, storage, migrations, cloud services, secrets, new dependencies, background collectors, non-NVIDIA telemetry, exact tokenizer counts, lab-grade power measurement, exact per-run GPU attribution, or production benchmark claims.
 
-## Repository discovery summary
+## Feature summary
 
-- Partner Hub is a Next.js App Router application under `ui/partner-hub` with route groups in `app/(routes)` and API route handlers in `app/api`.
-- Phase 1 adds the page at `ui/partner-hub/app/(routes)/ai-factory-economics/page.tsx` and delegates rendering to feature-scoped components under `ui/partner-hub/components/ai-factory-economics/`.
-- The app is served under a configurable base path that defaults to `/partner-hub`, so user-facing links should be written as application-relative paths such as `/ai-factory-economics` and will render beneath the base path at runtime.
-- Current pages use route-level `page.tsx` files that delegate most feature logic to feature folders under `components/<feature>` and `lib/<feature>`.
-- Phase 1 mock data and types live under `ui/partner-hub/lib/ai-factory-economics/`.
-- Styling uses Tailwind CSS utility classes, shared CSS variables in `styles/globals.css`, and reusable UI primitives in `components/ui`.
-- Existing local-AI patterns already proxy to local Ollama from API routes and return graceful JSON errors when the local service is unavailable.
-- Tests are currently package-script based: `npm run typecheck`, `npm run lint`, and a long `npm test` command that compiles selected TypeScript modules into `.tmp-tests` and runs Node's built-in test runner.
-- Documentation conventions are Markdown files with practical sections in `ui/partner-hub/docs`; this canonical plan remains at `docs/AI_FACTORY_ECONOMICS_MODULE.md`, with a Partner Hub docs pointer maintained at `ui/partner-hub/docs/ai-factory-economics.md` so the module is discoverable from the existing app docs area.
-
-## Phase 2 status
-
-Phase 2 is implemented as local-only Ollama health and model discovery in Partner Hub. The Phase 1 demo/mock economics dashboard remains visible, while the page now calls feature-scoped API routes that check the configured local Ollama service and discover model names from `/api/tags`.
-
-Phase 2 intentionally does **not** add prompt execution, streaming, TTFT calculation, real tokens/sec calculation, `nvidia-smi`, NVIDIA telemetry, run history, persistent storage, database migrations, dependencies, cloud services, secrets, or external APIs.
-
-Phase 2 files added:
-
-```text
-ui/partner-hub/app/api/ai-factory-economics/health/route.ts
-ui/partner-hub/app/api/ai-factory-economics/models/route.ts
-ui/partner-hub/components/ai-factory-economics/ollama-status-card.tsx
-ui/partner-hub/components/ai-factory-economics/model-discovery-panel.tsx
-ui/partner-hub/lib/ai-factory-economics/ollama.ts
-ui/partner-hub/lib/ai-factory-economics/ollama.test.ts
-```
-
-Phase 2 files updated:
-
-```text
-ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
-ui/partner-hub/lib/ai-factory-economics/mock-data.ts
-ui/partner-hub/lib/ai-factory-economics/types.ts
-ui/partner-hub/lib/ai-factory-economics/mock-data.ts
-ui/partner-hub/package.json (test/typecheck script maintenance and AI Factory helper test inclusion)
-docs/AI_FACTORY_ECONOMICS_MODULE.md
-ui/partner-hub/docs/ai-factory-economics.md
-```
-
-Phase 2 runtime behavior:
-
-- `AI_FACTORY_OLLAMA_URL` configures the local Ollama base URL.
-- The default local Ollama URL is `http://127.0.0.1:11434`.
-- `/api/ai-factory-economics/health` performs a short-timeout local Ollama check and returns clean JSON with demo-mode availability and a Phase 2 NVIDIA telemetry `not_connected` status.
-- `/api/ai-factory-economics/models` performs a short-timeout local Ollama `/api/tags` call and returns normalized model names.
-- Both routes return graceful JSON errors without stack traces when Ollama is unavailable or returns unexpected data.
-- Live Ollama health and discovered model names are labeled **Measured**.
-- Demo dashboard values and fallback model names remain labeled **Demo/mock** or **Configured**.
-
-Local Phase 2 test flow:
-
-```bash
-cd ui/partner-hub
-ollama serve
-ollama pull llama3.2:3b
-npm run dev
-```
-
-Then open:
-
-```text
-http://localhost:3000/partner-hub/ai-factory-economics
-```
-
-Use the refresh buttons on the Ollama status and model discovery cards after starting Ollama or pulling a model.
-
-## Phase 3 status
-
-Phase 3 is implemented as a local-only Ollama prompt runner and streaming proxy in Partner Hub. The Phase 1 demo/mock economics dashboard remains visible, while users can now select or manually enter a local Ollama model, enter a prompt, submit it to the local Ollama `/api/generate` endpoint through the Partner Hub proxy, and see streamed response content in the UI.
-
-Phase 3 intentionally does **not** add official TTFT calculation, official tokens/sec calculation, real cost-per-run calculation, GPU telemetry, `nvidia-smi` calls, run history, persistent storage, database migrations, dependencies, cloud services, secrets, prompt persistence, or response persistence. Prompt and response content remain in request/browser memory for the active run only.
-
-Phase 3 files added:
-
-```text
-ui/partner-hub/app/api/ai-factory-economics/run/route.ts
-ui/partner-hub/components/ai-factory-economics/prompt-runner.tsx
-```
-
-Phase 3 files updated:
-
-```text
-ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
-ui/partner-hub/components/ai-factory-economics/model-discovery-panel.tsx
-ui/partner-hub/components/ai-factory-economics/ollama-status-card.tsx
-ui/partner-hub/lib/ai-factory-economics/mock-data.ts
-ui/partner-hub/lib/ai-factory-economics/ollama.ts
-ui/partner-hub/lib/ai-factory-economics/ollama.test.ts
-ui/partner-hub/lib/ai-factory-economics/types.ts
-docs/AI_FACTORY_ECONOMICS_MODULE.md
-ui/partner-hub/docs/ai-factory-economics.md
-```
-
-Phase 3 runtime behavior:
-
-- `AI_FACTORY_OLLAMA_URL` configures the local Ollama base URL and still defaults to `http://127.0.0.1:11434`.
-- `/api/ai-factory-economics/run` accepts `POST` JSON with `model` and `prompt`, validates both fields, rejects empty prompts, rejects missing model names, enforces a prompt length limit, and calls local Ollama only.
-- The run route requests Ollama streaming with `stream: true` and relays response chunks as server-sent events to the browser.
-- Validation and pre-stream Ollama failures return graceful JSON errors without stack traces. Streaming-time failures emit safe stream error events.
-- The prompt runner supports discovered models from Phase 2, manual model entry when discovery is unavailable, idle/running/completed/failed/canceled state, reset/clear, and cancel through `AbortController`.
-- Streamed response content is labeled **Measured** for local runtime availability, not as measured economics.
-- Existing TTFT, tokens/sec, cost/run, and GPU dashboard cards remain **Demo/mock** and are not updated from live prompt runs in Phase 3.
-
-Local Phase 3 test flow:
-
-```bash
-cd ui/partner-hub
-ollama serve
-ollama pull llama3.2:3b
-npm run dev
-```
-
-Then open:
-
-```text
-http://localhost:3000/partner-hub/ai-factory-economics
-```
-
-Select a discovered model or enter one manually, enter a prompt, click **Run local prompt**, and verify the response streams into the prompt runner.
-
-## Purpose
-
-The AI Factory Economics module should demonstrate the economics and operational signals of local AI inference using a laptop or workstation as the demo environment. It will combine local Ollama inference timing with local NVIDIA GPU telemetry to help users explain:
-
-- How model choice affects latency, throughput, power, and estimated per-run cost.
-- How GPU utilization, memory pressure, watts, and temperature move during prompt execution.
-- Which values are directly measured on the local machine versus estimated for demonstration.
-- How AI Factory concepts can be taught in Partner Hub without relying on cloud services or stored secrets.
-
-The module is not intended to become a cloud SaaS metering product. It is a local demo and education asset.
-
-## Why this belongs in Partner Hub
-
-Partner Hub already contains practical enablement tools, local demo utilities, and infrastructure-oriented explainers. AI Factory Economics fits because it can:
-
-- Turn abstract AI infrastructure economics into a runnable local demonstration.
-- Support partner conversations about latency, throughput, power, utilization, and cost tradeoffs.
-- Reuse existing Partner Hub patterns: App Router pages, local API proxy routes, feature-scoped components, feature-scoped libraries, Tailwind styling, and Markdown docs.
-- Complement existing infrastructure learning modules by showing inference economics from the application, model, and workstation telemetry layers.
+- Route: `/partner-hub/ai-factory-economics` with the default Partner Hub base path.
+- Static demo/mock dashboard remains available when local services are unavailable.
+- Local Ollama health and model discovery call only the configured local Ollama URL.
+- Prompt runner streams through the local Partner Hub API route to Ollama `/api/generate`.
+- Runtime metrics include measured TTFT/latency, estimated prompt/response tokens, and derived estimated tokens/sec.
+- Optional NVIDIA GPU telemetry reads a point-in-time `nvidia-smi` snapshot server-side.
+- Browser-memory run history stores sanitized summaries only; prompt and response content are excluded.
+- Model comparison, scorecards, and recommendations are derived from current in-memory summaries and labeled as local demo guidance.
 
 ## Local-only architecture
 
-The smallest safe architecture is:
-
 ```text
 Browser UI
-  -> Next.js page at /ai-factory-economics
-  -> Next.js local API routes under /api/ai-factory-economics/*
-  -> Local Ollama HTTP API at http://127.0.0.1:11434 by default
-  -> Local nvidia-smi child process when available
-  -> In-memory browser state for initial history and comparisons
+  -> /api/ai-factory-economics/health  -> local Ollama /api/tags
+  -> /api/ai-factory-economics/models  -> local Ollama /api/tags
+  -> /api/ai-factory-economics/run     -> local Ollama /api/generate streaming
+  -> /api/ai-factory-economics/gpu     -> server-side nvidia-smi snapshot
 ```
 
-Design rules:
+The API routes run in the Next.js Node.js runtime, use `no-store`/stream-safe cache headers, and return sanitized errors without stack traces. The GPU route uses `execFile` with a fixed argument array instead of shell-string execution. The module has no database, no migrations, no backend storage, no browser storage, and no cloud endpoints.
 
-- Default to local endpoints only.
-- Do not require cloud APIs, accounts, credentials, or secrets.
-- Keep all telemetry collection server-side in Next.js API routes.
-- Do not persist prompt content permanently.
-- Do not add a database until a future phase explicitly opts in.
-- Treat mock/demo mode as a first-class path so the module works without Ollama or NVIDIA hardware.
-- Clearly label every metric as **Measured**, **Estimated**, **Configured**, **Derived**, or **Demo/mock**.
-
-## Proposed route
-
-Use `/ai-factory-economics`.
-
-Rationale:
-
-- It is descriptive and executive-friendly.
-- It matches the requested module name.
-- It follows current top-level feature-route patterns such as `/hpc-lab` and `/skin-review`.
-- It can later be optionally gated by `NEXT_PUBLIC_ENABLE_AI_FACTORY_ECONOMICS=true`, following the existing feature-flag pattern used by larger local demo modules.
-
-## Proposed folder and module structure
-
-Planned files for future phases:
-
-```text
-ui/partner-hub/app/(routes)/ai-factory-economics/page.tsx
-ui/partner-hub/app/api/ai-factory-economics/health/route.ts
-ui/partner-hub/app/api/ai-factory-economics/models/route.ts
-ui/partner-hub/app/api/ai-factory-economics/run/route.ts
-ui/partner-hub/app/api/ai-factory-economics/gpu/route.ts
-ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
-ui/partner-hub/components/ai-factory-economics/executive-summary-cards.tsx
-ui/partner-hub/components/ai-factory-economics/model-selector.tsx
-ui/partner-hub/components/ai-factory-economics/prompt-runner.tsx
-ui/partner-hub/components/ai-factory-economics/run-status-panel.tsx
-ui/partner-hub/components/ai-factory-economics/gpu-telemetry-panel.tsx
-ui/partner-hub/components/ai-factory-economics/model-comparison-table.tsx
-ui/partner-hub/components/ai-factory-economics/run-history-panel.tsx
-ui/partner-hub/components/ai-factory-economics/metric-label.tsx
-ui/partner-hub/lib/ai-factory-economics/types.ts
-ui/partner-hub/lib/ai-factory-economics/ollama.ts
-ui/partner-hub/lib/ai-factory-economics/gpu.ts
-ui/partner-hub/lib/ai-factory-economics/metrics.ts
-ui/partner-hub/lib/ai-factory-economics/mockData.ts
-ui/partner-hub/lib/ai-factory-economics/format.ts
-ui/partner-hub/lib/ai-factory-economics/*.test.ts
-```
-
-Keep the first implementation small. Avoid cross-feature coupling except for shared UI primitives.
-
-## Planned API endpoints
-
-All endpoints should be local-only and should fail closed with clear JSON messages.
-
-| Endpoint                           | Method | Purpose                                                                                                    | External dependency                    |
-| ---------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| `/api/ai-factory-economics/health` | `GET`  | Report module readiness, Ollama reachability, mock-mode status, and optional GPU telemetry availability.   | Ollama and `nvidia-smi`, both optional |
-| `/api/ai-factory-economics/models` | `GET`  | Return locally available Ollama models.                                                                    | Ollama `/api/tags`                     |
-| `/api/ai-factory-economics/run`    | `POST` | Run one prompt against selected local model, optionally streaming, and return timing plus token estimates. | Ollama `/api/generate` or `/api/chat`  |
-| `/api/ai-factory-economics/gpu`    | `GET`  | Return current NVIDIA telemetry snapshot.                                                                  | `nvidia-smi`                           |
-
-Future endpoint candidates:
-
-- `/api/ai-factory-economics/mock-run` only if separating demo mode from real runs improves clarity.
-- `/api/ai-factory-economics/export` only after run history exists and excludes prompt content by default.
-
-## Planned UI components
-
-- **Feature shell:** Page header, local-only notice, setup checklist, and status summary.
-- **Executive summary cards:** Selected model, run status, TTFT, total latency, tokens/sec, GPU watts, estimated tokens per watt, estimated cost per run.
-- **Ollama status card:** Reachability, configured base URL, model count, selected model, last error.
-- **Model selector:** Local model list, refresh button, disabled state when Ollama is unavailable, demo model fallback.
-- **Prompt runner:** Prompt input for active session only, run button, stop/cancel option if supported, streaming output view.
-- **Metric label/chip:** Reusable label that marks values as Measured, Estimated, Derived, Configured, or Demo/mock.
-- **GPU telemetry panel:** Utilization, memory used/total, watts, temperature, availability state, and last sample time.
-- **Run status panel:** Idle, checking, running, streaming, completed, canceled, failed, or demo mode.
-- **Run history panel:** In-memory list of recent runs without saved prompt content.
-- **Model comparison table:** Side-by-side comparison of recent runs by model and prompt class.
-- **Recommendation card:** Human-readable interpretation for executive demos, clearly labeled as generated from local measurements and estimates.
-
-## Planned metric definitions
-
-| Metric                    | Definition                                                                   | Source label                                             |
-| ------------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------- |
-| Ollama health             | Whether the configured local Ollama base URL responds within timeout.        | Measured                                                 |
-| Available models          | Models returned by local Ollama model listing.                               | Measured                                                 |
-| Selected model            | Model chosen by the user or demo fallback.                                   | Configured                                               |
-| Prompt run status         | Current state of the run lifecycle.                                          | Measured/Derived                                         |
-| TTFT                      | Time from request start to first streamed response token/chunk.              | Measured when streaming; Estimated/Unavailable otherwise |
-| Total latency             | Time from request start to completed response or error.                      | Measured                                                 |
-| Estimated prompt tokens   | Approximation of prompt token count when exact tokenizer is not available.   | Estimated                                                |
-| Estimated response tokens | Approximation of response token count when exact tokenizer is not available. | Estimated                                                |
-| Estimated tokens/sec      | Estimated response tokens divided by generation duration.                    | Derived from estimated and measured values               |
-| GPU utilization           | Percent utilization from `nvidia-smi`.                                       | Measured                                                 |
-| GPU memory usage          | Used and total framebuffer memory from `nvidia-smi`.                         | Measured                                                 |
-| GPU watts                 | Current power draw from `nvidia-smi`.                                        | Measured                                                 |
-| GPU temperature           | Current GPU temperature from `nvidia-smi`.                                   | Measured                                                 |
-| Estimated tokens per watt | Estimated response tokens per measured average watts during the run.         | Derived/Estimated                                        |
-| Estimated cost per run    | Configurable local estimate based on energy usage and optional cost rate.    | Estimated                                                |
-| Run history               | Recent in-memory run summaries excluding prompt content.                     | Derived                                                  |
-| Model comparison          | Aggregation of recent run summaries by model.                                | Derived                                                  |
-
-## Measured vs estimated rules
-
-Measured values are values directly observed from local services or process timers. Estimated values are approximations used for demo economics when exact instrumentation is unavailable.
-
-Rules for future implementation:
-
-- Show a visible label next to every metric.
-- Never imply estimated token counts are exact tokenizer counts unless a model-specific tokenizer is added later.
-- Keep latency measurements based on monotonic server-side timers where possible.
-- Use browser-side timing only for UI responsiveness metrics, not authoritative run economics.
-- If GPU telemetry is sampled before and after a run rather than continuously during the run, label averages as estimated or sampled.
-- Cost per run must display the configured assumptions, such as energy rate and whether idle baseline was subtracted.
-
-## Ollama connectivity plan
-
-Default local configuration:
-
-```text
-AI_FACTORY_OLLAMA_URL=http://127.0.0.1:11434
-AI_FACTORY_DEFAULT_MODEL=<optional local model name>
-NEXT_PUBLIC_ENABLE_AI_FACTORY_ECONOMICS=false
-NEXT_PUBLIC_AI_FACTORY_DEMO_MODE=true
-```
-
-Implementation plan:
-
-1. Health route performs a short-timeout request to Ollama.
-2. Models route calls Ollama `/api/tags` and normalizes model names.
-3. Run route sends the prompt to Ollama with the selected model.
-4. Prefer streaming for TTFT measurement because the first chunk can mark first-token timing.
-5. If streaming is not enabled in an early phase, total latency can still be measured and TTFT should be labeled unavailable.
-6. Handle malformed Ollama responses as local service errors, not application crashes.
-7. Keep prompt text in request memory only; do not log or persist it.
-
-## NVIDIA telemetry plan
-
-Use `nvidia-smi` because it is already present on many NVIDIA developer workstations and avoids new dependencies.
-
-Planned command shape:
-
-```bash
-nvidia-smi --query-gpu=utilization.gpu,memory.used,memory.total,power.draw,temperature.gpu --format=csv,noheader,nounits
-```
-
-Implementation plan:
-
-1. API route runs `nvidia-smi` server-side with a short timeout.
-2. Parse CSV output into typed telemetry snapshots.
-3. Support multiple GPUs by returning an array, with the UI defaulting to GPU 0 and later allowing selection.
-4. Sample telemetry immediately before, during, and after a prompt run when Phase 5 introduces collection.
-5. Avoid long-running background collectors in the first implementation.
-6. If power draw is unavailable on a GPU, show utilization, memory, and temperature while marking power-derived metrics unavailable.
-7. Do not require admin permissions.
-
-## Graceful failure: Ollama not running
-
-When Ollama is unavailable:
-
-- The page should still render.
-- Status should show `Ollama unavailable` with the configured local URL.
-- Model selector should be disabled or populated with demo models only when demo mode is enabled.
-- Prompt runner should disable real runs and offer mock/demo run if enabled.
-- API routes should return clear JSON errors and appropriate `4xx`/`5xx` statuses without stack traces.
-- The UI should include setup guidance: install/start Ollama, pull a model, refresh status.
-- Metrics from demo mode must be labeled `Demo/mock`, never `Measured`.
-
-## Graceful failure: `nvidia-smi` unavailable
-
-When `nvidia-smi` is missing, fails, times out, or returns unsupported fields:
-
-- The page should still render.
-- GPU panel should show `NVIDIA telemetry unavailable` with a concise reason.
-- Inference runs should still work if Ollama is available.
-- GPU-specific metrics should show unavailable states, not zeroes.
-- Tokens per watt and cost estimates that require watts should be unavailable unless demo/mock mode is active.
-- Mock telemetry can be shown only when demo mode is enabled and must be clearly labeled `Demo/mock`.
-
-## Guardrails
-
-- Local-only by default; no cloud dependency.
-- No secrets, API keys, or external account requirements.
-- No dependency additions in early phases unless explicitly justified later.
-- No persistent prompt storage by default.
-- Run history should initially live in browser memory only.
-- Never store prompt content permanently unless a future opt-in setting is explicitly added.
-- Do not add database migrations until a persistence phase is approved.
-- Do not over-engineer background workers or queues for the local demo.
-- Every generated metric must carry a measured/estimated/configured/derived/demo label.
-- Mock/demo mode must be available for machines without Ollama or NVIDIA GPUs.
-- API routes should sanitize errors and avoid exposing local filesystem paths or stack traces.
-- Keep files under 800 lines.
-
-## Phase roadmap
-
-### Phase 1: Feature shell with static/mock dashboard only
-
-Status: **implemented**.
-
-- Added `/ai-factory-economics` route as an active Phase 1 shell. It is not feature-flag gated because this phase is static/mock only and needs to be directly accessible for local review.
-- Built static dashboard cards with mock values for selected model, time to first token, total latency, estimated tokens/sec, GPU utilization, GPU memory, GPU watts, GPU temperature, estimated tokens per watt, and estimated cost per run.
-- Added local-only notice explaining that no cloud services are required, Phase 1 uses mock data only, and Ollama plus NVIDIA telemetry arrive later.
-- Added setup/readiness and phase-status panels showing Ollama, NVIDIA telemetry, run history, Phase 1, Phase 2, Phase 3, and Phase 5 status.
-- Added a home-page card and left-nav link because existing Partner Hub conventions expose local demo modules from those surfaces when the route is active.
-- No real Ollama calls, `nvidia-smi` calls, API routes, telemetry collectors, prompt execution, persistent storage, database migrations, new frameworks, cloud dependencies, or package dependencies were added.
-
-Phase 1 files added:
-
-```text
-ui/partner-hub/app/(routes)/ai-factory-economics/page.tsx
-ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
-ui/partner-hub/components/ai-factory-economics/executive-summary-cards.tsx
-ui/partner-hub/components/ai-factory-economics/metric-card.tsx
-ui/partner-hub/components/ai-factory-economics/metric-label.tsx
-ui/partner-hub/components/ai-factory-economics/readiness-panel.tsx
-ui/partner-hub/components/ai-factory-economics/phase-status-panel.tsx
-ui/partner-hub/lib/ai-factory-economics/types.ts
-ui/partner-hub/lib/ai-factory-economics/mock-data.ts
-```
-
-Phase 1 files updated:
-
-```text
-docs/AI_FACTORY_ECONOMICS_MODULE.md
-ui/partner-hub/docs/ai-factory-economics.md
-ui/partner-hub/app/page.tsx
-ui/partner-hub/components/left-nav.tsx
-```
-
-Open locally from `ui/partner-hub`:
-
-```bash
-npm run dev
-```
-
-Then visit `http://localhost:3000/partner-hub/ai-factory-economics` when using the default Partner Hub base path.
-
-### Phase 2: Ollama health and model discovery
-
-Status: **implemented**.
-
-- Added local-only health and model API routes.
-- Detects configured local Ollama availability with `AI_FACTORY_OLLAMA_URL` defaulting to `http://127.0.0.1:11434`.
-- Discovers local model names from Ollama `/api/tags` and displays them as read-only measured values.
-- Keeps demo mode fallback and all Phase 1 demo/mock dashboard values visible.
-- Does not execute prompts, stream responses, calculate TTFT, calculate real tokens/sec, call `nvidia-smi`, collect GPU telemetry, persist data, add dependencies, or call cloud services.
-
-### Phase 3: Prompt runner and streaming proxy
-
-Status: **implemented**.
-
-- Added a prompt runner UI that uses discovered local models when available and supports manual model entry when discovery is unavailable.
-- Added a server-side run proxy to local Ollama at `/api/ai-factory-economics/run`.
-- Streams Ollama response chunks to the browser as server-sent events.
-- Supports cancel/stop through `AbortController` without adding persistence or run history.
-- Keeps official TTFT, tokens/sec, real cost/run, and GPU telemetry out of scope until later phases.
-
-### Phase 4: TTFT, latency, token estimate, tokens/sec calculations
-
-Status: **implemented**.
-
-- Added server-side run timing.
-- Computes TTFT from the first streamed Ollama response chunk.
-- Estimates prompt and response tokens with a documented rough local approximation.
-- Derives estimated tokens/sec from estimated response tokens and measured generation duration.
-- Added tests for metric calculations and incomplete/missing-duration behavior.
-
-### Phase 5: NVIDIA telemetry collector using `nvidia-smi`
-
-- Add GPU telemetry API route.
-- Parse `nvidia-smi` CSV output.
-- Display utilization, memory, watts, and temperature.
-- Sample around prompt runs and calculate sampled/estimated power economics.
-
-### Phase 6: Run history and model comparison
-
-- Add in-memory browser run history.
-- Exclude prompt content from stored summaries by default.
-- Compare recent runs by model, latency, throughput, watts, and estimated cost.
-- Add export only if it excludes prompt content by default.
-
-### Phase 7: Executive dashboard polish and recommendations
-
-- Improve summary cards and explanations for executive demos.
-- Add recommendations based on local run patterns.
-- Make assumptions visible and editable where safe.
-- Keep recommendation copy clearly tied to local measurements and estimates.
-
-### Phase 8: Documentation, hardening, validation, and test cleanup
-
-- Update docs with setup and troubleshooting.
-- Harden error handling and timeouts.
-- Add/clean tests for metric math, parsers, and API behavior.
-- Validate no prompt content is persisted by default.
-
-## Known limitations
-
-- Ollama token counts may not match model-specific tokenizer counts unless future phases add exact tokenizer support.
-- `nvidia-smi` availability and fields vary by GPU, driver, operating system, and permissions.
-- GPU telemetry sampling is not equivalent to lab-grade power measurement.
-- Local workstation results should not be presented as production benchmark claims.
-- Browser and server timing can be affected by local system load.
-- Cost estimates depend on configurable assumptions and should be treated as directional.
-- Multi-GPU attribution to a specific Ollama process may be approximate unless future phases add process-level correlation.
-- Apple Silicon, AMD, and CPU-only telemetry are out of the smallest safe initial scope.
-
-## Future enhancement ideas
-
-- Optional exact token accounting if Ollama or model metadata exposes reliable counts.
-- Optional process-level GPU attribution when safe and portable.
-- Optional baseline idle power subtraction.
-- Optional configurable electricity-rate profiles.
-- Optional side-by-side prompt templates for repeatable model comparisons.
-- Optional local-only export of sanitized run summaries.
-- Optional support for non-NVIDIA telemetry providers after the NVIDIA path is stable.
-- Optional guided demo script for partner enablement workshops.
-- Optional static screenshots or mock-data mode for presentations.
-
-## Open questions
-
-- Future phases can decide whether to add `NEXT_PUBLIC_ENABLE_AI_FACTORY_ECONOMICS`; Phase 1 is visible by default because it is static/mock only.
-- Phase 1 includes home-page and left-nav entries because active Partner Hub tool routes are already discoverable through those surfaces.
-- The current mock selected model is `llama3.1:8b-instruct`; discovered and manually entered Phase 3 runtime models are displayed separately from the demo/mock dashboard model.
-- The current static energy-rate display assumption is `$0.16/kWh`; future phases should decide whether this becomes user-configurable.
-- Prompt history remains absent in Phase 1; future phases should keep any run-history work in memory first and continue excluding prompt content from stored summaries by default.
-
-## Phase 4 status
-
-Phase 4 is implemented as measured local Ollama run timing plus estimated response-efficiency metrics. The prompt runner still sends prompts only to local Ollama through the Partner Hub server-side streaming proxy, keeps response content in memory only for the active browser session, and does not add run history or persistent storage.
-
-Phase 4 adds measured TTFT, measured total latency, measured generation duration when Ollama sends `done`, estimated prompt tokens, estimated response tokens, and derived estimated tokens/sec. Token counts use a documented local approximation of roughly four normalized characters per token; they are not exact tokenizer counts.
-
-Phase 4 intentionally does **not** add GPU telemetry, `nvidia-smi` calls, NVIDIA telemetry, watts, tokens/watt from real telemetry, real cost-per-run calculations, run history, persistent storage, prompt persistence, response persistence, database migrations, dependencies, cloud services, secrets, or external APIs.
-
-Phase 4 files added:
-
-```text
-ui/partner-hub/components/ai-factory-economics/run-metrics-panel.tsx
-ui/partner-hub/lib/ai-factory-economics/metrics.ts
-ui/partner-hub/lib/ai-factory-economics/metrics.test.ts
-```
-
-Phase 4 files updated:
-
-```text
-ui/partner-hub/app/api/ai-factory-economics/run/route.ts
-ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
-ui/partner-hub/components/ai-factory-economics/ollama-status-card.tsx
-ui/partner-hub/components/ai-factory-economics/prompt-runner.tsx
-ui/partner-hub/lib/ai-factory-economics/mock-data.ts
-ui/partner-hub/lib/ai-factory-economics/ollama.ts
-ui/partner-hub/lib/ai-factory-economics/types.ts
-ui/partner-hub/lib/ai-factory-economics/mock-data.ts
-ui/partner-hub/package.json
-docs/AI_FACTORY_ECONOMICS_MODULE.md
-ui/partner-hub/docs/ai-factory-economics.md
-```
-
-Phase 4 runtime behavior:
-
-- `/api/ai-factory-economics/run` captures a server-side request start timestamp.
-- The route captures TTFT from request start to the first streamed Ollama response chunk and labels TTFT **Measured**.
-- The route captures completion when Ollama sends `done`; total latency and generation duration are labeled **Measured** when available.
-- Prompt and response token counts are estimated locally and labeled **Estimated**.
-- Tokens/sec is derived from estimated response tokens divided by measured generation duration and labeled **Derived**.
-- The route emits SSE `meta`, `chunk`, `metrics`, `done`, and `error` events.
-- If a stream ends without a `done` event, the route emits an incomplete metrics state and the UI keeps the partial response visible while refusing to mark the run completed.
-- Existing GPU, watts, tokens/watt, and cost/run dashboard cards remain **Demo/mock** or unavailable for live runs.
-- Prompt and response content are not persisted; response text is retained in request/browser memory only long enough to stream and estimate active-run tokens.
-
-Local Phase 4 test flow:
-
-```bash
-cd ui/partner-hub
-ollama serve
-ollama pull llama3.2:3b
-npm run dev
-```
-
-Then open:
-
-```text
-http://localhost:3000/partner-hub/ai-factory-economics
-```
-
-Run a prompt and confirm:
-
-- The response streams into the generated response panel.
-- TTFT appears and is labeled **Measured**.
-- Total latency and generation duration appear after completion and are labeled **Measured**.
-- Prompt and response token counts appear and are labeled **Estimated**.
-- Tokens/sec appears after completion and is labeled **Derived**.
-- GPU telemetry, watts, tokens/watt, and real cost/run remain unavailable for live runs or **Demo/mock** in the dashboard.
-- Prompt and response content are not saved by Partner Hub.
-
-## Phase 5 status
-
-Phase 5 is implemented as local-only NVIDIA GPU telemetry snapshots using `nvidia-smi`. The module now exposes a server-side API route that invokes `nvidia-smi` with safe argument passing, parses one or more GPU rows, and displays a manually refreshable snapshot panel in Partner Hub.
-
-Phase 5 intentionally does **not** add run history, persistent storage, prompt persistence, response persistence, database migrations, dependencies, background daemons, long-running collectors, cloud services, secrets, non-NVIDIA telemetry, per-process GPU attribution, lab-grade power measurement claims, or real cost-per-run calculations from telemetry.
-
-Phase 5 files added:
-
-```text
-ui/partner-hub/app/api/ai-factory-economics/gpu/route.ts
-ui/partner-hub/components/ai-factory-economics/gpu-telemetry-panel.tsx
-ui/partner-hub/lib/ai-factory-economics/gpu.ts
-ui/partner-hub/lib/ai-factory-economics/gpu.test.ts
-```
-
-Phase 5 files updated:
-
-```text
-ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
-ui/partner-hub/lib/ai-factory-economics/mock-data.ts
-ui/partner-hub/lib/ai-factory-economics/ollama.ts
-ui/partner-hub/lib/ai-factory-economics/types.ts
-ui/partner-hub/lib/ai-factory-economics/mock-data.ts
-ui/partner-hub/package.json
-docs/AI_FACTORY_ECONOMICS_MODULE.md
-ui/partner-hub/docs/ai-factory-economics.md
-```
-
-Phase 5 runtime behavior:
-
-- `/api/ai-factory-economics/gpu` runs only in the Next.js Node.js runtime and never from client-side code.
-- The GPU helper invokes `nvidia-smi` with `execFile`/argument-array semantics, not string-shell execution.
-- The query is `index,utilization.gpu,memory.used,memory.total,power.draw,temperature.gpu` with `--format=csv,noheader,nounits`.
-- A short timeout prevents long-running telemetry calls.
-- One or more GPU rows are parsed into snapshots; the UI defaults to the first row/GPU 0 snapshot.
-- Empty output, missing `nvidia-smi`, timeouts, unsupported queries, and unexpected command failures return clean UI-facing unavailable states without stack traces.
-- Missing fields are represented as `null` and shown as **Unavailable**, never as zero.
-- The health route remains high-level and points to the dedicated GPU snapshot endpoint instead of duplicating full telemetry logic.
-
-Phase 5 metric labeling:
-
-- GPU telemetry availability is **Measured** by the local snapshot endpoint.
-- GPU utilization is **Measured** when returned by `nvidia-smi`.
-- GPU memory used and total are **Measured** when returned by `nvidia-smi`.
-- GPU watts/power draw is **Measured** when returned by `nvidia-smi`.
-- GPU temperature is **Measured** when returned by `nvidia-smi`.
-- Tokens/watt remains unavailable for active runs in Phase 5.
-- Existing static dashboard economics can remain **Demo/mock** until later phases wire them to sampled live values.
-
-Local Phase 5 test flow:
-
-```bash
-cd ui/partner-hub
-nvidia-smi
-ollama serve
-ollama pull llama3.2:3b
-npm run dev
-```
-
-Then open:
-
-```text
-http://localhost:3000/partner-hub/ai-factory-economics
-```
-
-Confirm:
-
-1. NVIDIA drivers are installed and `nvidia-smi` works manually.
-2. The GPU telemetry panel can be refreshed.
-3. Utilization, memory used/total, watts, temperature, GPU index, availability, and sample timestamp appear when available.
-4. If `nvidia-smi` is missing, times out, is unsupported, or returns unexpected data, the panel shows a safe unavailable state.
-5. Prompt runner behavior is unchanged and still works without GPU telemetry.
-6. No run history is created.
-7. Prompt and response content are not persisted.
-8. No database migrations or persistent stores are added.
-9. Telemetry is snapshot-based, not lab-grade power measurement.
-10. Multi-GPU attribution to a specific Ollama process remains out of scope.
-
-Verification commands from `ui/partner-hub`:
-
-```bash
-npm run typecheck
-npm test
-npm run lint
-```
-
-## Phase 6 in-memory run history and model comparison
-
-Phase 6 is implemented as browser-memory-only sanitized run history and derived model comparison for `/ai-factory-economics`. It does not add persistent storage, localStorage, database migrations, backend storage, cloud services, new dependencies, background daemons, long-running collectors, exact tokenizers, exact per-process GPU attribution, or lab-grade power measurement.
-
-Files added in Phase 6:
-
-```text
-ui/partner-hub/lib/ai-factory-economics/history.ts
-ui/partner-hub/lib/ai-factory-economics/history.test.ts
-ui/partner-hub/components/ai-factory-economics/run-history-panel.tsx
-ui/partner-hub/components/ai-factory-economics/model-comparison-table.tsx
-```
-
-Files updated in Phase 6:
-
-```text
-ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
-ui/partner-hub/components/ai-factory-economics/prompt-runner.tsx
-ui/partner-hub/lib/ai-factory-economics/types.ts
-ui/partner-hub/lib/ai-factory-economics/mock-data.ts
-ui/partner-hub/package.json
-docs/AI_FACTORY_ECONOMICS_MODULE.md
-ui/partner-hub/docs/ai-factory-economics.md
-```
-
-### What Phase 6 stores
-
-Phase 6 stores only sanitized run summaries in React state owned by the AI Factory Economics tool. The history length is limited to the most recent 20 runs and is cleared by page reload or by the **Clear in-memory history** button.
-
-Run summaries may include:
-
-- Generated run summary id.
-- Started and completed timestamps.
-- Local model name.
-- Terminal run status: completed, failed, canceled, or incomplete.
-- TTFT, total latency, and generation duration when available (**Measured**).
-- Estimated prompt tokens and estimated response tokens when supplied by the run metrics stream (**Estimated**).
-- Estimated tokens/sec when available (**Derived**).
-- Metric classification labels.
-- A note that prompt and response content are excluded.
-- Optional shape for sampled GPU snapshot summaries, labeled as measured snapshot telemetry only; Phase 6 does not wire GPU snapshots into run summaries yet to avoid unnecessary coupling.
-
-Run summaries do **not** include prompt text, response text, generated answers, raw request bodies, raw stream chunks, raw local filesystem paths, raw stack traces, secrets, or API keys.
-
-### Model comparison behavior
-
-The model comparison table aggregates the current in-memory run history by model and shows:
-
-- Run count.
-- Completed count.
-- Failed, canceled, and incomplete counts.
-- Average TTFT.
-- Average total latency.
-- Average estimated tokens/sec.
-- Best estimated tokens/sec.
-- Fastest TTFT.
-- Most recent run timestamp.
-
-All model comparison values are labeled **Derived**. Missing metric values are excluded from averages and are never substituted with zero. If no valid value exists, the UI shows **Unavailable**.
-
-### Phase 6 metric labels
-
-- TTFT remains **Measured**.
-- Total latency remains **Measured**.
-- Generation duration remains **Measured**.
-- Prompt tokens remain **Estimated**.
-- Response tokens remain **Estimated**.
-- Tokens/sec remains **Derived**.
-- Model comparison aggregates are **Derived**.
-- GPU telemetry remains **Measured** only as refresh-time snapshot telemetry and is not exact per-run attribution.
-- Demo/mock dashboard economics remain **Demo/mock**.
-
-### Local Phase 6 test flow
+## Setup and local run instructions
 
 From `ui/partner-hub`:
 
 ```bash
-ollama serve
-ollama pull llama3.2:3b
+npm install
 npm run dev
 ```
 
-Then open:
+Open `http://localhost:3000/partner-hub/ai-factory-economics`.
+
+Optional local environment variables:
 
 ```text
-http://localhost:3000/partner-hub/ai-factory-economics
+AI_FACTORY_OLLAMA_URL=http://127.0.0.1:11434
+NEXT_PUBLIC_BASE_PATH=/partner-hub
 ```
 
-Manual verification steps:
+### Ollama setup
 
-1. Start Ollama.
+1. Install Ollama from the official Ollama distribution for your workstation.
+2. Start Ollama:
+
+   ```bash
+   ollama serve
+   ```
+
+3. Pull a local model:
+
+   ```bash
+   ollama pull llama3.2:3b
+   ```
+
+4. Verify model discovery directly:
+
+   ```bash
+   curl http://127.0.0.1:11434/api/tags
+   ```
+
+5. Refresh the Partner Hub Ollama status/model cards.
+
+### NVIDIA telemetry setup
+
+GPU telemetry is optional. Verify NVIDIA tooling first:
+
+```bash
+nvidia-smi
+```
+
+When available, Partner Hub samples:
+
+```bash
+nvidia-smi --query-gpu=index,utilization.gpu,memory.used,memory.total,power.draw,temperature.gpu --format=csv,noheader,nounits
+```
+
+Unavailable states are expected on machines without an NVIDIA GPU, missing drivers, unsupported fields, timeout, empty output, or missing `nvidia-smi`. The prompt runner and demo dashboard continue to work when GPU telemetry is unavailable. Missing GPU values display as **Unavailable**, not zero.
+
+## How to run a prompt
+
+1. Start Partner Hub and Ollama.
 2. Pull at least one local model.
-3. Run Partner Hub.
-4. Open `/partner-hub/ai-factory-economics`.
-5. Run several prompts across one or more local models.
-6. Confirm recent sanitized run summaries appear.
-7. Confirm model comparison aggregates appear and are labeled **Derived**.
-8. Confirm prompt and response content remain visible only for the active run and are not stored in history.
-9. Confirm **Clear in-memory history** clears only the browser-memory history.
-10. Refresh the page and confirm history disappears.
-11. Confirm Ollama unavailable and incomplete stream states remain graceful and do not expose stack traces.
+3. Open the AI Factory Economics page.
+4. Choose a discovered model or enter a local model name manually.
+5. Enter a prompt within the local demo character limit.
+6. Click **Run local prompt**.
+7. Read the streamed response and metrics panel.
+8. Use **Cancel** to abort an in-flight browser request, or **Reset / clear** to clear active prompt/output UI state.
 
-Verification commands from `ui/partner-hub`:
+The app does not persist prompt text or response text. Sanitized run summaries may be added to browser memory after terminal run states, but they contain model/status/metric metadata only.
+
+## How to compare models safely
+
+Run the same or similar prompt against two or more local models in the same browser session. The comparison table and executive recommendations are **Derived** from the current sanitized in-memory summaries. Treat results as directional local demo evidence only, not a production benchmark, procurement result, or business proof.
+
+## Metric definitions and labels
+
+| Label | Meaning |
+| --- | --- |
+| **Measured** | Directly observed from local service responses, server-side timing, browser run state, or `nvidia-smi` snapshot output. |
+| **Estimated** | Rough approximation, currently used for prompt/response token counts. |
+| **Derived** | Calculated from measured and/or estimated values, such as estimated tokens/sec, model comparisons, scorecards, and recommendations. |
+| **Configured** | Static local assumptions, setup values, or caveats. |
+| **Demo/mock** | Non-live dashboard economics retained for demonstration/future-work context. |
+
+| Metric | Definition | Label |
+| --- | --- | --- |
+| TTFT | Time from server-side run start to the first streamed Ollama response chunk. | Measured when a first chunk is received; otherwise unavailable. |
+| Total latency | Time from server-side run start to Ollama completion when a done signal is received. | Measured; unavailable for incomplete streams. |
+| Generation duration | Time from first streamed response chunk to Ollama completion. | Measured; unavailable without both timestamps. |
+| Estimated prompt tokens | Rough four-normalized-characters-per-token prompt approximation. | Estimated, not exact tokenizer output. |
+| Estimated response tokens | Rough four-normalized-characters-per-token response approximation. | Estimated, not exact tokenizer output. |
+| Estimated tokens/sec | Estimated response tokens divided by measured generation duration. | Derived; unavailable without generation duration. |
+| GPU utilization | Current utilization from `nvidia-smi`. | Measured snapshot; unavailable if missing/unsupported. |
+| GPU memory | Current used and total framebuffer memory from `nvidia-smi`. | Measured snapshot; unavailable if missing/unsupported. |
+| GPU watts | Current power draw from `nvidia-smi`. | Measured snapshot, not lab-grade wall power. |
+| GPU temperature | Current GPU temperature from `nvidia-smi`. | Measured snapshot. |
+| Tokens/watt | Not a real measured Phase 8 metric. | Demo/mock or unavailable until explicitly approved future instrumentation. |
+| Cost/run | Not a real measured Phase 8 metric. | Demo/mock/future work unless safe assumptions are explicitly added later. |
+
+## Privacy and storage statement
+
+- Prompt content is not stored in run history.
+- Response content is not stored in run history.
+- Prompt/response text exists only in request/browser memory for the active run UI.
+- Run summaries are browser-memory only and disappear on reload or clear-history.
+- No `localStorage`, `sessionStorage`, or IndexedDB is used by this module.
+- No database tables, migrations, backend persistence, exports, or cloud storage are added.
+
+## Troubleshooting
+
+| Symptom | Safe interpretation and action |
+| --- | --- |
+| Ollama not running | Start `ollama serve`, confirm `AI_FACTORY_OLLAMA_URL`, then refresh status. |
+| No models discovered | Run `ollama pull <model>` and verify `curl http://127.0.0.1:11434/api/tags`. Manual model entry remains available. |
+| Model not found | Pull the model locally or correct the manual model name. Validation rejects empty, overlong, or control-character model names. |
+| Stream ends without done signal | The UI marks the run incomplete; partial output remains visible but should not be treated as a complete benchmark. |
+| `nvidia-smi` not found | GPU telemetry shows unavailable. Install NVIDIA drivers/tooling or continue without GPU telemetry. |
+| GPU fields unavailable | Unsupported or blank fields display as unavailable, not zero. |
+| Type/test/lint failures | Run the verification commands below from `ui/partner-hub` and inspect the exact error output. |
+
+Verification commands:
 
 ```bash
 npm run typecheck
@@ -754,47 +157,26 @@ npm test
 npm run lint
 ```
 
-## Phase 7: executive dashboard polish and safe recommendations
+## Phase 8 guardrail audit
 
-Phase 7 is implemented as a local-only UI/interpretation polish phase for `/partner-hub/ai-factory-economics`. It adds executive scorecards, safe recommendations, and clearer demo caveats without telemetry sources, background collection, persistence, backend storage, migrations, cloud services, secrets, dependencies, or cost-per-run calculations.
+- No AI Factory file exceeds 800 lines.
+- No storage was added.
+- No prompt/response persistence was added.
+- No `localStorage`, `sessionStorage`, or IndexedDB was added.
+- No database code or migrations were added for this module.
+- No cloud calls, secrets, API keys, or new dependencies were added.
+- GPU telemetry remains optional NVIDIA `nvidia-smi` snapshot-only data.
+- Token counts remain rough estimates.
+- Scorecards and recommendations remain derived local demo guidance.
+- The module does not claim production benchmark validity, exact token counts, lab-grade power measurement, or exact per-run GPU attribution.
 
-### Files added in Phase 7
+## Remaining future work
 
-- `ui/partner-hub/lib/ai-factory-economics/insights.ts`
-- `ui/partner-hub/lib/ai-factory-economics/insights.test.ts`
-- `ui/partner-hub/components/ai-factory-economics/executive-insights-panel.tsx`
+Only if explicitly approved later:
 
-### Files updated in Phase 7
-
-- `ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx`
-- `ui/partner-hub/lib/ai-factory-economics/types.ts`
-- `ui/partner-hub/lib/ai-factory-economics/mock-data.ts`
-- `ui/partner-hub/package.json`
-- `ui/partner-hub/docs/ai-factory-economics.md`
-- `docs/AI_FACTORY_ECONOMICS_MODULE.md`
-
-### Runtime behavior and labels
-
-- The header identifies **Local-only Phase 7** and explains measured local runtime, estimated token counts, derived model comparison/recommendations, and no persisted prompt or response content.
-- A new executive insights panel appears after the existing demo/mock executive summary cards and explains what the local demo proves.
-- Scorecards are **Derived** and transparent: runs compared, best average TTFT, best average estimated tokens/sec, completion rate, and telemetry coverage.
-- Missing metrics display as unavailable and are never treated as zero.
-- Recommendations are **Derived** from current sanitized in-memory history and can identify fastest average TTFT, highest average estimated throughput, highest completion rate, or a completion warning.
-- Static caveats and demo narration guidance are **Configured**.
-- Demo economics remain **Demo/mock**; direct Ollama/model/runtime observations remain **Measured**; token counts remain **Estimated**; tokens/sec remains **Derived**.
-- GPU telemetry remains **Measured** only as a point-in-time NVIDIA `nvidia-smi` snapshot when available. It is not exact per-run attribution, per-process attribution, or lab-grade wall-power measurement.
-- The page is grouped as executive view, local readiness, prompt running, learning from runs, and readiness/phase status without rebuilding unrelated components.
-
-### Local manual test flow
-
-1. Start Ollama: `ollama serve`.
-2. Pull one or more local models, for example `ollama pull llama3.2:3b`.
-3. Run Partner Hub from `ui/partner-hub`: `npm run dev`.
-4. Open `http://localhost:3000/partner-hub/ai-factory-economics`.
-5. Run several prompts, ideally with the same prompt across two local models.
-6. Confirm executive insights appear, recommendations are labeled **Derived**, prompt/response content is not stored, history disappears on reload, GPU telemetry remains snapshot-only, and no production benchmark claims are made.
-
-Verification commands from `ui/partner-hub`: `npm run typecheck`, `npm test`, and `npm run lint`.
-
-### Phase 7 guardrails
-Phase 7 keeps all prior local-only guardrails. It does not persist prompt content, persist response content, use localStorage/sessionStorage/IndexedDB, add database/backend storage, add migrations, add dependencies, add cloud services, add background collectors, add non-NVIDIA telemetry, claim exact tokenizer counts, claim lab-grade power measurement, claim exact per-run GPU attribution, or claim production benchmark validity.
+- Optional export of sanitized summaries that still excludes prompt/response content.
+- Optional exact tokenizer support without cloud calls or content persistence.
+- Optional configurable electricity rate.
+- Optional baseline idle power subtraction.
+- Optional non-NVIDIA telemetry.
+- Optional persistence with explicit privacy, storage, and migration approval.

--- a/ui/partner-hub/app/api/ai-factory-economics/gpu/route.ts
+++ b/ui/partner-hub/app/api/ai-factory-economics/gpu/route.ts
@@ -11,7 +11,7 @@ export async function GET() {
   return NextResponse.json(result, {
     status: result.ok ? 200 : 503,
     headers: {
-      "Cache-Control": "no-store",
+      "Cache-Control": "no-store, no-cache",
     },
   });
 }

--- a/ui/partner-hub/app/api/ai-factory-economics/health/route.ts
+++ b/ui/partner-hub/app/api/ai-factory-economics/health/route.ts
@@ -11,7 +11,7 @@ export async function GET() {
   return NextResponse.json(health, {
     status: health.ok ? 200 : 503,
     headers: {
-      "Cache-Control": "no-store",
+      "Cache-Control": "no-store, no-cache",
     },
   });
 }

--- a/ui/partner-hub/app/api/ai-factory-economics/models/route.ts
+++ b/ui/partner-hub/app/api/ai-factory-economics/models/route.ts
@@ -11,7 +11,7 @@ export async function GET() {
   return NextResponse.json(result, {
     status: result.ok ? 200 : 503,
     headers: {
-      "Cache-Control": "no-store",
+      "Cache-Control": "no-store, no-cache",
     },
   });
 }

--- a/ui/partner-hub/app/api/ai-factory-economics/run/route.ts
+++ b/ui/partner-hub/app/api/ai-factory-economics/run/route.ts
@@ -110,13 +110,13 @@ export async function POST(request: Request) {
 
       send("meta", {
         ok: true,
-        phase: "Phase 5",
+        phase: "Phase 8",
         model: validation.request.model,
         baseUrl: getAiFactoryOllamaBaseUrl(),
         classification: "Measured",
         economicsClassification: "Demo/mock",
         message:
-          "Streaming response timing is measured from local Ollama. Prompt and response tokens are estimated; tokens/sec is derived. GPU snapshots are separate from this run stream; tokens/watt and real cost telemetry are not included in Phase 5.",
+          "Streaming response timing is measured from local Ollama. Prompt and response tokens are estimated; tokens/sec is derived. GPU snapshots are separate from this run stream; tokens/watt and real cost telemetry are not included in Phase 8.",
       });
 
       try {
@@ -163,7 +163,7 @@ export async function POST(request: Request) {
                 status: "completed",
                 classification: "Measured",
                 message:
-                  "Prompt run completed with Phase 5 measured timing, estimated token counts, and derived throughput. GPU snapshots remain separate; tokens/watt and real cost/run remain unavailable.",
+                  "Prompt run completed with Phase 8 measured timing, estimated token counts, and derived throughput. GPU snapshots remain separate; tokens/watt and real cost/run remain unavailable.",
               });
             }
           }
@@ -192,7 +192,7 @@ export async function POST(request: Request) {
                   status: "completed",
                   classification: "Measured",
                   message:
-                    "Prompt run completed with Phase 5 measured timing, estimated token counts, and derived throughput. GPU snapshots remain separate; tokens/watt and real cost/run remain unavailable.",
+                    "Prompt run completed with Phase 8 measured timing, estimated token counts, and derived throughput. GPU snapshots remain separate; tokens/watt and real cost/run remain unavailable.",
                 });
               }
             }
@@ -222,7 +222,7 @@ export async function POST(request: Request) {
 
   return new Response(stream, {
     headers: {
-      "Cache-Control": "no-cache, no-transform",
+      "Cache-Control": "no-store, no-cache, no-transform",
       Connection: "keep-alive",
       "Content-Type": "text/event-stream; charset=utf-8",
       "X-Content-Type-Options": "nosniff",

--- a/ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
+++ b/ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
@@ -34,14 +34,14 @@ export function AiFactoryEconomicsTool() {
         <div className="relative grid gap-8 lg:grid-cols-[1.25fr_0.75fr] lg:items-end">
           <div className="space-y-5">
             <div className="inline-flex rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-white/80">
-              Local-only Phase 7
+              Local-only Phase 8
             </div>
             <div className="space-y-3">
               <h1 className="text-3xl font-semibold tracking-tight md:text-5xl">
                 AI Factory Economics
               </h1>
               <p className="max-w-3xl text-sm leading-relaxed text-white/75 md:text-base">
-                Phase 7 turns the local AI Factory demo into an executive-ready
+                Phase 8 turns the local AI Factory demo into an executive-ready
                 view: measured local runtime, estimated token counts, derived
                 model comparison/recommendations, and no persisted prompt or
                 response content.
@@ -90,7 +90,7 @@ export function AiFactoryEconomicsTool() {
                 secrets, or external APIs are required.
               </p>
               <p>
-                Phase 7 adds executive scorecards and safe Derived
+                Phase 8 adds executive scorecards and safe Derived
                 recommendations from current in-memory summaries. Demo/mock
                 economics remain visible; GPU telemetry is optional snapshot
                 data and is not exact per-run attribution.

--- a/ui/partner-hub/components/ai-factory-economics/executive-insights-panel.tsx
+++ b/ui/partner-hub/components/ai-factory-economics/executive-insights-panel.tsx
@@ -55,7 +55,7 @@ export function ExecutiveInsightsPanel({ runs }: ExecutiveInsightsPanelProps) {
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground/50">
-              Executive view · Phase 7
+              Executive view · Phase 8
             </p>
             <CardTitle className="mt-1 flex items-center gap-2 text-2xl">
               <Lightbulb className="h-6 w-6 text-primary" aria-hidden />
@@ -189,7 +189,7 @@ export function ExecutiveInsightsPanel({ runs }: ExecutiveInsightsPanelProps) {
                 </span>{" "}
                 No production benchmark claims, no persisted prompt/response
                 content, no backend storage, and no database persistence are
-                part of this Phase 7 panel.
+                part of this Phase 8 panel.
               </span>
             </li>
           </ul>

--- a/ui/partner-hub/components/ai-factory-economics/gpu-telemetry-panel.tsx
+++ b/ui/partner-hub/components/ai-factory-economics/gpu-telemetry-panel.tsx
@@ -130,7 +130,7 @@ export function GpuTelemetryPanel() {
             <div className="rounded-xl border border-dashed border-border bg-muted/30 p-4 text-xs">
               <p className="font-semibold text-foreground">Snapshot guardrails</p>
               <p className="mt-1">
-                Phase 5 samples nvidia-smi only on refresh. It does not persist telemetry, does not create run history, does not
+                Phase 8 samples nvidia-smi only on refresh. It does not persist telemetry, does not create run history, does not
                 attribute GPU power to a specific Ollama process, and does not claim lab-grade power measurement.
               </p>
             </div>

--- a/ui/partner-hub/components/ai-factory-economics/ollama-status-card.tsx
+++ b/ui/partner-hub/components/ai-factory-economics/ollama-status-card.tsx
@@ -79,12 +79,12 @@ export function OllamaStatusCard() {
           </div>
           <div className="rounded-xl border border-border/60 bg-background p-3">
             <p className="text-xs font-semibold uppercase tracking-wide text-foreground/50">NVIDIA telemetry</p>
-            <p className="mt-1 font-semibold text-foreground">GPU snapshots separate in Phase 5</p>
+            <p className="mt-1 font-semibold text-foreground">GPU snapshots separate in Phase 8</p>
           </div>
         </div>
 
         <p>
-          Phase 5 checks health, discovers local models, streams prompt responses, measures TTFT/latency, estimates token counts,
+          Phase 8 checks health, discovers local models, streams prompt responses, measures TTFT/latency, estimates token counts,
           derives tokens/sec, and exposes GPU telemetry in a separate snapshot panel. It still does not calculate tokens/watt or real cost/run.
         </p>
 

--- a/ui/partner-hub/components/ai-factory-economics/prompt-runner.tsx
+++ b/ui/partner-hub/components/ai-factory-economics/prompt-runner.tsx
@@ -159,7 +159,7 @@ export function PromptRunner({ onRunSummary }: PromptRunnerProps) {
     if (trimmedPrompt.length > promptMaxLength) {
       setStatus("failed");
       setError(
-        `Prompts must be ${promptMaxLength.toLocaleString()} characters or fewer for Phase 6.`,
+        `Prompts must be ${promptMaxLength.toLocaleString()} characters or fewer for Phase 8.`,
       );
       return;
     }
@@ -313,7 +313,7 @@ export function PromptRunner({ onRunSummary }: PromptRunnerProps) {
             </p>
             <CardTitle className="mt-1 flex items-center gap-2 text-xl">
               <Terminal className="h-5 w-5 text-primary" aria-hidden />
-              Phase 6 prompt runner
+              Phase 8 prompt runner
             </CardTitle>
           </div>
           <MetricLabel classification="Measured" />
@@ -321,13 +321,13 @@ export function PromptRunner({ onRunSummary }: PromptRunnerProps) {
       </CardHeader>
       <CardContent className="space-y-5 text-sm leading-relaxed text-foreground/70">
         <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-amber-800 dark:text-amber-200">
-          <p className="font-semibold">Phase 6 boundary</p>
+          <p className="font-semibold">Phase 8 boundary</p>
           <p className="mt-1">
             This runner sends prompts only to local Ollama, streams the response
             into this browser session, measures server-side TTFT and latency,
             estimates token counts, derives tokens/sec, and records sanitized
             in-memory run summaries. GPU telemetry, watts, tokens/watt, and real
-            cost/run are not exact per-run values in Phase 6. Prompt and
+            cost/run are not exact per-run values in Phase 8. Prompt and
             response content are not persisted by the app or stored in history.
           </p>
         </div>
@@ -452,7 +452,7 @@ export function PromptRunner({ onRunSummary }: PromptRunnerProps) {
             </p>
             <MetricLabel classification="Measured" />
             <span className="text-xs text-foreground/50">
-              Runtime response content only; Phase 6 history stores sanitized
+              Runtime response content only; Phase 8 history stores sanitized
               metrics/metadata without prompt or response content.
             </span>
           </div>

--- a/ui/partner-hub/components/ai-factory-economics/run-history-panel.tsx
+++ b/ui/partner-hub/components/ai-factory-economics/run-history-panel.tsx
@@ -51,7 +51,7 @@ export function RunHistoryPanel({
             Prompt and response content are not stored.
           </p>
           <p className="mt-1">
-            Phase 6 stores sanitized run summaries in React/browser memory only.
+            Phase 8 stores sanitized run summaries in React/browser memory only.
             History disappears on page reload and never uses localStorage, a
             database, or backend storage.
           </p>

--- a/ui/partner-hub/components/ai-factory-economics/run-metrics-panel.tsx
+++ b/ui/partner-hub/components/ai-factory-economics/run-metrics-panel.tsx
@@ -71,7 +71,7 @@ function displayMetrics(metrics: AiFactoryRunMetrics | null, status: AiFactoryRu
       label: "Prompt tokens",
       value: formatTokenCount(metrics.estimatedPromptTokens),
       classification: metrics.classifications.promptTokens,
-      help: "Estimated; Phase 5 does not add an exact tokenizer dependency.",
+      help: "Estimated; Phase 8 does not add an exact tokenizer dependency.",
     },
     {
       label: "Response tokens",
@@ -96,7 +96,7 @@ export function RunMetricsPanel({ metrics, status }: RunMetricsPanelProps) {
     <div className="space-y-3 rounded-xl border border-border/70 bg-muted/20 p-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">Phase 5 local run metrics</p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-foreground/60">Phase 8 local run metrics</p>
           <p className="mt-1 text-xs text-foreground/55">
             Local-only Ollama timing is measured on the server. Token counts are estimates; throughput is derived.
           </p>
@@ -131,7 +131,7 @@ export function RunMetricsPanel({ metrics, status }: RunMetricsPanelProps) {
         <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-amber-800 dark:text-amber-200">
           <p className="text-xs font-semibold uppercase tracking-wide">Telemetry boundary</p>
           <p className="mt-1 text-xs">
-            GPU telemetry is displayed as a separate snapshot panel in Phase 5; tokens/watt and real cost/run remain unavailable for live runs.
+            GPU telemetry is displayed as a separate snapshot panel in Phase 8; tokens/watt and real cost/run remain unavailable for live runs.
           </p>
         </div>
       </div>

--- a/ui/partner-hub/docs/ai-factory-economics-quickstart.md
+++ b/ui/partner-hub/docs/ai-factory-economics-quickstart.md
@@ -1,0 +1,43 @@
+# AI Factory Economics quickstart
+
+Canonical plan and guardrails: [`../../../docs/AI_FACTORY_ECONOMICS_MODULE.md`](../../../docs/AI_FACTORY_ECONOMICS_MODULE.md).
+
+## 1. Start Partner Hub
+
+```bash
+cd ui/partner-hub
+npm install
+npm run dev
+```
+
+Open `http://localhost:3000/partner-hub/ai-factory-economics`.
+
+## 2. Start Ollama
+
+```bash
+ollama serve
+ollama pull llama3.2:3b
+curl http://127.0.0.1:11434/api/tags
+```
+
+Refresh the Ollama cards on the page. You can also enter a local model name manually.
+
+## 3. Optional NVIDIA snapshot telemetry
+
+```bash
+nvidia-smi
+```
+
+If unavailable, the GPU panel should fail gracefully and the prompt runner still works.
+
+## 4. Run a prompt safely
+
+Choose a local model, enter a prompt, and click **Run local prompt**. Prompt and response content are not persisted; history is sanitized browser memory only and clears on reload.
+
+## 5. Verify changes
+
+```bash
+npm run typecheck
+npm test
+npm run lint
+```

--- a/ui/partner-hub/docs/ai-factory-economics.md
+++ b/ui/partner-hub/docs/ai-factory-economics.md
@@ -1,326 +1,116 @@
-# AI Factory Economics
+# Partner Hub AI Factory Economics
 
-The canonical architecture and roadmap plan for this local-only AI FinOps / AI Factory Economics module lives at:
+AI Factory Economics is a local-only Partner Hub demo module for explaining workstation AI economics safely. Phase 8 is the final hardening/documentation pass. The canonical project plan and guardrail audit live at [`../../../docs/AI_FACTORY_ECONOMICS_MODULE.md`](../../../docs/AI_FACTORY_ECONOMICS_MODULE.md).
 
-```text
-../../../docs/AI_FACTORY_ECONOMICS_MODULE.md
-```
+## What the module does
 
-Use that root-level plan as the source of truth for the module purpose, guardrails, metric definitions, local-only architecture, and implementation phases.
+- Keeps the original demo/mock economics dashboard available.
+- Checks a local Ollama service and discovers models from `/api/tags`.
+- Streams local prompt runs through Partner Hub to Ollama `/api/generate`.
+- Measures TTFT, total latency, and generation duration when stream timing supports them.
+- Estimates prompt/response token counts with a rough local approximation.
+- Derives estimated tokens/sec, model comparison, executive scorecards, and recommendations from sanitized in-memory summaries.
+- Optionally samples local NVIDIA GPU telemetry with server-side `nvidia-smi`.
 
-This pointer exists so the module is discoverable from the existing Partner Hub docs area alongside the other local demo module documentation.
-
-## Current status
-
-- Phase 4 is implemented as local-only Ollama prompt streaming with measured run timing, estimated token counts, and derived throughput.
-- The page is available at `/ai-factory-economics`; with the default Partner Hub base path, open `http://localhost:3000/partner-hub/ai-factory-economics`.
-- The feature keeps the Phase 1 demo/mock dashboard economics visible.
-- The page shows measured local Ollama readiness and measured discovered local model names when Ollama is available.
-- The Phase 4 prompt runner lets a user choose a discovered model or enter a model manually, enter a prompt, submit it to local Ollama, stream the response into the browser, and see TTFT/latency/token-efficiency metrics.
-- The page still renders gracefully when Ollama is not running, when `/api/tags` fails, or when the run endpoint cannot reach local Ollama.
-- NVIDIA telemetry is explicitly shown as not connected in Phase 4.
-- Phase 4 measures TTFT and latency, estimates prompt/response tokens, and derives tokens/sec, but still does not calculate real cost per run, call `nvidia-smi`, collect GPU telemetry, measure watts or tokens/watt, persist prompt content, persist response content, add run history, add dependencies, add database migrations, or call cloud services.
-
-## Files added or updated in Phase 4
-
-Added:
+## Architecture and guardrails
 
 ```text
-ui/partner-hub/components/ai-factory-economics/run-metrics-panel.tsx
-ui/partner-hub/lib/ai-factory-economics/metrics.ts
-ui/partner-hub/lib/ai-factory-economics/metrics.test.ts
+Browser page
+  -> /api/ai-factory-economics/health  -> http://127.0.0.1:11434/api/tags by default
+  -> /api/ai-factory-economics/models  -> http://127.0.0.1:11434/api/tags by default
+  -> /api/ai-factory-economics/run     -> http://127.0.0.1:11434/api/generate by default
+  -> /api/ai-factory-economics/gpu     -> nvidia-smi via server-side execFile
 ```
 
-Updated:
+The module has no cloud calls, no secrets, no database, no migrations, no backend storage, no `localStorage`, no `sessionStorage`, no IndexedDB, no new dependencies, no background collectors, and no prompt/response persistence.
 
-```text
-ui/partner-hub/app/api/ai-factory-economics/run/route.ts
-ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
-ui/partner-hub/components/ai-factory-economics/ollama-status-card.tsx
-ui/partner-hub/components/ai-factory-economics/prompt-runner.tsx
-ui/partner-hub/lib/ai-factory-economics/mock-data.ts
-ui/partner-hub/lib/ai-factory-economics/ollama.ts
-ui/partner-hub/lib/ai-factory-economics/types.ts
-ui/partner-hub/lib/ai-factory-economics/mock-data.ts
-ui/partner-hub/package.json
-docs/AI_FACTORY_ECONOMICS_MODULE.md
-ui/partner-hub/docs/ai-factory-economics.md
-```
+## Quick setup
 
-## Local Ollama configuration
-
-The AI Factory Economics API routes are local-only and never call cloud services. Configure Ollama with:
+From `ui/partner-hub`:
 
 ```bash
-AI_FACTORY_OLLAMA_URL=http://127.0.0.1:11434
-```
-
-If the variable is not set, the module defaults to:
-
-```text
-http://127.0.0.1:11434
-```
-
-## Local development and testing
-
-From `ui/partner-hub`, run:
-
-```bash
+npm install
 npm run dev
 ```
 
-Then open:
+Open:
 
 ```text
 http://localhost:3000/partner-hub/ai-factory-economics
 ```
 
-If `NEXT_PUBLIC_BASE_PATH` is changed, keep using the same internal route (`/ai-factory-economics`) under that configured base path.
+Optional local configuration:
 
-To test Phase 4 with local Ollama:
+```text
+AI_FACTORY_OLLAMA_URL=http://127.0.0.1:11434
+NEXT_PUBLIC_BASE_PATH=/partner-hub
+```
+
+## Ollama setup
 
 ```bash
 ollama serve
 ollama pull llama3.2:3b
-npm run dev
+curl http://127.0.0.1:11434/api/tags
 ```
 
-Then:
+If `/api/tags` returns models, refresh the Ollama status/model cards. If discovery is empty, pull a model or use manual local model entry after confirming the model exists.
 
-1. Open `http://localhost:3000/partner-hub/ai-factory-economics`.
-2. Verify the Ollama status card reports the configured local URL.
-3. Select a discovered model in the Phase 4 prompt runner, or choose manual entry and enter a local model name such as `llama3.2:3b`.
-4. Enter a prompt.
-5. Click **Run local prompt**.
-6. Verify the generated response streams into the response panel.
-7. Confirm TTFT and total latency appear as **Measured**, prompt/response token counts appear as **Estimated**, and tokens/sec appears as **Derived**.
-8. Confirm GPU telemetry, watts, tokens/watt, and real cost/run remain unavailable or demo/mock.
-9. Optionally click **Cancel** during a run to abort the browser request with `AbortController`.
-10. Click **Reset / clear** to clear in-memory prompt and response UI state.
+## Optional NVIDIA telemetry
 
-Verification commands from `ui/partner-hub`:
-
-```bash
-npm run typecheck
-npm test
-npm run lint
-```
-
-## Graceful fallback behavior
-
-If Ollama is not running, the page should show an “Ollama unavailable” state with the configured local URL and setup guidance:
-
-- Start Ollama.
-- Pull a model with `ollama pull <model>`.
-- Refresh the page/status.
-
-If `/api/tags` returns no models, the model discovery card and prompt runner show setup guidance while the demo/mock dashboard remains visible. The prompt runner still allows manual model entry so users can run a model immediately after pulling it.
-
-If `/api/ai-factory-economics/run` receives invalid input, it returns graceful JSON validation errors without stack traces. If local Ollama is unavailable, the route returns a safe JSON error before streaming begins. If an upstream streaming error occurs after streaming begins, the route emits a safe stream error event.
-
-## Metric labeling rules
-
-- Live Ollama health is labeled **Measured**.
-- Discovered local Ollama models are labeled **Measured**.
-- Prompt run status and streamed response content are labeled **Measured** for runtime availability.
-- TTFT is **Measured** from server-side request start to first streamed Ollama response chunk.
-- Total latency is **Measured** from server-side request start to Ollama `done` when available.
-- Generation duration is **Measured** from first streamed response chunk to Ollama `done` when available.
-- Prompt tokens and response tokens are **Estimated** using a rough local approximation; they are not exact tokenizer counts.
-- Tokens/sec is **Derived** from estimated response tokens and measured generation duration.
-- Generated response content remains active-run content only and is not persisted.
-- Demo dashboard economics remain labeled **Demo/mock**.
-- Static assumptions such as demo mode and energy rate remain labeled **Configured**.
-
-## Phase 4 guardrails
-
-Phase 4 intentionally does **not** add:
-
-- Exact tokenizer counts.
-- Real cost-per-run calculation.
-- `nvidia-smi` calls.
-- GPU telemetry.
-- Watts or tokens/watt from real power telemetry.
-- Run history.
-- Persistent storage.
-- Prompt or response content persistence.
-- Database migrations.
-- New dependencies.
-- Cloud services, secrets, or API keys.
-
-Prompt and response content remain in request/browser memory for the active run only. Partner Hub does not save prompt content, response content, or run history in Phase 4.
-
-## Phase 5 local NVIDIA telemetry
-
-Phase 5 adds an optional local NVIDIA telemetry snapshot panel to `/ai-factory-economics`. The panel calls the Partner Hub local API route `/api/ai-factory-economics/gpu`, which runs `nvidia-smi` server-side only and never calls cloud services.
-
-Files added in Phase 5:
-
-```text
-ui/partner-hub/app/api/ai-factory-economics/gpu/route.ts
-ui/partner-hub/components/ai-factory-economics/gpu-telemetry-panel.tsx
-ui/partner-hub/lib/ai-factory-economics/gpu.ts
-ui/partner-hub/lib/ai-factory-economics/gpu.test.ts
-```
-
-Files updated in Phase 5:
-
-```text
-ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
-ui/partner-hub/lib/ai-factory-economics/mock-data.ts
-ui/partner-hub/lib/ai-factory-economics/ollama.ts
-ui/partner-hub/lib/ai-factory-economics/types.ts
-ui/partner-hub/lib/ai-factory-economics/mock-data.ts
-ui/partner-hub/package.json
-docs/AI_FACTORY_ECONOMICS_MODULE.md
-ui/partner-hub/docs/ai-factory-economics.md
-```
-
-### What Phase 5 collects
-
-The server-side helper runs:
-
-```bash
-nvidia-smi --query-gpu=index,utilization.gpu,memory.used,memory.total,power.draw,temperature.gpu --format=csv,noheader,nounits
-```
-
-It parses one or more NVIDIA GPU rows and displays GPU 0/the first row by default. The panel shows:
-
-- NVIDIA telemetry availability (**Measured**)
-- GPU index (**Measured** when returned; row position fallback if the index field is unavailable)
-- GPU utilization percent (**Measured**)
-- GPU memory used and total (**Measured**)
-- GPU watts/power draw (**Measured**)
-- GPU temperature (**Measured**)
-- Sample timestamp
-
-Missing or unsupported telemetry fields are shown as **Unavailable**, not zero.
-
-### Graceful unavailable states
-
-The GPU telemetry panel is optional. The prompt runner still works without it. The API and UI return safe unavailable states when:
-
-- NVIDIA GPU/driver is not available.
-- `nvidia-smi` is not installed or not in `PATH`.
-- `nvidia-smi` times out.
-- The requested telemetry fields are unsupported.
-- `nvidia-smi` returns empty or unexpected output.
-
-No stack traces are exposed to the browser.
-
-### Phase 5 guardrails
-
-Phase 5 does not create run history, does not persist prompt content, does not persist response content, does not add a database, does not add migrations, does not add new dependencies, and does not add background daemons or long-running collectors. GPU telemetry is a refresh-time snapshot only. It is not lab-grade wall-power measurement and it is not exact per-run or per-process attribution to Ollama. AMD, Apple Silicon, and CPU-only telemetry remain out of scope.
-
-### Local testing steps
-
-From `ui/partner-hub`:
+Verify local NVIDIA support with:
 
 ```bash
 nvidia-smi
-ollama serve
-ollama pull llama3.2:3b
-npm run dev
 ```
 
-Then open `http://localhost:3000/partner-hub/ai-factory-economics`, refresh GPU telemetry, and confirm utilization, memory, watts, temperature, GPU index, and sample timestamp appear when available.
+When available, the GPU route samples utilization, memory, watts, and temperature with `nvidia-smi`. This is snapshot-only telemetry. It is not exact per-run attribution, lab-grade wall-power measurement, or non-NVIDIA telemetry. Missing or unsupported values display as **Unavailable**, not zero.
 
-Verification commands:
+## Running prompts and comparing models
 
-```bash
-npm run typecheck
-npm test
-npm run lint
-```
+1. Start Partner Hub and Ollama.
+2. Pull a local model.
+3. Choose a discovered model or enter one manually.
+4. Enter a prompt within the local demo character limit.
+5. Click **Run local prompt**.
+6. Repeat with another model if you want a derived local comparison.
 
-## Phase 6: in-memory run history and model comparison
+For safer comparisons, use the same or similar prompt across models and treat the output as directional local demo guidance only. Do not present it as a production benchmark or procurement-grade result.
 
-Phase 6 adds sanitized browser-memory run history and a derived model comparison table to `/partner-hub/ai-factory-economics`.
+## Metric labels
 
-### Files added
+- **Measured:** Local service status, stream timing, run status, and `nvidia-smi` snapshot fields.
+- **Estimated:** Prompt and response token counts from a rough local approximation.
+- **Derived:** Estimated tokens/sec, model comparison, scorecards, and recommendations.
+- **Configured:** Static assumptions, setup values, and caveats.
+- **Demo/mock:** Non-live economics values retained for demo/future-work context.
 
-```text
-ui/partner-hub/lib/ai-factory-economics/history.ts
-ui/partner-hub/lib/ai-factory-economics/history.test.ts
-ui/partner-hub/components/ai-factory-economics/run-history-panel.tsx
-ui/partner-hub/components/ai-factory-economics/model-comparison-table.tsx
-```
+Important metric caveats:
 
-### Files updated
+- TTFT is measured from server-side request start to first streamed Ollama response chunk.
+- Total latency is measured from server-side request start to Ollama completion when a done signal is received.
+- Generation duration is measured from first response chunk to Ollama completion.
+- Estimated prompt/response tokens are not exact tokenizer counts.
+- Estimated tokens/sec is derived from estimated response tokens and measured generation duration.
+- GPU utilization, memory, watts, and temperature are `nvidia-smi` snapshots.
+- Tokens/watt and cost/run are not real measured Phase 8 values; they remain demo/mock, unavailable, or future work.
 
-```text
-ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
-ui/partner-hub/components/ai-factory-economics/prompt-runner.tsx
-ui/partner-hub/lib/ai-factory-economics/types.ts
-ui/partner-hub/lib/ai-factory-economics/mock-data.ts
-ui/partner-hub/package.json
-docs/AI_FACTORY_ECONOMICS_MODULE.md
-ui/partner-hub/docs/ai-factory-economics.md
-```
+## Privacy and storage
 
-### Runtime behavior
+Prompt content is not stored. Response content is not stored. Sanitized run summaries are browser-memory only, exclude prompt/response content, and disappear on reload or clear-history. This module does not use `localStorage`, `sessionStorage`, IndexedDB, database storage, migrations, exports, backend persistence, or cloud storage.
 
-- Recent run history lives in React state in the AI Factory Economics page only.
-- History is limited to the most recent 20 sanitized summaries.
-- History disappears on page reload.
-- A **Clear in-memory history** button clears the current page-session history.
-- Partner Hub does not use localStorage, sessionStorage, IndexedDB, a database, migrations, backend storage, cloud services, or secrets for Phase 6 history.
-- Prompt content is not stored in history.
-- Response content is not stored in history.
-- Raw stream chunks, raw request bodies, raw filesystem paths, and raw stack traces are not stored in history.
+## Troubleshooting
 
-### Run history fields
+| Issue | Action |
+| --- | --- |
+| Ollama unavailable | Run `ollama serve`, check `AI_FACTORY_OLLAMA_URL`, and refresh status. |
+| No models discovered | Run `ollama pull <model>` and verify `curl http://127.0.0.1:11434/api/tags`. |
+| Model not found | Pull the model locally or fix the manual model name. Empty, overlong, and control-character names are rejected. |
+| Stream ends without done signal | Treat the run as incomplete; partial output is visible but not complete benchmark data. |
+| `nvidia-smi` missing | GPU telemetry is optional and will show unavailable. |
+| GPU fields unavailable | Unsupported/blank fields display as unavailable rather than zero. |
 
-Each sanitized summary may include safe metadata only:
-
-- id
-- started timestamp
-- completed timestamp
-- model
-- run status
-- measured TTFT
-- measured total latency
-- measured generation duration
-- estimated prompt tokens
-- estimated response tokens
-- derived estimated tokens/sec
-- metric classification labels
-- a note that prompt and response content are excluded
-
-GPU snapshot summary support remains a typed future extension in Phase 6. If a GPU snapshot is associated with a run in a future phase, it must be labeled as sampled snapshot telemetry and not exact per-run or per-process attribution.
-
-### Model comparison
-
-The model comparison table aggregates the in-memory sanitized history by model. It shows run count, completed count, failed/canceled/incomplete counts, average TTFT, average total latency, average estimated tokens/sec, best estimated tokens/sec, fastest TTFT, and most recent run time.
-
-All comparison values are labeled **Derived**. Missing metrics are excluded from averages and are never treated as zero; unavailable aggregate values display as **Unavailable**.
-
-### Metric labels
-
-- TTFT: **Measured**
-- Total latency: **Measured**
-- Generation duration: **Measured**
-- Prompt tokens: **Estimated**
-- Response tokens: **Estimated**
-- Tokens/sec: **Derived**
-- Model comparison aggregates: **Derived**
-- GPU telemetry: **Measured** snapshot telemetry only, not exact per-run attribution
-- Demo dashboard economics: **Demo/mock**
-
-### Local manual test flow
-
-1. Start Ollama: `ollama serve`.
-2. Pull at least one local model: `ollama pull llama3.2:3b`.
-3. Run Partner Hub from `ui/partner-hub`: `npm run dev`.
-4. Open `http://localhost:3000/partner-hub/ai-factory-economics`.
-5. Run several prompts across one or more models.
-6. Confirm recent run summaries appear.
-7. Confirm model comparison aggregates appear.
-8. Confirm prompt and response content are not stored in history.
-9. Confirm **Clear in-memory history** works.
-10. Refresh the page and confirm the in-memory history disappears.
-
-### Verification commands
+## Verification commands
 
 Run from `ui/partner-hub`:
 
@@ -329,81 +119,3 @@ npm run typecheck
 npm test
 npm run lint
 ```
-
-## Phase 7: executive insights and safe recommendations
-
-Phase 7 is active on `/partner-hub/ai-factory-economics` as a UI/interpretation polish phase. It keeps the module local-only while adding a stronger executive summary, AI Factory Efficiency scorecards, safe recommendations, and clearer caveats for partner/customer demos.
-
-### Files added
-
-```text
-ui/partner-hub/lib/ai-factory-economics/insights.ts
-ui/partner-hub/lib/ai-factory-economics/insights.test.ts
-ui/partner-hub/components/ai-factory-economics/executive-insights-panel.tsx
-```
-
-### Files updated
-
-```text
-ui/partner-hub/components/ai-factory-economics/ai-factory-economics-tool.tsx
-ui/partner-hub/lib/ai-factory-economics/types.ts
-ui/partner-hub/lib/ai-factory-economics/mock-data.ts
-ui/partner-hub/package.json
-docs/AI_FACTORY_ECONOMICS_MODULE.md
-ui/partner-hub/docs/ai-factory-economics.md
-```
-
-### What changed in the UI
-
-- The page header now states **Local-only Phase 7** and explains that the demo combines measured runtime, estimated tokens, derived comparison/recommendations, and no persisted prompt/response content.
-- The new executive insights panel appears high on the page, below the existing demo/mock executive summary cards.
-- The panel includes a plain-English description of what the local demo proves, scorecards, derived recommendations, and configured caveats.
-- The page is visually grouped into:
-  - Executive view: demo/mock summary cards plus the new insights/recommendations panel.
-  - Local readiness: Ollama status, model discovery, and NVIDIA GPU snapshot.
-  - Run a prompt: local prompt runner and measured runtime metrics.
-  - Learn from runs: browser-memory history and derived model comparison.
-  - Readiness/roadmap status: existing setup and phase panels.
-
-### AI Factory Efficiency scorecards
-
-Scorecards are deliberately simple and transparent:
-
-- **Runs compared**: count of current sanitized in-memory run summaries.
-- **Best avg TTFT**: fastest available average TTFT from current history.
-- **Best avg throughput**: highest available average derived estimated tokens/sec from current history.
-- **Completion rate**: completed runs divided by all current in-memory runs.
-- **Telemetry coverage**: whether known local signals are available to the helper.
-
-All Phase 7 scorecards are labeled **Derived**. Missing metrics display as unavailable and are not substituted with zero.
-
-### Recommendations and caveats
-
-Safe recommendations are labeled **Derived** and may identify the fastest average TTFT model, highest average estimated throughput model, highest completion-rate model, or warn when failed/canceled/incomplete runs outnumber completed runs. Each recommendation includes caveat text stating that it is based only on local workstation demo data and sanitized in-memory summaries.
-
-Configured caveats explain that token counts are estimated, GPU telemetry is unavailable or snapshot-only, comparable prompts make demos easier to explain, no prompt/response content is stored, and no production benchmark claims should be made.
-
-### Local testing steps
-
-1. Start Ollama: `ollama serve`.
-2. Pull one or more models: `ollama pull llama3.2:3b`.
-3. Run Partner Hub from `ui/partner-hub`: `npm run dev`.
-4. Open `http://localhost:3000/partner-hub/ai-factory-economics`.
-5. Run several prompts.
-6. Confirm executive insights appear.
-7. Confirm model comparison recommendations are labeled **Derived**.
-8. Confirm no prompt content is stored in run history, model comparison, or executive insights.
-9. Confirm no response content is stored in run history, model comparison, or executive insights.
-10. Refresh the page and confirm history disappears.
-11. Confirm recommendations are framed as local demo guidance only, not production benchmark claims.
-12. Confirm GPU telemetry remains snapshot-only and is not described as exact per-run attribution.
-
-### Verification commands
-
-```bash
-npm run typecheck
-npm test
-npm run lint
-```
-
-Phase 7 adds no persistence, no localStorage, no backend storage, no database changes, no migrations, no cloud services, no secrets, no new dependencies, no background collectors, and no new telemetry source.

--- a/ui/partner-hub/lib/ai-factory-economics/gpu.ts
+++ b/ui/partner-hub/lib/ai-factory-economics/gpu.ts
@@ -126,7 +126,7 @@ export async function getNvidiaGpuTelemetry(runner: ExecFileRunner = defaultExec
     if (gpus.length === 0) {
       return {
         ok: false,
-        phase: "Phase 5",
+        phase: "Phase 8",
         status: "unavailable",
         available: false,
         timeoutMs: AI_FACTORY_NVIDIA_SMI_TIMEOUT_MS,
@@ -142,7 +142,7 @@ export async function getNvidiaGpuTelemetry(runner: ExecFileRunner = defaultExec
 
     return {
       ok: true,
-      phase: "Phase 5",
+      phase: "Phase 8",
       status: "available",
       available: true,
       timeoutMs: AI_FACTORY_NVIDIA_SMI_TIMEOUT_MS,
@@ -154,7 +154,7 @@ export async function getNvidiaGpuTelemetry(runner: ExecFileRunner = defaultExec
   } catch (error) {
     return {
       ok: false,
-      phase: "Phase 5",
+      phase: "Phase 8",
       status: "unavailable",
       available: false,
       timeoutMs: AI_FACTORY_NVIDIA_SMI_TIMEOUT_MS,

--- a/ui/partner-hub/lib/ai-factory-economics/metrics.ts
+++ b/ui/partner-hub/lib/ai-factory-economics/metrics.ts
@@ -17,7 +17,7 @@ function safeElapsedMs(startMs: number | undefined, endMs: number | undefined) {
 /**
  * Estimates tokens with a deliberately simple local-only approximation.
  *
- * This is not an exact tokenizer. Phase 5 still uses roughly four normalized
+ * This is not an exact tokenizer. Phase 8 still uses roughly four normalized
  * characters per token so prompt/response content can remain transient and no
  * tokenizer dependency or cloud call is required.
  */
@@ -59,7 +59,7 @@ export function calculateRunMetrics(input: AiFactoryRunMetricsInput): AiFactoryR
       costPerRun: "Demo/mock",
     },
     note:
-      "Phase 5 measures local Ollama run timing and estimates token counts only. GPU telemetry is shown as a separate snapshot; tokens/watt and real cost-per-run are not included.",
+      "Phase 8 measures local Ollama run timing and estimates token counts only. GPU telemetry is shown as a separate snapshot; tokens/watt and real cost-per-run are not included.",
   };
 }
 

--- a/ui/partner-hub/lib/ai-factory-economics/mock-data.ts
+++ b/ui/partner-hub/lib/ai-factory-economics/mock-data.ts
@@ -4,7 +4,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard =
   {
     scenarioName: "Local workstation inference economics demo",
     summary:
-      "A Phase 7 dashboard that keeps demo/mock economics visible while measuring local Ollama runtime, estimating tokens, deriving model comparison, and presenting safe local-only recommendations.",
+      "A Phase 8 dashboard that keeps demo/mock economics visible while measuring local Ollama runtime, estimating tokens, deriving model comparison, and presenting safe local-only recommendations.",
     assumptions: [
       {
         id: "energy-rate",
@@ -12,7 +12,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard =
         value: "$0.16/kWh",
         classification: "Configured",
         description:
-          "Static display assumption only; not used by a live collector or Phase 7 recommendation.",
+          "Static display assumption only; not used by a live collector or Phase 8 recommendation.",
         tone: "info",
       },
       {
@@ -21,7 +21,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard =
         value: "On",
         classification: "Configured",
         description:
-          "Phase 7 renders demo/mock economics plus local Ollama health, model discovery, prompt streaming, measured timing, estimated token counts, derived throughput/comparison, safe recommendations, and optional NVIDIA GPU snapshots.",
+          "Phase 8 renders demo/mock economics plus local Ollama health, model discovery, prompt streaming, measured timing, estimated token counts, derived throughput/comparison, safe recommendations, and optional NVIDIA GPU snapshots.",
         tone: "good",
       },
     ],
@@ -32,7 +32,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard =
         value: "llama3.1:8b-instruct",
         classification: "Demo/mock",
         description:
-          "Placeholder model name for demo fallback; discovered local Ollama models and prompt streams are shown separately as Measured/Estimated/Derived in Phase 7.",
+          "Placeholder model name for demo fallback; discovered local Ollama models and prompt streams are shown separately as Measured/Estimated/Derived in Phase 8.",
         tone: "info",
       },
       {
@@ -41,7 +41,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard =
         value: "420 ms",
         classification: "Demo/mock",
         description:
-          "Mock first-token timing for the dashboard shell; Phase 7 measures TTFT in the prompt runner while this card remains demo/mock.",
+          "Mock first-token timing for the dashboard shell; Phase 8 measures TTFT in the prompt runner while this card remains demo/mock.",
         tone: "good",
       },
       {
@@ -50,7 +50,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard =
         value: "2.8 s",
         classification: "Demo/mock",
         description:
-          "Mock end-to-end economics placeholder; Phase 7 measures total latency in the prompt runner while this card remains demo/mock.",
+          "Mock end-to-end economics placeholder; Phase 8 measures total latency in the prompt runner while this card remains demo/mock.",
         tone: "good",
       },
       {
@@ -59,7 +59,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard =
         value: "31.4 tok/s",
         classification: "Demo/mock",
         description:
-          "Mock dashboard throughput preview; the Phase 7 prompt runner separately derives tokens/sec from measured generation duration and estimated response tokens.",
+          "Mock dashboard throughput preview; the Phase 8 prompt runner separately derives tokens/sec from measured generation duration and estimated response tokens.",
         tone: "info",
       },
       {
@@ -68,7 +68,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard =
         value: "68%",
         classification: "Demo/mock",
         description:
-          "Mock GPU utilization; Phase 7 samples nvidia-smi in a separate live panel; this static dashboard card remains demo/mock.",
+          "Mock GPU utilization; Phase 8 samples nvidia-smi in a separate live panel; this static dashboard card remains demo/mock.",
         tone: "info",
       },
       {
@@ -86,7 +86,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard =
         value: "146 W",
         classification: "Demo/mock",
         description:
-          "Mock power draw; the live GPU panel remains snapshot-only and is not exact per-run attribution in Phase 7.",
+          "Mock power draw; the live GPU panel remains snapshot-only and is not exact per-run attribution in Phase 8.",
         tone: "warning",
       },
       {
@@ -104,7 +104,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard =
         value: "0.22 tok/W",
         classification: "Demo/mock",
         description:
-          "Mock efficiency preview; later phases will explain whether watts are sampled, measured, or unavailable.",
+          "Mock efficiency preview; Phase 8 leaves real tokens/watt unavailable unless future instrumentation is explicitly approved.",
         tone: "good",
       },
       {
@@ -113,7 +113,7 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard =
         value: "$0.000018",
         classification: "Demo/mock",
         description:
-          "Mock economics preview using a static energy-rate assumption; no persisted cost model exists in Phase 7.",
+          "Mock economics preview using a static energy-rate assumption; no persisted cost model exists in Phase 8.",
         tone: "good",
       },
     ],
@@ -123,21 +123,21 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard =
         status: "Checked",
         classification: "Measured",
         description:
-          "Phase 7 checks local Ollama health, discovers /api/tags models, runs local prompt streams, displays timing/token metrics, and keeps graceful fallback when unavailable.",
+          "Phase 8 checks local Ollama health, discovers /api/tags models, runs local prompt streams, displays timing/token metrics, and keeps graceful fallback when unavailable.",
       },
       {
         title: "NVIDIA telemetry",
         status: "Checked",
         classification: "Measured",
         description:
-          "Phase 7 keeps local NVIDIA telemetry as optional nvidia-smi snapshots and shows safe unavailable states otherwise.",
+          "Phase 8 keeps local NVIDIA telemetry as optional nvidia-smi snapshots and shows safe unavailable states otherwise.",
       },
       {
         title: "Run history",
         status: "Checked",
         classification: "Derived",
         description:
-          "Phase 7 keeps sanitized run summaries in browser memory only and derives model comparisons/recommendations without prompt/response persistence.",
+          "Phase 8 keeps sanitized run summaries in browser memory only and derives model comparisons/recommendations without prompt/response persistence.",
       },
     ],
     phases: [
@@ -186,9 +186,16 @@ export const aiFactoryEconomicsMockDashboard: AiFactoryEconomicsMockDashboard =
       {
         phase: "Phase 7",
         title: "Executive insights and recommendations",
-        status: "Active",
+        status: "Complete",
         description:
           "Add executive scorecards, safe Derived recommendations, and Configured caveats from current local in-memory summaries only.",
+      },
+      {
+        phase: "Phase 8",
+        title: "Final hardening and documentation",
+        status: "Active",
+        description:
+          "Validate local-only guardrails, tighten copy/error handling, and document setup, troubleshooting, privacy, metrics, and limitations.",
         active: true,
       },
     ],

--- a/ui/partner-hub/lib/ai-factory-economics/ollama.ts
+++ b/ui/partner-hub/lib/ai-factory-economics/ollama.ts
@@ -102,7 +102,7 @@ export async function getOllamaHealth(fetcher: FetchLike = fetch): Promise<AiFac
 
     return {
       ok: true,
-      phase: "Phase 5",
+      phase: "Phase 8",
       ollama: {
         status: "available",
         reachable: true,
@@ -115,7 +115,7 @@ export async function getOllamaHealth(fetcher: FetchLike = fetch): Promise<AiFac
       nvidiaTelemetry: {
         status: "snapshot_endpoint_available",
         classification: "Measured",
-        message: "Phase 5 exposes local NVIDIA snapshot telemetry at /api/ai-factory-economics/gpu when nvidia-smi is available.",
+        message: "Phase 8 exposes local NVIDIA snapshot telemetry at /api/ai-factory-economics/gpu when nvidia-smi is available.",
       },
       promptExecution: "enabled",
       streaming: "enabled",
@@ -123,7 +123,7 @@ export async function getOllamaHealth(fetcher: FetchLike = fetch): Promise<AiFac
   } catch (error) {
     return {
       ok: false,
-      phase: "Phase 5",
+      phase: "Phase 8",
       ollama: {
         status: "unavailable",
         reachable: false,
@@ -137,7 +137,7 @@ export async function getOllamaHealth(fetcher: FetchLike = fetch): Promise<AiFac
       nvidiaTelemetry: {
         status: "snapshot_endpoint_available",
         classification: "Measured",
-        message: "Phase 5 exposes local NVIDIA snapshot telemetry at /api/ai-factory-economics/gpu when nvidia-smi is available.",
+        message: "Phase 8 exposes local NVIDIA snapshot telemetry at /api/ai-factory-economics/gpu when nvidia-smi is available.",
       },
       promptExecution: "enabled",
       streaming: "enabled",
@@ -154,7 +154,7 @@ export async function discoverOllamaModels(fetcher: FetchLike = fetch): Promise<
 
     return {
       ok: true,
-      phase: "Phase 5",
+      phase: "Phase 8",
       baseUrl,
       timeoutMs: AI_FACTORY_OLLAMA_TIMEOUT_MS,
       classification: "Measured",
@@ -164,7 +164,7 @@ export async function discoverOllamaModels(fetcher: FetchLike = fetch): Promise<
   } catch (error) {
     return {
       ok: false,
-      phase: "Phase 5",
+      phase: "Phase 8",
       baseUrl,
       timeoutMs: AI_FACTORY_OLLAMA_TIMEOUT_MS,
       classification: "Measured",

--- a/ui/partner-hub/lib/ai-factory-economics/types.ts
+++ b/ui/partner-hub/lib/ai-factory-economics/types.ts
@@ -111,7 +111,7 @@ export type AiFactorySafeGpuError = AiFactorySafeError & {
 
 export type AiFactoryGpuTelemetrySuccess = {
   ok: true;
-  phase: "Phase 5";
+  phase: "Phase 8";
   status: "available";
   available: true;
   timeoutMs: number;
@@ -123,7 +123,7 @@ export type AiFactoryGpuTelemetrySuccess = {
 
 export type AiFactoryGpuTelemetryUnavailable = {
   ok: false;
-  phase: "Phase 5";
+  phase: "Phase 8";
   status: "unavailable";
   available: false;
   timeoutMs: number;
@@ -139,7 +139,7 @@ export type AiFactoryGpuTelemetryResult =
 
 export type AiFactoryHealthStatus = {
   ok: boolean;
-  phase: "Phase 5";
+  phase: "Phase 8";
   ollama: OllamaAvailability;
   demoModeAvailable: boolean;
   nvidiaTelemetry: AiFactoryNvidiaTelemetryStatus;
@@ -149,7 +149,7 @@ export type AiFactoryHealthStatus = {
 
 export type AiFactoryModelDiscoverySuccess = {
   ok: true;
-  phase: "Phase 5";
+  phase: "Phase 8";
   baseUrl: string;
   timeoutMs: number;
   classification: "Measured";
@@ -159,7 +159,7 @@ export type AiFactoryModelDiscoverySuccess = {
 
 export type AiFactoryModelDiscoveryFailure = {
   ok: false;
-  phase: "Phase 5";
+  phase: "Phase 8";
   baseUrl: string;
   timeoutMs: number;
   classification: "Measured";
@@ -283,7 +283,7 @@ export type AiFactoryRunMetricsEventPayload = AiFactoryRunMetrics & {
 
 export type AiFactoryRunMetaEventPayload = {
   ok: true;
-  phase: "Phase 5";
+  phase: "Phase 8";
   model: string;
   baseUrl: string;
   classification: "Measured";


### PR DESCRIPTION
### Motivation
- Finalize Phase 8 as a documentation, hardening, and guardrail pass for the AI Factory Economics local demo module. 
- Tighten API and UI behavior so the module fails safely when Ollama or `nvidia-smi` are unavailable. 
- Ensure copy, metric labels, and phase metadata explicitly reflect the final Phase 8 scope and remaining limitations. 
- Preserve all privacy/storage guardrails (no prompt/response persistence, no browser storage, no DB/migrations, no new dependencies). 

### Description
- Documentation: updated canonical plan `docs/AI_FACTORY_ECONOMICS_MODULE.md`, partner doc `ui/partner-hub/docs/ai-factory-economics.md`, and added `ui/partner-hub/docs/ai-factory-economics-quickstart.md` with setup, Ollama/NVIDIA instructions, metric definitions, privacy statement, troubleshooting, guardrail audit, and future work. 
- UI copy and metadata: replaced Phase labels and explanatory copy with Phase 8 in feature components and mock data so all user-facing copy and phase lists reflect the final pass. 
- API hardening: tightened cache headers on JSON endpoints to include `no-store, no-cache` and on the SSE run stream to `no-store, no-cache, no-transform`, and updated run-stream metadata messages to reference Phase 8; streaming errors continue to return safe, sanitized error objects. 
- Libraries: adjusted phase/notes strings in `ollama.ts`, `gpu.ts`, `metrics.ts`, and `mock-data.ts`; preserved token-estimate logic (4-character approximation), `nvidia-smi` exec-file usage, and in-memory history sanitization without adding any persistence or new telemetry sources. 

### Testing
- Commands attempted: `cd ui/partner-hub && npm run typecheck`, `npm test`, and `npm run lint`; these package-script verifications could not complete in this environment because local dependency installation was blocked by registry/network policy and the container’s TypeScript/global tooling (typecheck/test/lint were therefore not fully runnable here). 
- Targeted compilation/tests: invoked isolated `tsc` + node `--test` over the ai-factory libs to validate unit helpers, but the container lacked `@types/node` and full package deps so the run surfaced type/test environment limitations rather than logic regressions. 
- Static audits and guards: ran file-size and guardrail audits locally in the repo; results passed — no AI Factory file exceeds 800 lines (largest file is `prompt-runner.tsx` at 466 lines), no `localStorage`/`sessionStorage`/IndexedDB usage was added, and no database/migration or dependency changes were introduced. 
- Verification summary: `git diff --check` passed, cache headers and SSE header were updated, docs and quickstart were added, and existing unit tests/helpers remain unchanged; environment-limited type/test/lint runs must be executed in CI or a developer machine after `npm install` to complete full verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22e4b14cf883309c0fa5158f4021e2)